### PR TITLE
fix: remove invalid WorktreeCreate hook event type

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -44,17 +44,6 @@
         ]
       }
     ],
-    "WorktreeCreate": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/worktree-setup.js\"",
-            "timeout": 120
-          }
-        ]
-      }
-    ],
     "Stop": [
       {
         "hooks": [


### PR DESCRIPTION
## Summary
- Removes the `WorktreeCreate` hook block from `.claude/settings.json` — it's not a valid Claude Code hook event type, which causes the entire settings file to be rejected and all hooks to be skipped (#8)
- The `worktree-setup.js` script is kept in place for potential future use

## Test plan
- [ ] Launch `claude` without seeing a Settings Error
- [ ] Verify other hooks (PreToolUse, PostToolUse, Stop, etc.) still fire correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)