### PR TITLE
feat: extend /triage to handle PRs, add CONTRIBUTING.md, update README

### DIFF
--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -1,24 +1,27 @@
 ---
 name: triage
 description: >-
-  GitHub issue investigator. Pulls open issues, classifies them, searches the codebase
-  for root cause, proposes fixes with file:line references, and optionally implements
-  fixes as PRs. Can operate on a single issue or batch-triage all untriaged issues.
+  GitHub issue and PR investigator. Pulls open issues/PRs, classifies them, searches
+  the codebase for root cause or reviews contributed code, proposes fixes with file:line
+  references, and optionally implements fixes. Handles both issues and pull requests.
 user-invocable: true
 auto-trigger: false
 effort: high
-last-updated: 2026-03-23
+last-updated: 2026-03-24
 ---
 
-# Triage — GitHub Issue Investigator
+# Triage — GitHub Issue & PR Investigator
 
-You are the project's issue triage system. You investigate GitHub issues with the rigor
-of a senior engineer doing root cause analysis — not a bot that pastes template responses.
+You are the project's triage system. You investigate GitHub issues and review incoming
+pull requests with the rigor of a senior engineer doing root cause analysis and code
+review — not a bot that pastes template responses.
 
 ## When to Use
 
 - `/triage` — triage all open, unlabeled issues
 - `/triage 10` — investigate issue #10 specifically
+- `/triage pr 13` — review PR #13
+- `/triage prs` — review all open PRs
 - `/triage --batch` — pull all open issues, classify, investigate, report
 - `/triage --stale` — find issues older than 14 days with no activity
 - After the `issue-monitor` SessionStart hook reports new issues
@@ -27,7 +30,8 @@ of a senior engineer doing root cause analysis — not a bot that pastes templat
 
 | Input | Source | Required |
 |-------|--------|----------|
-| Issue number | Argument (e.g., `/triage 10`) | No — omit to triage all open |
+| Issue/PR number | Argument (e.g., `/triage 10`, `/triage pr 13`) | No — omit to triage all open |
+| Mode | `pr` prefix for PRs (e.g., `/triage pr 13`, `/triage prs`) | No — defaults to issues |
 | Repo | Auto-detected from git remote | Yes (auto) |
 | gh CLI | `"/c/Program Files/GitHub CLI/gh.exe"` on Windows, `gh` elsewhere | Yes (auto) |
 
@@ -64,6 +68,81 @@ $GH issue list --repo <owner/repo> --state open --json number,title,labels,creat
 Filter to issues with no activity in 14+ days.
 
 Output: list of issues to investigate, sorted by age (oldest first).
+
+**Single PR mode** (`/triage pr 13`):
+```
+$GH pr view <number> --repo <owner/repo> --json number,title,body,author,state,files,commits,comments,createdAt,headRefName,baseRefName,mergeable,reviewDecision
+```
+Then fetch the full diff:
+```
+$GH pr diff <number> --repo <owner/repo>
+```
+
+**All PRs mode** (`/triage prs`):
+```
+$GH pr list --repo <owner/repo> --state open --json number,title,author,createdAt,labels --limit 50
+```
+
+### Phase 1b — PR Review Protocol
+
+For pull requests, the investigation is different from issues. You are reviewing contributed code.
+
+#### PR Classification
+
+| Type | Signal |
+|------|--------|
+| `bugfix` | Fixes a reported issue, closes #N |
+| `feature` | Adds new functionality |
+| `refactor` | Restructures without changing behavior |
+| `docs` | Documentation only |
+| `infra` | CI/CD, build, packaging, installer |
+
+#### PR Review Checklist
+
+1. **Read the full diff.** Not just the PR description. The code is the truth.
+2. **Check for regressions.** Does this PR reintroduce a bug we already fixed? Search closed issues and recent commits for overlap.
+3. **Check for conflicts with in-flight work.** Does this touch the same files as open PRs or recent commits on dev/main?
+4. **Verify the approach.** Is this the right solution? Could it be simpler?
+5. **Check cross-platform.** Does it assume Unix? Does it handle Windows paths? Does it use `$CLAUDE_PROJECT_DIR` (broken on Windows, see #10)?
+6. **Check conventions.** Does the code follow the project's existing patterns?
+7. **Check for scope creep.** Does the PR do more than its title says?
+
+#### PR Resolution
+
+Produce a structured review:
+
+```markdown
+## PR #<N>: <title>
+
+**Author:** <username>
+**Type:** bugfix | feature | refactor | docs | infra
+**Files changed:** <count>
+**Mergeable:** yes | no
+
+### What it does
+<1-3 sentences>
+
+### Review findings
+- <finding with file:line reference>
+
+### Issues found
+- **Critical:** <blocks merge>
+- **Non-critical:** <nice to fix but not blocking>
+
+### Recommendation
+- [ ] Approve
+- [ ] Request changes: <specific changes needed>
+- [ ] Close: <reason>
+```
+
+#### PR Actions
+
+**IMPORTANT:** All PR actions (commenting, requesting changes, approving) are external actions.
+Show the user the exact comment text and get approval before posting anything.
+
+- **Approve:** draft approval comment, show to user, post after approval
+- **Request changes:** draft comment with specific findings, show to user, post after approval
+- **Close:** draft explanation, show to user, close after approval
 
 ### Phase 2 — Classification
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing to Citadel
+
+Contributions are welcome. Issues, bug reports, new skills, and hook improvements all help.
+
+## Reporting Issues
+
+Open an issue on [GitHub](https://github.com/SethGammon/Citadel/issues). Include:
+
+- What you expected to happen
+- What actually happened
+- Error messages (full text, not screenshots of text)
+- Your OS, shell, and Node version
+
+## Submitting Pull Requests
+
+1. Fork the repo
+2. Create a branch from `main` (e.g., `fix/issue-10-description` or `feat/new-skill`)
+3. Make your changes
+4. Run `npm run test:hooks` to verify hooks are healthy
+5. Open a PR against `main`
+
+**Branch protection is enabled.** All changes go through a PR. Direct pushes to main are blocked.
+
+### What to watch out for
+
+**Cross-platform compatibility.** Citadel runs on Windows, macOS, and Linux. Before submitting:
+
+- Do NOT use `$CLAUDE_PROJECT_DIR` in hook commands. It doesn't expand on Windows. Use relative paths (`node .claude/hooks/your-hook.js`). See [#10](https://github.com/SethGammon/Citadel/issues/10).
+- Do NOT hardcode `/bin/bash`, `/bin/sh`, or other Unix-only paths
+- Do NOT assume forward-slash path separators in Node scripts (use `path.join()`)
+- Test on your platform and note which platform you tested on in the PR
+
+**Hook commands use relative paths.** All hook commands in `settings.json` use the form `node .claude/hooks/<script>.js`. Claude Code sets cwd to the project root, so relative paths work everywhere.
+
+**settings.json vs settings.local.json.** `settings.json` is tracked and ships to every user. `settings.local.json` is gitignored and is for personal configuration. If your hook or feature is only useful to specific workflows (not all users), it belongs in `settings.local.json`.
+
+## Adding a New Skill
+
+Skills live in `.claude/skills/<name>/SKILL.md`. Every skill needs:
+
+```yaml
+---
+name: skill-name
+description: >-
+  One or two sentences explaining what the skill does.
+user-invocable: true
+auto-trigger: false
+---
+```
+
+Follow the patterns in existing skills. Read 2-3 before writing your own.
+
+## Adding a New Hook
+
+Hooks live in `.claude/hooks/`. Before adding one:
+
+1. Read `harness-health-util.js` for shared utilities (telemetry, config, validation)
+2. Use `execFileSync` (not `execSync`) to avoid shell injection
+3. Use `require('./harness-health-util')` for the project root path
+4. Add your hook to `settings.json` (if universal) or document it for `settings.local.json` (if opt-in)
+5. Run `npm run test:hooks` to make sure the smoke test picks it up
+
+## Code Style
+
+- Node.js scripts use CommonJS (`require`), not ESM
+- Keep hooks fast (under 5s for PreToolUse, under 30s for PostToolUse)
+- Fail-closed for security hooks (exit 2 on error), fail-open for non-critical hooks (exit 0 on error)
+- No external dependencies. Hooks use only Node built-ins.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Run autonomous coding campaigns with Claude Code. Route any task through the right tool at the right scale — from a one-line fix to a multi-day parallel campaign.
 
-**24 skills | 3 autonomous agents | 8 lifecycle hooks | campaign persistence | fleet coordination**
+**26 skills | 4 autonomous agents | 10 lifecycle hooks | campaign persistence | fleet coordination**
 
 <img src="assets/citadel-overview.svg" width="100%" alt="Citadel system overview — app creation pipeline and safety systems" />
 
@@ -98,7 +98,7 @@ Four tiers. Use the cheapest one that fits.
 </tr>
 </table>
 
-## Skills (24)
+## Skills (26)
 
 ### App Creation (3)
 | Skill | What It Does | Invoke |
@@ -141,14 +141,20 @@ Four tiers. Use the cheapest one that fits.
 | QA | Browser-based interaction testing via Playwright (optional dependency) | `/qa` |
 | Postmortem | Auto-generates structured postmortems from completed campaigns | `/postmortem` |
 
-### Utilities (3)
+### Maintenance (1)
+| Skill | What It Does | Invoke |
+|---|---|---|
+| Triage | GitHub issue and PR investigator. Classifies, investigates root cause, reviews contributed code. | `/triage` |
+
+### Utilities (4)
 | Skill | What It Does | Invoke |
 |---|---|---|
 | Live Preview | Mid-build visual verification via screenshots | `/live-preview` |
 | Session Handoff | Context transfer between sessions | `/session-handoff` |
 | Setup | First-run harness configuration | `/do setup` |
+| Simplify | Reviews changed code for reuse, quality, and efficiency | `/simplify` |
 
-## Hooks (8)
+## Hooks (10)
 
 Automated quality enforcement that runs without you thinking about it.
 
@@ -162,6 +168,8 @@ Automated quality enforcement that runs without you thinking about it.
 | Pre-compaction save | Before context compaction | Saves session state so nothing is lost |
 | Post-compaction restore | After context compaction | Restores session state from saved snapshot |
 | Worktree setup | Agent spawn | Auto-installs deps in parallel agent worktrees |
+| Smoke test | On demand | Validates all hooks load, parse, and resolve (`npm run test:hooks`) |
+| External action gate | Before bash (opt-in) | Blocks push/PR/comment until user approves. Add to `settings.local.json` to enable. |
 
 ## Sub-Agents (4)
 
@@ -197,6 +205,10 @@ Run 2-3 agents simultaneously in isolated worktrees. Discoveries compress into ~
 **Can I use this with other AI tools?** — Designed for Claude Code specifically. The concepts are portable but the implementation uses Claude Code's extension points.
 
 **Does this work on Windows?** — Yes. All hooks and scripts run on Node.js. The [quickstart](#quickstart) has install commands for Bash, PowerShell, and Command Prompt.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on submitting issues, PRs, and new skills.
 
 ## Learn More
 


### PR DESCRIPTION
## Summary
- /triage skill now handles PR review: `/triage pr 13`, `/triage prs`
- Added CONTRIBUTING.md with cross-platform guidelines and hook rules
- README updated: 26 skills, 10 hooks, new triage/simplify entries, contributing link
- Includes previous commit: external-action-gate hook and smoke test

## Test plan
- [ ] npm run test:hooks passes
- [ ] /triage pr <number> works on an open PR
- [ ] CONTRIBUTING.md renders correctly on GitHub