### PR TITLE
fix: correct marketplace source path for plugin install (closes #19)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "citadel",
       "description": "Agent orchestration harness for Claude Code — route any task through the right tool at the right scale",
       "version": "1.0.0",
-      "source": "./",
+      "source": "../",
       "author": {
         "name": "SethGammon",
         "email": "noreply@github.com"


### PR DESCRIPTION
## Summary
- Fix `source` in `.claude-plugin/marketplace.json` from `"./"` to `"../"`
- `"./"` resolved relative to marketplace.json (inside `.claude-plugin/`), pointing to the wrong directory
- `"../"` resolves to the repo root where `.claude-plugin/plugin.json` lives

Fixes #19.

## Test plan
- [ ] Run `/plugin marketplace add /path/to/Citadel` followed by `/plugin install citadel@citadel-local`
- [ ] Confirm plugin installs successfully without falling back to interactive mode