### PR TITLE
security: harden hooks against shell injection

### DIFF
--- a/.claude/hooks/harness-health-util.js
+++ b/.claude/hooks/harness-health-util.js
@@ -149,11 +149,11 @@ function getTypecheckConfig(language) {
     case 'python':
       // Try mypy first, fall back to pyright
       try {
-        require('child_process').execSync('mypy --version', { stdio: 'pipe' });
+        require('child_process').execFileSync('mypy', ['--version'], { stdio: 'pipe' });
         return { command: 'mypy', perFile: true };
       } catch {
         try {
-          require('child_process').execSync('pyright --version', { stdio: 'pipe' });
+          require('child_process').execFileSync('pyright', ['--version'], { stdio: 'pipe' });
           return { command: 'pyright', perFile: true };
         } catch {
           return { command: null, perFile: false };
@@ -170,12 +170,47 @@ function getTypecheckConfig(language) {
   }
 }
 
+// ── Input Validation ────────────────────────────────────────────────────────
+
+// Paths allow backslash (Windows path separator).
+// Commands reject backslash — expected to be simple tool names (e.g., "mypy"),
+// not absolute paths. Windows users with paths like C:\Python39\python.exe
+// would need to add the tool to PATH instead.
+const PATH_META_RE = /[`$;|&\n\r\0]|\$\(/;
+const CMD_META_RE = /[`$;|&\n\r\0\\]|\$\(/;
+
+/** @returns {{ safe: boolean, violation: string|null }} */
+function _validateInput(value, label, regex) {
+  if (!value || typeof value !== 'string') {
+    return { safe: false, violation: `empty or non-string ${label}` };
+  }
+  const match = value.match(regex);
+  if (match) {
+    return {
+      safe: false,
+      violation: `shell metacharacter ${JSON.stringify(match[0])} in ${label}: ${value.slice(0, 200)}`,
+    };
+  }
+  return { safe: true, violation: null };
+}
+
+function validatePath(filePath) { return _validateInput(filePath, 'path', PATH_META_RE); }
+function validateCommand(command) { return _validateInput(command, 'command', CMD_META_RE); }
+
+function securityWarning(hook, message) {
+  process.stdout.write(`[SECURITY] ${hook}: ${message}\n`);
+  increment(hook, 'security-warning');
+}
+
 module.exports = {
   increment,
   logTiming,
   readConfig,
   detectStack,
   getTypecheckConfig,
+  validatePath,
+  validateCommand,
+  securityWarning,
   PROJECT_ROOT,
   TELEMETRY_DIR,
 };

--- a/.claude/hooks/post-edit.js
+++ b/.claude/hooks/post-edit.js
@@ -16,7 +16,7 @@
  *   2 = type errors found in edited file
  */
 
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 const health = require('./harness-health-util');
@@ -48,6 +48,12 @@ function main() {
     // Extract file path from tool input
     const filePath = event.tool_input?.file_path || event.tool_input?.path || '';
     if (!filePath) {
+      process.exit(0);
+    }
+
+    const pathCheck = health.validatePath(filePath);
+    if (!pathCheck.safe) {
+      health.securityWarning('post-edit', `Possible injection in file path — ${pathCheck.violation}. Skipping typecheck.`);
       process.exit(0);
     }
 
@@ -107,7 +113,7 @@ function typecheckTypeScript(filePath, relativePath) {
   if (/\.d\.ts$/.test(filePath)) return 0;
 
   try {
-    execSync(`npx tsc --noEmit --pretty false 2>&1`, {
+    execFileSync('npx', ['tsc', '--noEmit', '--pretty', 'false'], {
       cwd: PROJECT_ROOT,
       timeout: 25000,
       encoding: 'utf8',
@@ -138,8 +144,17 @@ function typecheckTypeScript(filePath, relativePath) {
 function typecheckPython(filePath, relativePath, command) {
   if (!/\.py$/.test(filePath)) return 0;
 
+  const cmdCheck = health.validateCommand(command);
+  if (!cmdCheck.safe) {
+    health.securityWarning('post-edit', `Possible injection in typecheck command — ${cmdCheck.violation}. Skipping typecheck.`);
+    return 0;
+  }
+
+  // Command is expected to be simple whitespace-separated tokens (e.g., "mypy --strict").
+  // Quoted arguments like --config-file "my config.ini" are not supported.
+  const [cmd, ...cmdArgs] = command.split(/\s+/);
   try {
-    execSync(`${command} "${filePath}"`, {
+    execFileSync(cmd, [...cmdArgs, filePath], {
       cwd: PROJECT_ROOT,
       timeout: 20000,
       encoding: 'utf8',
@@ -162,7 +177,7 @@ function typecheckGo(filePath, relativePath) {
   const dir = path.dirname(filePath);
 
   try {
-    execSync(`go vet ./...`, {
+    execFileSync('go', ['vet', './...'], {
       cwd: dir,
       timeout: 20000,
       encoding: 'utf8',
@@ -181,7 +196,7 @@ function typecheckGo(filePath, relativePath) {
 
 function typecheckRust() {
   try {
-    execSync('cargo check --message-format=short 2>&1', {
+    execFileSync('cargo', ['check', '--message-format=short'], {
       cwd: PROJECT_ROOT,
       timeout: 30000,
       encoding: 'utf8',

--- a/.claude/hooks/quality-gate.js
+++ b/.claude/hooks/quality-gate.js
@@ -16,7 +16,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const health = require('./harness-health-util');
 
 // Read stdin for hook context
@@ -46,15 +46,25 @@ function run() {
   // Get recently modified files from git
   let changedFiles = [];
   try {
-    const output = execSync('git diff --name-only HEAD 2>/dev/null || git diff --name-only', {
-      cwd: projectDir,
-      encoding: 'utf8',
-      timeout: 5000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
+    let output;
+    try {
+      output = execFileSync('git', ['diff', '--name-only', 'HEAD'], {
+        cwd: projectDir,
+        encoding: 'utf8',
+        timeout: 5000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    } catch {
+      // HEAD may not exist (fresh repo) — fall back to plain diff
+      output = execFileSync('git', ['diff', '--name-only'], {
+        cwd: projectDir,
+        encoding: 'utf8',
+        timeout: 5000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    }
     changedFiles = output.trim().split('\n').filter(Boolean);
   } catch {
-    // No git or no changes — skip
     process.exit(0);
   }
 

--- a/.claude/hooks/worktree-setup.js
+++ b/.claude/hooks/worktree-setup.js
@@ -14,7 +14,7 @@
  *   2 = setup failed (blocks worktree creation)
  */
 
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 const health = require('./harness-health-util');
@@ -25,19 +25,25 @@ function main(input) {
   const worktreePath = input.path;
   if (!worktreePath) return;
 
+  const pathCheck = health.validatePath(worktreePath);
+  if (!pathCheck.safe) {
+    health.securityWarning('worktree-setup', `Possible injection in worktree path — ${pathCheck.violation}. Skipping setup.`);
+    return;
+  }
+
   // Verify the worktree has a package.json (Node project)
   if (fs.existsSync(path.join(worktreePath, 'package.json'))) {
     // Skip if node_modules already exists (resuming a worktree)
     if (!fs.existsSync(path.join(worktreePath, 'node_modules'))) {
       const config = health.readConfig();
       const pm = config.packageManager || 'npm';
-      const installCmd = pm === 'pnpm' ? 'pnpm install --frozen-lockfile'
-        : pm === 'yarn' ? 'yarn install --frozen-lockfile'
-        : pm === 'bun' ? 'bun install --frozen-lockfile'
-        : 'npm ci --prefer-offline';
+      const [cmd, args] = pm === 'pnpm' ? ['pnpm', ['install', '--frozen-lockfile']]
+        : pm === 'yarn' ? ['yarn', ['install', '--frozen-lockfile']]
+        : pm === 'bun' ? ['bun', ['install', '--frozen-lockfile']]
+        : ['npm', ['ci', '--prefer-offline']];
 
       try {
-        execSync(installCmd, {
+        execFileSync(cmd, args, {
           cwd: worktreePath,
           timeout: 120000,
           encoding: 'utf8',
@@ -54,10 +60,16 @@ function main(input) {
   if (fs.existsSync(path.join(worktreePath, 'requirements.txt'))) {
     if (!fs.existsSync(path.join(worktreePath, '.venv'))) {
       try {
+        execFileSync('python', ['-m', 'venv', '.venv'], {
+          cwd: worktreePath,
+          timeout: 60000,
+          encoding: 'utf8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+        });
         const pipPath = process.platform === 'win32'
-          ? '.venv\\Scripts\\pip'
-          : '.venv/bin/pip';
-        execSync(`python -m venv .venv && ${pipPath} install -r requirements.txt`, {
+          ? path.join('.venv', 'Scripts', 'pip')
+          : path.join('.venv', 'bin', 'pip');
+        execFileSync(pipPath, ['install', '-r', 'requirements.txt'], {
           cwd: worktreePath,
           timeout: 120000,
           encoding: 'utf8',


### PR DESCRIPTION
## Summary

This PR is designed to harden Citadel against attacks from malicious skills, and from content that Claude Code reviews designed to escape encapsulation and perform remote code execution. 

- Replace all `execSync` calls with `execFileSync` + argv arrays across all lifecycle hooks, eliminating shell interpretation entirely
- Add input validation (`validatePath`, `validateCommand`) that detects shell metacharacters and surfaces `[SECURITY]` warnings to the user
- Split chained shell commands (`&&`, `||`, `2>/dev/null`) into separate `execFileSync` calls with try/catch fallback logic

## Design

**Two-layer defense:**
- **Layer 1 (Detect + Alert):** `validatePath` and `validateCommand` in `harness-health-util.js` check inputs for shell metacharacters (backticks, `$()`, `;`, `|`, `&`, newlines, null bytes). On detection, a `[SECURITY]` warning is written to stdout (surfaced to the user via hook feedback) and execution is skipped.
- **Layer 2 (Prevent):** `execFileSync` with argv arrays bypasses the shell entirely. Even if validation is bypassed, injection is structurally impossible.

## Files changed

| File | Changes |
|------|---------|
| `harness-health-util.js` | Added `validatePath`, `validateCommand`, `securityWarning`; converted remaining `execSync` in `getTypecheckConfig` |
| `post-edit.js` | `execSync` → `execFileSync` for all 4 language typecheckers; added path + command validation |
| `quality-gate.js` | `execSync` → `execFileSync` for `git diff`; shell `\|\|` fallback → try/catch |
| `worktree-setup.js` | `execSync` → `execFileSync` for package install + python venv; split chained `&&` into two calls; added path validation |

## Test plan

- [x] All 4 modified files pass `node -c` syntax check
- [x] `validatePath` correctly allows normal paths, rejects backticks, `$()`, `;`, `|`, `&`, newlines, null bytes
- [x] `validateCommand` correctly allows simple commands, rejects metacharacters + backslash
- [x] Windows backslash paths pass `validatePath`, fail `validateCommand` (by design — documented)
- [x] Zero `execSync` calls remain across all hook files (verified via grep)
- [x] Zero `shell: true` options in any `execFileSync` call

🤖 Generated with [Claude Code](https://claude.com/claude-code)