### PR TITLE
docs: update install instructions with reliable plugin-dir method (#19)

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -16,22 +16,27 @@ No API key setup needed — Citadel inherits Claude Code's authentication.
 git clone https://github.com/SethGammon/Citadel.git
 ```
 
-Then register it as a local plugin in Claude Code:
+### Option A: Quick start (per-session)
 
-```
-# Add as a local marketplace
-/plugin marketplace add /path/to/Citadel
-
-# Install the plugin
-/plugin install citadel@citadel-local
-```
-
-Alternatively, load it for a single session without installing:
+Launch Claude Code with the plugin loaded:
 ```bash
 claude --plugin-dir /path/to/Citadel
 ```
 
-No file copying required. The plugin installs once and works across all your projects.
+This loads the plugin for the current session. Use this to get started immediately.
+
+### Option B: Persistent install (all sessions)
+
+Inside Claude Code, register the marketplace and install:
+```
+/plugin marketplace add /path/to/Citadel
+/plugin install citadel@citadel-local
+/reload-plugins
+```
+
+This installs the plugin permanently — no flags needed on future sessions.
+
+> **Troubleshooting:** If `/plugin install` says "Plugin not found", launch with `claude --plugin-dir /path/to/Citadel` first, then run the marketplace add and install from inside that session.
 
 ## 2. Run setup
 

--- a/README.md
+++ b/README.md
@@ -17,21 +17,27 @@ Run autonomous coding campaigns with Claude Code. Route any task through the rig
 Citadel is a Claude Code **plugin** — install once, works across all your projects. No per-project file copying.
 
 ```bash
-# 1. Clone and register as a local plugin
+# 1. Clone Citadel
 git clone https://github.com/SethGammon/Citadel.git
 
-# In Claude Code, add as a local marketplace and install:
-/plugin marketplace add /path/to/Citadel
-/plugin install citadel@citadel-local
+# 2. Launch Claude Code with the plugin loaded
+claude --plugin-dir /path/to/Citadel
 
-# 2. Run setup (inside any project)
+# 3. Run setup (inside any project)
 /do setup
 
-# 3. Try something
+# 4. Try something
 /do review src/main.ts
 ```
 
-That's it. The `init-project` hook auto-scaffolds `.planning/` and `.citadel/scripts/` on every session start. [Full install guide →](QUICKSTART.md)
+For persistent install across all sessions, use the marketplace method inside Claude Code:
+```
+/plugin marketplace add /path/to/Citadel
+/plugin install citadel@citadel-local
+/reload-plugins
+```
+
+[Full install guide →](QUICKSTART.md)
 
 ## Try These First
 


### PR DESCRIPTION
## Summary
- Lead with `--plugin-dir` as the primary install method (works immediately, no marketplace issues)
- Move marketplace install to Option B with troubleshooting note
- Addresses the "Plugin not found" issue in #19

## Context
The marketplace-only install path has a reproducible issue where `/plugin install citadel@citadel-local` fails with "Plugin not found" even after marketplace add succeeds. Root cause is still under investigation, but `--plugin-dir` works reliably as a workaround.