### PR TITLE
fix: update stale skill path in examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -16,7 +16,7 @@ A completed campaign file showing Archon's multi-phase execution model. This exa
 - Active Context and Continuation State for cross-session persistence
 
 **How to use it:**
-1. Read it alongside the Archon skill definition at `.claude/skills/archon/SKILL.md`
+1. Read it alongside the Archon skill definition at `skills/archon/SKILL.md`
 2. Compare its structure to the campaign template at `.planning/_templates/campaign.md`
 3. Use it as a reference when creating your own campaigns — the format is the contract that Archon reads and writes
 


### PR DESCRIPTION
## Summary
- Fix stale path reference: `.claude/skills/archon/SKILL.md` → `skills/archon/SKILL.md`
- Missed in the plugin architecture migration (PR #16)

One-liner, no test plan needed.