### PR TITLE
feat: hook smoke test, external-action-gate, and triage system

### DIFF
--- a/.claude/hooks/external-action-gate.js
+++ b/.claude/hooks/external-action-gate.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+/**
+ * external-action-gate.js — PreToolUse hook (Bash)
+ *
+ * Blocks external-facing actions that publish content under the user's name:
+ *   - git push (any variant)
+ *   - gh pr/issue create/comment/close/edit/merge/delete
+ *   - gh release create, gh repo fork
+ *   - gh api with mutating methods
+ *
+ * Strips quoted strings and heredoc bodies before matching to avoid
+ * false positives from commit messages and PR descriptions.
+ *
+ * NOT shipped in settings.json (would break Fleet/Archon autonomy).
+ * Users opt-in via settings.local.json.
+ *
+ * Exit codes:
+ *   0 = allowed
+ *   2 = blocked — agent must get user approval first
+ */
+
+const health = require('./harness-health-util');
+
+const BLOCKED_PATTERNS = [
+  { regex: /\bgit\s+push\b/, label: 'git push' },
+  { regex: /\bgh\s+pr\s+create\b/, label: 'gh pr create' },
+  { regex: /\bgh\s+pr\s+merge\b/, label: 'gh pr merge' },
+  { regex: /\bgh\s+pr\s+close\b/, label: 'gh pr close' },
+  { regex: /\bgh\s+pr\s+comment\b/, label: 'gh pr comment' },
+  { regex: /\bgh\s+pr\s+edit\b/, label: 'gh pr edit' },
+  { regex: /\bgh\s+pr\s+review\b/, label: 'gh pr review' },
+  { regex: /\bgh\s+issue\s+create\b/, label: 'gh issue create' },
+  { regex: /\bgh\s+issue\s+comment\b/, label: 'gh issue comment' },
+  { regex: /\bgh\s+issue\s+close\b/, label: 'gh issue close' },
+  { regex: /\bgh\s+issue\s+edit\b/, label: 'gh issue edit' },
+  { regex: /\bgh\s+issue\s+delete\b/, label: 'gh issue delete' },
+  { regex: /\bgh\s+release\s+create\b/, label: 'gh release create' },
+  { regex: /\bgh\s+repo\s+fork\b/, label: 'gh repo fork' },
+  { regex: /gh\.exe"\s+pr\s+create\b/, label: 'gh pr create' },
+  { regex: /gh\.exe"\s+pr\s+merge\b/, label: 'gh pr merge' },
+  { regex: /gh\.exe"\s+pr\s+close\b/, label: 'gh pr close' },
+  { regex: /gh\.exe"\s+pr\s+comment\b/, label: 'gh pr comment' },
+  { regex: /gh\.exe"\s+pr\s+edit\b/, label: 'gh pr edit' },
+  { regex: /gh\.exe"\s+pr\s+review\b/, label: 'gh pr review' },
+  { regex: /gh\.exe"\s+issue\s+create\b/, label: 'gh issue create' },
+  { regex: /gh\.exe"\s+issue\s+comment\b/, label: 'gh issue comment' },
+  { regex: /gh\.exe"\s+issue\s+close\b/, label: 'gh issue close' },
+  { regex: /gh\.exe"\s+issue\s+edit\b/, label: 'gh issue edit' },
+  { regex: /gh\.exe"\s+issue\s+delete\b/, label: 'gh issue delete' },
+  { regex: /gh\.exe"\s+release\s+create\b/, label: 'gh release create' },
+  { regex: /gh\.exe"\s+repo\s+fork\b/, label: 'gh repo fork' },
+  { regex: /\bgh\s+api\b.*--method\s+(POST|PUT|PATCH|DELETE)/i, label: 'gh api (mutating)' },
+  { regex: /gh\.exe"\s+api\b.*--method\s+(POST|PUT|PATCH|DELETE)/i, label: 'gh api (mutating)' },
+];
+
+/**
+ * Strip quoted strings and heredoc bodies so commit messages,
+ * PR descriptions, and echo'd text don't trigger false positives.
+ */
+function stripQuotedContent(cmd) {
+  let stripped = cmd;
+  // Strip heredoc bodies: <<'DELIM' ... DELIM  and  << DELIM ... DELIM
+  stripped = stripped.replace(/<<-?\s*'?(\w+)'?[^\n]*\n[\s\S]*?\n\s*\1\b/g, '');
+  // Strip $(...) subshells (often contain heredocs for commit messages)
+  stripped = stripped.replace(/"\$\([\s\S]*?\)"/g, '""');
+  // Strip remaining double-quoted strings
+  stripped = stripped.replace(/"(?:[^"\]|\.)*"/g, '""');
+  // Strip single-quoted strings
+  stripped = stripped.replace(/'(?:[^'\]|\.)*'/g, "''");
+  return stripped;
+}
+
+function main() {
+  let input = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', (chunk) => { input += chunk; });
+  process.stdin.on('end', () => {
+    try {
+      run(input);
+    } catch {
+      process.exit(0); // Fail open
+    }
+  });
+}
+
+function run(input) {
+  let event;
+  try { event = JSON.parse(input); } catch { process.exit(0); }
+
+  if ((event.tool_name || '') !== 'Bash') process.exit(0);
+
+  const command = event.tool_input?.command || '';
+  if (!command) process.exit(0);
+
+  const stripped = stripQuotedContent(command);
+
+  for (const { regex, label } of BLOCKED_PATTERNS) {
+    if (regex.test(stripped)) {
+      health.logBlock('external-action-gate', 'blocked', `${label}: ${command.slice(0, 200)}`);
+      process.stdout.write(
+        `[external-action-gate] Blocked: "${label}" is an external action. ` +
+        `Show the user the exact content and get approval before executing. ` +
+        `Do NOT retry — ask the user first.`
+      );
+      process.exit(2);
+    }
+  }
+
+  process.exit(0);
+}
+
+main();

--- a/.claude/hooks/smoke-test.js
+++ b/.claude/hooks/smoke-test.js
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+/**
+ * smoke-test.js — Validates all hooks load and execute without errors.
+ *
+ * Run manually: node .claude/hooks/smoke-test.js
+ * Run via setup: automatically invoked during /setup
+ *
+ * Tests:
+ *   1. Every hook file referenced in settings.json exists and parses (require())
+ *   2. Settings.json is valid JSON with expected structure
+ *   3. Hook commands use relative paths (not $CLAUDE_PROJECT_DIR)
+ *   4. All hook utility imports resolve
+ *   5. No platform-specific assumptions that would break cross-platform
+ *
+ * Exit codes:
+ *   0 = all checks pass
+ *   1 = one or more checks failed (details printed to stdout)
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PROJECT_ROOT = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+const SETTINGS_PATH = path.join(PROJECT_ROOT, '.claude', 'settings.json');
+const HOOKS_DIR = path.join(PROJECT_ROOT, '.claude', 'hooks');
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+
+function check(name, fn) {
+  try {
+    const result = fn();
+    if (result === true || result === undefined) {
+      passed++;
+      console.log(`  PASS  ${name}`);
+    } else {
+      failed++;
+      const msg = typeof result === 'string' ? result : 'returned falsy';
+      failures.push({ name, msg });
+      console.log(`  FAIL  ${name}: ${msg}`);
+    }
+  } catch (err) {
+    failed++;
+    const msg = err.message || String(err);
+    failures.push({ name, msg });
+    console.log(`  FAIL  ${name}: ${msg}`);
+  }
+}
+
+function main() {
+  console.log('\nCitadel Hook Smoke Test\n' + '='.repeat(40));
+
+  // ── 1. Settings.json exists and is valid JSON ──
+
+  let settings;
+  check('settings.json exists', () => {
+    if (!fs.existsSync(SETTINGS_PATH)) return 'File not found';
+    return true;
+  });
+
+  check('settings.json is valid JSON', () => {
+    settings = JSON.parse(fs.readFileSync(SETTINGS_PATH, 'utf8'));
+    return true;
+  });
+
+  check('settings.json has hooks object', () => {
+    if (!settings || !settings.hooks) return 'No "hooks" key found';
+    if (typeof settings.hooks !== 'object') return '"hooks" is not an object';
+    return true;
+  });
+
+  if (!settings || !settings.hooks) {
+    console.log('\nCannot continue — settings.json is invalid.\n');
+    process.exit(1);
+  }
+
+  // ── 2. No $CLAUDE_PROJECT_DIR in commands ──
+
+  check('no $CLAUDE_PROJECT_DIR in hook commands', () => {
+    const raw = fs.readFileSync(SETTINGS_PATH, 'utf8');
+    if (raw.includes('$CLAUDE_PROJECT_DIR')) {
+      return '$CLAUDE_PROJECT_DIR found — this breaks on Windows. Use relative paths instead.';
+    }
+    return true;
+  });
+
+  // ── 3. Every referenced hook file exists ──
+
+  const hookCommands = [];
+  for (const [event, entries] of Object.entries(settings.hooks)) {
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      const hooks = entry.hooks || [];
+      for (const hook of hooks) {
+        if (hook.command) {
+          hookCommands.push({ event, command: hook.command });
+        }
+      }
+    }
+  }
+
+  const hookFiles = new Set();
+  for (const { event, command } of hookCommands) {
+    // Extract the JS file path from commands like "node .claude/hooks/foo.js"
+    const match = command.match(/node\s+(.+\.js)/);
+    if (match) {
+      const relPath = match[1].replace(/"/g, '');
+      hookFiles.add(relPath);
+      const fullPath = path.join(PROJECT_ROOT, relPath);
+
+      check(`${event}: ${relPath} exists`, () => {
+        if (!fs.existsSync(fullPath)) return `File not found: ${fullPath}`;
+        return true;
+      });
+    }
+  }
+
+  // ── 4. Every hook file parses without syntax errors ──
+
+  for (const relPath of hookFiles) {
+    const fullPath = path.join(PROJECT_ROOT, relPath);
+    if (!fs.existsSync(fullPath)) continue;
+
+    check(`${relPath} has valid syntax`, () => {
+      const content = fs.readFileSync(fullPath, 'utf8');
+      // Use Node's built-in syntax check
+      new (require('vm').Script)(content, { filename: relPath });
+      return true;
+    });
+  }
+
+  // ── 5. harness-health-util.js loads ──
+
+  check('harness-health-util.js loads', () => {
+    const utilPath = path.join(HOOKS_DIR, 'harness-health-util.js');
+    if (!fs.existsSync(utilPath)) return 'File not found';
+    // Clear cache to test fresh load
+    delete require.cache[require.resolve(utilPath)];
+    const util = require(utilPath);
+    if (!util.PROJECT_ROOT) return 'MODULE_ROOT not exported';
+    if (!util.readConfig) return 'readConfig not exported';
+    if (!util.validatePath) return 'validatePath not exported';
+    return true;
+  });
+
+  // ── 6. Check for hooks that require() harness-health-util ──
+
+  for (const relPath of hookFiles) {
+    const fullPath = path.join(PROJECT_ROOT, relPath);
+    if (!fs.existsSync(fullPath)) continue;
+    const content = fs.readFileSync(fullPath, 'utf8');
+
+    if (content.includes("require('./harness-health-util')")) {
+      check(`${relPath} can resolve harness-health-util`, () => {
+        const utilPath = path.join(path.dirname(fullPath), 'harness-health-util.js');
+        if (!fs.existsSync(utilPath)) return `Cannot find harness-health-util.js relative to ${relPath}`;
+        return true;
+      });
+    }
+  }
+
+  // ── 7. Cross-platform checks ──
+
+  for (const relPath of hookFiles) {
+    const fullPath = path.join(PROJECT_ROOT, relPath);
+    if (!fs.existsSync(fullPath)) continue;
+    const content = fs.readFileSync(fullPath, 'utf8');
+
+    // Check for hardcoded Unix-only commands used unsafely
+    check(`${relPath} no hardcoded /bin/ paths`, () => {
+      if (/\/bin\/(bash|sh|zsh)\b/.test(content)) {
+        return 'Hardcoded Unix shell path — will fail on Windows';
+      }
+      return true;
+    });
+  }
+
+  // ── Summary ──
+
+  console.log('\n' + '='.repeat(40));
+  console.log(`Results: ${passed} passed, ${failed} failed\n`);
+
+  if (failures.length > 0) {
+    console.log('Failures:');
+    for (const { name, msg } of failures) {
+      console.log(`  - ${name}: ${msg}`);
+    }
+    console.log('');
+    process.exit(1);
+  }
+
+  console.log('All hooks are healthy.\n');
+  process.exit(0);
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "coord:sweep": "node scripts/coordination.js sweep",
     "telemetry:report": "node scripts/telemetry-report.cjs",
     "telemetry:log": "node scripts/telemetry-log.cjs",
-    "compress:discovery": "node scripts/compress-discovery.cjs"
+    "compress:discovery": "node scripts/compress-discovery.cjs",
+    "test:hooks": "node .claude/hooks/smoke-test.js"
   },
   "keywords": [
     "claude",


### PR DESCRIPTION
## Summary
- Fixed $CLAUDE_PROJECT_DIR Windows path issue (closes #10)
- Added /triage skill for GitHub issue investigation
- Added issue-monitor SessionStart hook for issue alerts
- Added external-action-gate hook (opt-in via settings.local.json)
- Added smoke-test.js — 34-check hook validation suite (npm run test:hooks)
- Added test:hooks script to package.json

## What ships to users vs what's local
- settings.json: universal hooks only (no gate)
- external-action-gate.js + issue-monitor.js: ship as files, users opt-in via settings.local.json
- settings.local.json is gitignored

## Test plan
- [ ] npm run test:hooks passes (34/34)
- [ ] Fresh clone on Windows: hooks work with relative paths
- [ ] external-action-gate blocks git push when wired in local settings
- [ ] Commit messages containing "git push" text don't trigger false positives