### PR TITLE
fix: post-merge cleanup for plugin architecture

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,35 @@ citadel/
   docs/                 # Reference documentation
 ```
 
+## Opt-in Hooks
+
+Some hooks are not wired in the plugin's `hooks/hooks.json` by default. They are available in `hooks_src/` for users who want them:
+
+- **`external-action-gate.js`** — Blocks git push, PR creation, issue comments, and other external actions until the user approves. Add to your project's `.claude/settings.local.json`:
+  ```json
+  {
+    "hooks": {
+      "PreToolUse": [{
+        "matcher": "Bash",
+        "hooks": [{ "type": "command", "command": "node '${CLAUDE_PLUGIN_ROOT}/hooks_src/external-action-gate.js'", "timeout": 5 }]
+      }]
+    }
+  }
+  ```
+
+- **`issue-monitor.js`** — Checks for new GitHub issues on session start. Add to `.claude/settings.local.json`:
+  ```json
+  {
+    "hooks": {
+      "SessionStart": [{
+        "hooks": [{ "type": "command", "command": "node '${CLAUDE_PLUGIN_ROOT}/hooks_src/issue-monitor.js'", "timeout": 20 }]
+      }]
+    }
+  }
+  ```
+
+> **Migrating from copy-based install?** These hooks previously lived at `.claude/hooks/`. The paths in your `settings.local.json` need to change from `node .claude/hooks/external-action-gate.js` to the `${CLAUDE_PLUGIN_ROOT}` form shown above.
+
 ## Code Style
 
 - Node.js scripts use CommonJS (`require`), not ESM

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -124,6 +124,59 @@ your-project/
     agent-context/        # Rules injected into sub-agents
 ```
 
+## Migrating from copy-based install
+
+If you previously installed Citadel by copying `.claude/`, `.planning/`, and `scripts/` into your project, follow these steps to switch to the plugin.
+
+### 1. Back up your project config
+
+These files are project-specific and should be kept:
+
+```bash
+# Keep these — they contain your project's state
+# .claude/harness.json     (project config from /do setup)
+# .planning/               (campaign state, fleet sessions, telemetry)
+# .claude/settings.local.json  (your personal hook config, if any)
+```
+
+### 2. Remove the copied harness files
+
+```bash
+# Remove Citadel's copied files (NOT your project config)
+rm -rf .claude/hooks/        # Hooks now live in the plugin
+rm -rf .claude/skills/       # Built-in skills now live in the plugin
+rm -rf .claude/agents/       # Agents now live in the plugin
+rm -rf scripts/              # Utility scripts are now synced to .citadel/scripts/
+rm -f .claude/settings.json  # Hook config is now in the plugin's hooks/hooks.json
+```
+
+Keep `.claude/harness.json` — it has your project's stack config. Keep `.planning/` — it has your campaign history.
+
+### 3. Install the plugin
+
+```bash
+git clone https://github.com/SethGammon/Citadel.git
+```
+
+In Claude Code:
+```
+/plugin marketplace add /path/to/Citadel
+/plugin install citadel@citadel-local
+```
+
+### 4. Update settings.local.json (if applicable)
+
+If you had opt-in hooks in `.claude/settings.local.json`, update the paths:
+
+| Before (copy-based) | After (plugin) |
+|---|---|
+| `node .claude/hooks/external-action-gate.js` | `node '${CLAUDE_PLUGIN_ROOT}/hooks_src/external-action-gate.js'` |
+| `node .claude/hooks/issue-monitor.js` | `node '${CLAUDE_PLUGIN_ROOT}/hooks_src/issue-monitor.js'` |
+
+### 5. Start a new session
+
+The `init-project` hook will auto-scaffold `.citadel/scripts/` and verify your `.planning/` directory on session start. Run `/do setup` to regenerate `harness.json` if needed.
+
 ## Telemetry
 
 The harness logs agent events, hook timing, and discovery compression to `.planning/telemetry/` (JSONL format, never leaves your machine).

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -52,7 +52,6 @@ maintain is a liability, not an asset.
 **What this skill produces:**
 - A complete `.claude/skills/{name}/SKILL.md` file in the project's directory
   (custom skills live in the project, separate from Citadel's built-in skills)
-  (custom skills live in the project, separate from Citadel's built-in skills)
 - A tested, working skill that has been validated on a real target
 - A user who understands how to invoke and modify their new skill
 


### PR DESCRIPTION
## Summary
- Remove duplicate line in `create-skill/SKILL.md`
- Add opt-in hook docs (external-action-gate, issue-monitor) with `${CLAUDE_PLUGIN_ROOT}` paths
- Add migration guide in QUICKSTART.md for users switching from copy-based install

Follow-up to PR #16.

## Test plan
- [ ] Verify QUICKSTART.md migration section renders correctly
- [ ] Verify CONTRIBUTING.md opt-in hooks section has correct JSON examples