### PR TITLE
fix: use relative paths in hook commands for Windows compatibility

### DIFF
--- a/.claude/hooks/issue-monitor.js
+++ b/.claude/hooks/issue-monitor.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+/**
+ * issue-monitor.js — SessionStart hook
+ *
+ * Checks for new/updated GitHub issues since last session.
+ * Reports count and titles so the user knows what needs attention.
+ * Stores last-check timestamp in .claude/issue-monitor-state.json (gitignored).
+ */
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const STATE_FILE = path.join(__dirname, '..', 'issue-monitor-state.json');
+
+function getGhPath() {
+  const windowsPath = '/c/Program Files/GitHub CLI/gh.exe';
+  try {
+    if (fs.existsSync(windowsPath) || fs.existsSync(windowsPath.replace(/\//g, '\'))) {
+      return `"${windowsPath}"`;
+    }
+  } catch {}
+  return 'gh';
+}
+
+function loadState() {
+  try {
+    return JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'));
+  } catch {
+    return { lastCheck: null, knownIssues: [] };
+  }
+}
+
+function saveState(state) {
+  fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+}
+
+function getRepoSlug() {
+  try {
+    const remote = execSync('git remote get-url origin', { encoding: 'utf8' }).trim();
+    const match = remote.match(/github\.com[/:]([\w.-]+)\/([\w.-]+?)(?:\.git)?$/);
+    if (match) return `${match[1]}/${match[2]}`;
+  } catch {}
+  return null;
+}
+
+function main() {
+  const repo = getRepoSlug();
+  if (!repo) process.exit(0);
+
+  const gh = getGhPath();
+  const state = loadState();
+
+  try {
+    const cmd = `${gh} issue list --repo ${repo} --state open --json number,title,labels,createdAt,updatedAt --limit 50`;
+    const raw = execSync(cmd, { encoding: 'utf8', timeout: 15000 });
+    const issues = JSON.parse(raw);
+
+    if (issues.length === 0) {
+      saveState({ lastCheck: new Date().toISOString(), knownIssues: [] });
+      process.exit(0);
+    }
+
+    const knownSet = new Set(state.knownIssues || []);
+    const newIssues = issues.filter(i => !knownSet.has(i.number));
+    const untriaged = issues.filter(i => !i.labels || i.labels.length === 0);
+
+    const lines = [];
+
+    if (newIssues.length > 0) {
+      lines.push(`New issues since last session: ${newIssues.length}`);
+      newIssues.slice(0, 5).forEach(i => {
+        lines.push(`  #${i.number}: ${i.title}`);
+      });
+      if (newIssues.length > 5) {
+        lines.push(`  ... and ${newIssues.length - 5} more`);
+      }
+    }
+
+    if (untriaged.length > 0) {
+      lines.push(`Untriaged (no labels): ${untriaged.length}`);
+      untriaged.slice(0, 3).forEach(i => {
+        lines.push(`  #${i.number}: ${i.title}`);
+      });
+    }
+
+    lines.push(`Total open issues: ${issues.length}`);
+
+    if (newIssues.length > 0 || untriaged.length > 0) {
+      lines.push('Run /triage to investigate.');
+    }
+
+    saveState({
+      lastCheck: new Date().toISOString(),
+      knownIssues: issues.map(i => i.number),
+    });
+
+    if (lines.length > 0) {
+      console.error(lines.join('\n'));
+    }
+
+  } catch (err) {
+    // Non-fatal — don't block session start
+    process.exit(0);
+  }
+}
+
+main();

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/protect-files.js\"",
+            "command": "node .claude/hooks/protect-files.js",
             "timeout": 5
           }
         ]
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/protect-files.js\"",
+            "command": "node .claude/hooks/protect-files.js",
             "timeout": 5
           }
         ]
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/post-edit.js\"",
+            "command": "node .claude/hooks/post-edit.js",
             "timeout": 30
           }
         ]
@@ -38,7 +38,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/pre-compact.js\"",
+            "command": "node .claude/hooks/pre-compact.js",
             "timeout": 10
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/quality-gate.js\"",
+            "command": "node .claude/hooks/quality-gate.js",
             "timeout": 10
           }
         ]
@@ -60,7 +60,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/circuit-breaker.js\"",
+            "command": "node .claude/hooks/circuit-breaker.js",
             "timeout": 5
           }
         ]
@@ -72,7 +72,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/restore-compact.js\"",
+            "command": "node .claude/hooks/restore-compact.js",
             "timeout": 5
           }
         ]
@@ -81,7 +81,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/intake-scanner.js\"",
+            "command": "node .claude/hooks/intake-scanner.js",
             "timeout": 5
           }
         ]

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: triage
+description: >-
+  GitHub issue investigator. Pulls open issues, classifies them, searches the codebase
+  for root cause, proposes fixes with file:line references, and optionally implements
+  fixes as PRs. Can operate on a single issue or batch-triage all untriaged issues.
+user-invocable: true
+auto-trigger: false
+effort: high
+last-updated: 2026-03-23
+---
+
+# Triage — GitHub Issue Investigator
+
+You are the project's issue triage system. You investigate GitHub issues with the rigor
+of a senior engineer doing root cause analysis — not a bot that pastes template responses.
+
+## When to Use
+
+- `/triage` — triage all open, unlabeled issues
+- `/triage 10` — investigate issue #10 specifically
+- `/triage --batch` — pull all open issues, classify, investigate, report
+- `/triage --stale` — find issues older than 14 days with no activity
+- After the `issue-monitor` SessionStart hook reports new issues
+
+## Inputs
+
+| Input | Source | Required |
+|-------|--------|----------|
+| Issue number | Argument (e.g., `/triage 10`) | No — omit to triage all open |
+| Repo | Auto-detected from git remote | Yes (auto) |
+| gh CLI | `"/c/Program Files/GitHub CLI/gh.exe"` on Windows, `gh` elsewhere | Yes (auto) |
+
+## Execution Protocol
+
+### Phase 0 — Environment Setup
+
+1. Detect the GitHub repo from `git remote get-url origin`
+2. Extract `owner/repo` from the remote URL
+3. Verify `gh` auth status
+4. Determine the gh CLI path:
+   - Windows: `"/c/Program Files/GitHub CLI/gh.exe"`
+   - Other: `gh`
+5. Store as `$GH` for all subsequent commands
+
+### Phase 1 — Issue Intake
+
+**Single issue mode** (`/triage 10`):
+```
+$GH issue view <number> --repo <owner/repo> --json number,title,body,labels,state,comments,createdAt,updatedAt,author,assignees
+```
+
+**Batch mode** (`/triage` or `/triage --batch`):
+```
+$GH issue list --repo <owner/repo> --state open --json number,title,labels,createdAt,updatedAt --limit 50
+```
+
+Filter to untriaged: issues with no labels, or issues missing a priority/type label.
+
+**Stale mode** (`/triage --stale`):
+```
+$GH issue list --repo <owner/repo> --state open --json number,title,labels,createdAt,updatedAt --limit 100
+```
+Filter to issues with no activity in 14+ days.
+
+Output: list of issues to investigate, sorted by age (oldest first).
+
+### Phase 2 — Classification
+
+For each issue, classify along these dimensions:
+
+**Type** (exactly one):
+| Type | Signal |
+|------|--------|
+| `bug` | Error messages, "doesn't work", "broken", stack traces, regression |
+| `feature` | "Would be nice", "add support for", "should be able to" |
+| `question` | "How do I", "is it possible", "what does X do" |
+| `docs` | "README says", "documentation", "typo", "unclear instructions" |
+| `infra` | CI/CD, build, packaging, release, dependency issues |
+
+**Severity** (for bugs only):
+| Severity | Criteria |
+|----------|----------|
+| `critical` | Blocks installation or core functionality for all users |
+| `high` | Breaks a major feature or affects many users |
+| `medium` | Breaks a minor feature or has a workaround |
+| `low` | Cosmetic, edge case, or has an easy workaround |
+
+**Affected Component** — map to project directory:
+- `.claude/hooks/` — hook system
+- `.claude/skills/` — skill system
+- `.claude/agents/` — agent system
+- `.claude/settings.json` — configuration
+- `.planning/` — planning/campaign system
+- `docs/` — documentation
+- Root files — project setup (README, package.json, CLAUDE.md)
+
+Record classification in a structured block before proceeding.
+
+### Phase 3 — Investigation
+
+This is the core phase. Investigate like a senior engineer, not a keyword matcher.
+
+#### 3a. Parse the Report
+
+Extract from the issue body:
+- **Error messages** — exact text, stack traces, error codes
+- **Environment** — OS, shell, Node version, Claude Code version
+- **Reproduction steps** — what the user did
+- **Expected vs actual behavior**
+- **Workaround** — did the user already find one?
+
+#### 3b. Search the Codebase
+
+Based on extracted signals, search systematically:
+
+1. **Error text search** — grep for exact error messages, error codes, exception types
+2. **File search** — if the issue mentions specific files, read them
+3. **Function search** — if stack traces name functions, find their definitions
+4. **Pattern search** — look for the anti-pattern or bug class described
+5. **Related changes** — `git log --oneline -20 -- <affected-files>` to see recent changes
+6. **Cross-reference** — check if similar issues exist or were previously fixed
+
+#### 3c. Root Cause Analysis
+
+For bugs, determine:
+1. **What breaks** — the specific code path that fails
+2. **Why it breaks** — the root cause (not the symptom)
+3. **When it was introduced** — git blame / log if applicable
+4. **Who is affected** — scope of impact (all users, Windows only, specific config, etc.)
+5. **What the fix is** — specific code change with file:line references
+
+For features/questions:
+1. **Is it already possible?** — search for existing functionality
+2. **Where would it go?** — which component/layer
+3. **What's the effort?** — trivial/small/medium/large
+4. **Are there blockers?** — dependencies, architecture constraints
+
+#### 3d. Reproduce (when possible)
+
+If the bug is in code you can execute (hooks, scripts):
+1. Set up the conditions described in the issue
+2. Run the failing command
+3. Confirm the error matches
+4. Verify the proposed fix resolves it
+
+### Phase 4 — Resolution Plan
+
+Produce a structured finding for each issue:
+
+```markdown
+## Issue #<N>: <title>
+
+**Type:** bug | feature | question | docs | infra
+**Severity:** critical | high | medium | low
+**Component:** <affected directory/file>
+**Reproducible:** yes | no | not-attempted
+
+### Root Cause
+<1-3 sentences explaining WHY, not just WHAT>
+
+### Affected Code
+- `<file>:<line>` — <what's wrong here>
+- `<file>:<line>` — <related code>
+
+### Proposed Fix
+<Specific code changes. Not "update the code" — actual diffs or clear instructions.>
+
+### Impact
+- Who is affected: <scope>
+- Workaround exists: yes/no — <workaround if yes>
+- Breaking change: yes/no
+
+### Recommended Action
+- [ ] Fix in next release
+- [ ] Needs more info from reporter
+- [ ] Won't fix — <reason>
+- [ ] Duplicate of #<N>
+```
+
+### Phase 5 — Action
+
+Based on the resolution plan, take one of these actions:
+
+**Auto-fix** (when all conditions met):
+- Root cause is clear and verified
+- Fix is contained (1-3 files)
+- No breaking changes
+- No architectural decisions needed
+
+Steps:
+1. Create a branch: `fix/issue-<number>-<slug>`
+2. Implement the fix
+3. Run typecheck/build to verify
+4. Commit with message: `fix: <description> (closes #<number>)`
+5. Push and open PR linking the issue
+6. Comment on the issue with the PR link
+
+**Comment with findings** (when fix needs discussion or user input):
+1. Post a structured comment on the issue with:
+   - Root cause analysis
+   - Proposed fix (if known)
+   - Questions (if more info needed)
+2. Add appropriate labels
+
+**Label only** (for questions, docs, features):
+1. Add type label
+2. Add priority label if applicable
+3. Optionally comment with pointers to existing docs/functionality
+
+### Phase 6 — Report
+
+After all issues are processed, output a summary table:
+
+```
+## Triage Summary
+
+| # | Title | Type | Severity | Action | Status |
+|---|-------|------|----------|--------|--------|
+| 10 | Cannot find module | bug | high | Auto-fixed → PR #11 | Done |
+| 8 | Feature request | feature | — | Labeled | Done |
+```
+
+## Label Taxonomy
+
+Apply these labels via `$GH issue edit <number> --add-label "<label>"`:
+
+**Type labels:**
+- `bug` — confirmed defect
+- `feature` — enhancement request
+- `question` — usage question
+- `docs` — documentation issue
+- `infra` — build/CI/packaging
+
+**Severity labels (bugs only):**
+- `critical` — blocks core functionality
+- `high` — major feature broken
+- `medium` — minor feature or has workaround
+- `low` — cosmetic or edge case
+
+**Status labels:**
+- `needs-info` — waiting for reporter response
+- `confirmed` — reproduced, fix identified
+- `wont-fix` — intentional behavior or out of scope
+- `duplicate` — duplicate of another issue
+
+## Quality Gates
+
+- [ ] Every investigated issue has a classification (type + severity for bugs)
+- [ ] Every bug has a root cause analysis with file:line references
+- [ ] Every auto-fix passes typecheck and build
+- [ ] Every PR links to the issue it fixes
+- [ ] Every issue comment is structured and actionable (no "I'll look into this")
+- [ ] No issue is left without at least a label or comment
+
+## Anti-Patterns — Do NOT
+
+- Do NOT post generic "thanks for reporting" comments without substance
+- Do NOT propose fixes without reading the actual code first
+- Do NOT label without investigating — classification requires reading the issue AND the code
+- Do NOT auto-fix if the root cause is unclear — comment with findings instead
+- Do NOT close issues without explanation
+- Do NOT comment on issues asking for more info if the answer is in the codebase
+- Do NOT guess at fixes — verify by reading code and running checks
+
+## gh CLI Notes
+
+- Windows path: `"/c/Program Files/GitHub CLI/gh.exe"`
+- Always use `--repo <owner/repo>` to avoid depending on git remote config
+- For comments: `$GH issue comment <number> --repo <owner/repo> --body "..."`
+- For labels: `$GH issue edit <number> --repo <owner/repo> --add-label "bug,high"`
+- For PRs: `$GH pr create --repo <owner/repo> --title "..." --body "..."`
+
+## Exit Protocol
+
+```
+---HANDOFF---
+- Triaged N issues: X bugs, Y features, Z questions
+- Auto-fixed: <list of issue numbers with PR links>
+- Needs attention: <list of issues requiring human decision>
+- New labels applied: <count>
+---
+```

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .claude/circuit-breaker-state.json
 .claude/compact-state.json
 .claude/harness.json
+.claude/issue-monitor-state.json
+.claude/settings.local.json
 
 # Coordination (ephemeral, per-session)
 .planning/coordination/instances/*.json

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -40,7 +40,7 @@ Hooks are configured in `.claude/settings.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "node \"$CLAUDE_PROJECT_DIR/.claude/hooks/post-edit.js\"",
+            "command": "node .claude/hooks/post-edit.js",
             "timeout": 30
           }
         ]


### PR DESCRIPTION
## Summary

Fixes #10 — `$CLAUDE_PROJECT_DIR` is not expanded on Windows (git bash, powershell, cmd), causing every hook to fail with `MODULE_NOT_FOUND`.

**Root cause:** Hook commands in `settings.json` used `node "$CLAUDE_PROJECT_DIR/.claude/hooks/<script>.js"`. On Windows, `$CLAUDE_PROJECT_DIR` is treated as a literal directory name, not an environment variable.

**Fix:** Replace with relative paths (`node .claude/hooks/<script>.js`). This works because Claude Code always sets cwd to the project root when executing hooks.

### Changes
- `.claude/settings.json` — all 8 hook commands updated to use relative paths
- `docs/HOOKS.md` — example code updated to match
- `.claude/skills/triage/SKILL.md` — new `/triage` skill for GitHub issue investigation
- `.claude/hooks/issue-monitor.js` — new SessionStart hook for issue alerts
- `.gitignore` — added `issue-monitor-state.json` and `settings.local.json`

### Affected
All Windows users — this was blocking 100% of hook functionality.