### PR TITLE
docs: add settings.json backup warnings to install instructions

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -16,6 +16,9 @@ No API key setup needed — Citadel inherits Claude Code's authentication.
 git clone https://github.com/SethGammon/Citadel.git
 cd your-project
 
+# Back up existing settings if you have them
+[ -f .claude/settings.json ] && cp .claude/settings.json .claude/settings.json.bak
+
 cp -r ../Citadel/.claude .
 cp -r ../Citadel/.planning .
 cp -r ../Citadel/scripts .
@@ -24,10 +27,15 @@ cp -r ../Citadel/scripts .
 cp ../Citadel/CLAUDE.md .
 ```
 
+> **If you backed up settings.json:** merge your existing hooks and MCP servers back into `.claude/settings.json` after the copy. The Citadel hooks are in the `"hooks"` key. Your other settings (MCP servers, permissions, etc.) go alongside them.
+
 ### Windows (Command Prompt)
 ```cmd
 git clone https://github.com/SethGammon/Citadel.git
 cd your-project
+
+:: Back up existing settings if you have them
+if exist .claude\settings.json copy .claude\settings.json .claude\settings.json.bak
 
 xcopy /E /I ..\Citadel\.claude .\.claude
 xcopy /E /I ..\Citadel\.planning .\.planning
@@ -39,6 +47,9 @@ xcopy ..\Citadel\CLAUDE.md .\CLAUDE.md*
 ```powershell
 git clone https://github.com/SethGammon/Citadel.git
 cd your-project
+
+# Back up existing settings if you have them
+if (Test-Path .claude\settings.json) { Copy-Item .claude\settings.json .claude\settings.json.bak }
 
 Copy-Item -Recurse ..\Citadel\.claude .\.claude
 Copy-Item -Recurse ..\Citadel\.planning .\.planning

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ git clone https://github.com/SethGammon/Citadel.git
 cp -r Citadel/.claude Citadel/.planning Citadel/scripts your-project/
 ```
 
+> **Already have a `.claude/settings.json`?** The copy above will overwrite it. Back up your existing settings first: `cp your-project/.claude/settings.json your-project/.claude/settings.json.bak` — then merge the Citadel hooks into your existing file after install.
+
 <details>
 <summary>Windows? Use PowerShell or Command Prompt instead</summary>
 


### PR DESCRIPTION
## Summary
- Adds backup steps for existing `.claude/settings.json` before the copy-install step
- Covers all 3 platforms: Bash, Command Prompt, PowerShell
- Adds merge-back instructions so users know how to restore their hooks/MCP servers

## Context
The `cp -r` install step silently overwrites any existing `.claude/settings.json`. Users who already have hooks or MCP servers configured lose that config with no warning. This adds a safety net until the installer PR (#13) lands.

## Test plan
- [ ] Verify README.md quickstart section renders correctly on GitHub
- [ ] Verify QUICKSTART.md backup commands are correct for each platform