### PR TITLE
fix: add hook installer to work around CLAUDE_PLUGIN_ROOT bug (#19)

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -38,9 +38,22 @@ This installs the plugin permanently — no flags needed on future sessions.
 
 > **Troubleshooting:** If `/plugin install` says "Plugin not found", launch with `claude --plugin-dir /path/to/Citadel` first, then run the marketplace add and install from inside that session.
 
-## 2. Run setup
+## 2. Install hooks into your project
 
-Open any project in Claude Code, then:
+From your project directory, run:
+```bash
+node /path/to/Citadel/scripts/install-hooks.js
+```
+
+This resolves Citadel's hook paths and writes them into your project's `.claude/settings.json`. It's a one-time step per project and is idempotent (safe to re-run after Citadel updates).
+
+> **Why is this needed?** There's a [known bug](https://github.com/anthropics/claude-code/issues/24529) in Claude Code where `${CLAUDE_PLUGIN_ROOT}` doesn't expand in hook commands. This script works around it by writing resolved absolute paths. Once the bug is fixed upstream, this step will no longer be necessary.
+
+If you already have a `.claude/settings.json`, the installer merges Citadel's hooks with your existing settings — it won't overwrite your permissions, env vars, or MCP servers.
+
+## 3. Run setup
+
+Open your project in Claude Code, then:
 ```
 /do setup
 ```
@@ -50,12 +63,10 @@ This will:
 - Detect your language and framework
 - Configure the typecheck hook for your stack
 - Generate `.claude/harness.json` with your settings
-- Verify the auto-scaffolded `.planning/` directory structure
+- Scaffold the `.planning/` directory structure
 - Run a quick demo on your code
 
-> **Note:** The `init-project` hook automatically creates `.planning/` and `.citadel/scripts/` on every session start. You don't need to copy any files.
-
-## 3. Try these first
+## 4. Try these first
 
 Start simple and work up:
 
@@ -75,7 +86,7 @@ Or just describe what you want:
 
 The `/do` router classifies your intent and dispatches to the cheapest tool that can handle it. Most requests resolve without spending any extra tokens.
 
-## 4. Scale up when ready
+## 5. Scale up when ready
 
 Once you're comfortable with skills, try orchestrators:
 
@@ -93,7 +104,7 @@ Or build entire apps from a description:
 
 Or let `/do` route to them automatically — it will escalate when the task requires it.
 
-## 5. Create your first custom skill
+## 6. Create your first custom skill
 
 ```
 /create-skill

--- a/README.md
+++ b/README.md
@@ -23,19 +23,24 @@ git clone https://github.com/SethGammon/Citadel.git
 # 2. Launch Claude Code with the plugin loaded
 claude --plugin-dir /path/to/Citadel
 
-# 3. Run setup (inside any project)
+# 3. Install hooks into your project (one-time per project)
+node /path/to/Citadel/scripts/install-hooks.js
+
+# 4. Run setup
 /do setup
 
-# 4. Try something
+# 5. Try something
 /do review src/main.ts
 ```
 
-For persistent install across all sessions, use the marketplace method inside Claude Code:
+For persistent plugin install across all sessions, use the marketplace method inside Claude Code:
 ```
 /plugin marketplace add /path/to/Citadel
 /plugin install citadel@citadel-local
 /reload-plugins
 ```
+
+> **Note:** The hook installer (step 3) is required until [a known upstream bug](https://github.com/anthropics/claude-code/issues/24529) is resolved. It writes Citadel's hook config into your project's `.claude/settings.json` with resolved paths. `/do setup` will also run this automatically.
 
 [Full install guide →](QUICKSTART.md)
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node '${CLAUDE_PLUGIN_ROOT}/hooks_src/protect-files.js'",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/protect-files.js",
             "timeout": 5
           }
         ]
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node '${CLAUDE_PLUGIN_ROOT}/hooks_src/protect-files.js'",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/protect-files.js",
             "timeout": 5
           }
         ]
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node '${CLAUDE_PLUGIN_ROOT}/hooks_src/post-edit.js'",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/post-edit.js",
             "timeout": 30
           }
         ]
@@ -38,7 +38,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node '${CLAUDE_PLUGIN_ROOT}/hooks_src/pre-compact.js'",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/pre-compact.js",
             "timeout": 10
           }
         ]
@@ -49,7 +49,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node '${CLAUDE_PLUGIN_ROOT}/hooks_src/quality-gate.js'",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/quality-gate.js",
             "timeout": 10
           }
         ]
@@ -60,7 +60,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node '${CLAUDE_PLUGIN_ROOT}/hooks_src/circuit-breaker.js'",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/circuit-breaker.js",
             "timeout": 5
           }
         ]
@@ -71,7 +71,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node '${CLAUDE_PLUGIN_ROOT}/hooks_src/init-project.js'",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/init-project.js",
             "timeout": 10
           }
         ]
@@ -81,7 +81,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node '${CLAUDE_PLUGIN_ROOT}/hooks_src/restore-compact.js'",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/restore-compact.js",
             "timeout": 5
           }
         ]
@@ -90,7 +90,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node '${CLAUDE_PLUGIN_ROOT}/hooks_src/intake-scanner.js'",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/intake-scanner.js",
             "timeout": 5
           }
         ]

--- a/scripts/install-hooks.js
+++ b/scripts/install-hooks.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+
+/**
+ * install-hooks.js — Resolves Citadel hook paths into a project's .claude/settings.json
+ *
+ * Why this exists:
+ *   ${CLAUDE_PLUGIN_ROOT} in hooks.json doesn't expand in hook commands
+ *   (anthropics/claude-code#24529). This script resolves the variable to an
+ *   absolute path and writes working hooks into the project's settings.json.
+ *
+ * Usage:
+ *   node /path/to/Citadel/scripts/install-hooks.js          # from project dir
+ *   node /path/to/Citadel/scripts/install-hooks.js /project  # explicit project path
+ *
+ * What it does:
+ *   1. Reads hooks/hooks.json from the Citadel plugin
+ *   2. Replaces ${CLAUDE_PLUGIN_ROOT} with the actual absolute path
+ *   3. Merges the resolved hooks into .claude/settings.json in the target project
+ *   4. Preserves any existing non-hook settings (permissions, env, mcpServers, etc.)
+ *
+ * Idempotent — safe to re-run after Citadel updates. Overwrites Citadel hooks
+ * but preserves user-added hooks (identified by commands that don't reference
+ * the Citadel hooks_src directory).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const CITADEL_ROOT = path.resolve(__dirname, '..');
+const HOOKS_JSON = path.join(CITADEL_ROOT, 'hooks', 'hooks.json');
+const PROJECT_ROOT = process.argv[2] || process.env.CLAUDE_PROJECT_DIR || process.cwd();
+const SETTINGS_PATH = path.join(PROJECT_ROOT, '.claude', 'settings.json');
+
+function resolveHooks() {
+  const raw = fs.readFileSync(HOOKS_JSON, 'utf8');
+  // Replace the variable with the actual path (forward slashes for cross-platform node)
+  const citadelPath = CITADEL_ROOT.replace(/\\/g, '/');
+  const resolved = raw.replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, citadelPath);
+  // Also strip single quotes that wrapped the variable (leftover from plugin convention)
+  const cleaned = resolved.replace(/node\s+'([^']+)'/g, 'node "$1"');
+  return JSON.parse(cleaned);
+}
+
+function readExistingSettings() {
+  try {
+    return JSON.parse(fs.readFileSync(SETTINGS_PATH, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function isCitadelHook(hookEntry) {
+  if (!hookEntry.hooks) return false;
+  return hookEntry.hooks.some(h =>
+    h.command && h.command.includes('hooks_src/')
+  );
+}
+
+function mergeHooks(existing, citadel) {
+  const merged = { ...existing };
+  merged.hooks = merged.hooks || {};
+
+  for (const [event, citadelEntries] of Object.entries(citadel.hooks)) {
+    const existingEntries = merged.hooks[event] || [];
+
+    // Keep user hooks that don't reference Citadel's hooks_src
+    const userHooks = existingEntries.filter(entry => !isCitadelHook(entry));
+
+    // Citadel hooks first, then user hooks
+    merged.hooks[event] = [...citadelEntries, ...userHooks];
+  }
+
+  return merged;
+}
+
+function main() {
+  // Validate
+  if (!fs.existsSync(HOOKS_JSON)) {
+    console.error(`Error: hooks.json not found at ${HOOKS_JSON}`);
+    console.error('Is this script inside a Citadel installation?');
+    process.exit(1);
+  }
+
+  // Ensure .claude/ exists in the project
+  const claudeDir = path.join(PROJECT_ROOT, '.claude');
+  if (!fs.existsSync(claudeDir)) {
+    fs.mkdirSync(claudeDir, { recursive: true });
+  }
+
+  // Resolve hooks
+  const citadelHooks = resolveHooks();
+  const existing = readExistingSettings();
+  const merged = mergeHooks(existing, citadelHooks);
+
+  // Write
+  fs.writeFileSync(SETTINGS_PATH, JSON.stringify(merged, null, 2) + '\n');
+
+  // Count what we installed
+  let hookCount = 0;
+  for (const entries of Object.values(citadelHooks.hooks)) {
+    hookCount += entries.length;
+  }
+
+  const preservedCount = Object.values(merged.hooks).reduce(
+    (sum, entries) => sum + entries.filter(e => !isCitadelHook(e)).length, 0
+  );
+
+  console.log(`Citadel hooks installed to ${SETTINGS_PATH}`);
+  console.log(`  ${hookCount} Citadel hooks resolved (${CITADEL_ROOT})`);
+  if (preservedCount > 0) {
+    console.log(`  ${preservedCount} existing user hooks preserved`);
+  }
+  console.log('Hooks are ready. No restart needed.');
+}
+
+main();

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -184,10 +184,30 @@ If CLAUDE.md ALREADY exists:
    reference lines. NEVER overwrite or delete existing content.
 4. If already present: skip, don't duplicate
 
-**Hooks:** Citadel's hooks are managed by the plugin and fire automatically.
-No per-project hook configuration is needed. The plugin's `hooks/hooks.json`
-defines all lifecycle hooks (protect-files, post-edit typecheck, circuit breaker,
-quality gate, intake scanner, init-project, pre-compact, restore-compact).
+**Hooks — Install to Project:**
+
+Citadel's plugin hooks require path resolution into the project's `.claude/settings.json`.
+This is necessary because `${CLAUDE_PLUGIN_ROOT}` variable expansion in hook commands
+has a known upstream bug (anthropics/claude-code#24529).
+
+Run the hook installer to resolve paths:
+```bash
+node {citadel-root}/scripts/install-hooks.js
+```
+
+Where `{citadel-root}` is the absolute path to the Citadel plugin directory. To find it:
+1. Check `.citadel/plugin-root.txt` in the project (written by init-project if it ran)
+2. Or ask the user where they cloned Citadel
+
+The installer:
+- Reads `hooks/hooks.json` from Citadel
+- Replaces `${CLAUDE_PLUGIN_ROOT}` with the resolved absolute path
+- Writes working hooks into this project's `.claude/settings.json`
+- Preserves any existing non-Citadel settings (permissions, env, mcpServers)
+- Is idempotent — safe to re-run after Citadel updates
+
+After running, verify hooks are active by checking `.claude/settings.json` exists
+and contains hook definitions with absolute paths to Citadel's `hooks_src/` directory.
 
 ### Step 3: DEMONSTRATE (run one real task)
 


### PR DESCRIPTION
## Summary
- Add `scripts/install-hooks.js` that resolves `${CLAUDE_PLUGIN_ROOT}` to absolute paths and writes working hooks into a project's `.claude/settings.json`
- Remove single quotes from `hooks/hooks.json` commands (blocked substitution even when the upstream bug is fixed)
- Update `/do setup` skill to run the hook installer automatically
- Update README and QUICKSTART with the new install step

## Context
`${CLAUDE_PLUGIN_ROOT}` doesn't expand in hook commands due to [anthropics/claude-code#24529](https://github.com/anthropics/claude-code/issues/24529). This breaks every hook for every user. The installer script works around it by resolving paths at install time.

The workaround is temporary. When the upstream bug is fixed, `hooks.json` will work natively through the plugin system and the installer step becomes unnecessary.

## Test results
- `install-hooks.js` tested: generates correct absolute paths, merges with existing settings, preserves user hooks
- Smoke test: 37/37 passed after removing quotes from hooks.json

Fixes #19.