### PR TITLE
fix: escape backslashes in hook scripts causing syntax errors

### DIFF
--- a/hooks_src/external-action-gate.js
+++ b/hooks_src/external-action-gate.js
@@ -65,9 +65,9 @@ function stripQuotedContent(cmd) {
   // Strip $(...) subshells (often contain heredocs for commit messages)
   stripped = stripped.replace(/"\$\([\s\S]*?\)"/g, '""');
   // Strip remaining double-quoted strings
-  stripped = stripped.replace(/"(?:[^"\]|\.)*"/g, '""');
+  stripped = stripped.replace(/"(?:[^"\\]|\\.)*"/g, '""');
   // Strip single-quoted strings
-  stripped = stripped.replace(/'(?:[^'\]|\.)*'/g, "''");
+  stripped = stripped.replace(/'(?:[^'\\]|\\.)*'/g, "''");
   return stripped;
 }
 

--- a/hooks_src/issue-monitor.js
+++ b/hooks_src/issue-monitor.js
@@ -19,7 +19,7 @@ const STATE_FILE = path.join(CITADEL_DIR, 'issue-monitor-state.json');
 function getGhPath() {
   const windowsPath = '/c/Program Files/GitHub CLI/gh.exe';
   try {
-    if (fs.existsSync(windowsPath) || fs.existsSync(windowsPath.replace(/\//g, '\'))) {
+    if (fs.existsSync(windowsPath) || fs.existsSync(windowsPath.replace(/\//g, '\\'))) {
       return `"${windowsPath}"`;
     }
   } catch {}


### PR DESCRIPTION
## Summary
- Fix `issue-monitor.js` line 22: `'\'` → `'\'` (unterminated string literal)
- Fix `external-action-gate.js` lines 68-70: `[^"\]` → `[^"\]` (unclosed character class)
- Both scripts were syntactically invalid JS — crashed on parse before executing
- Caused `SessionStart:startup hook error` in **every repo** using the plugin, not just Citadel

## Test plan
- [x] `node -c hooks_src/issue-monitor.js` passes
- [x] `node -c hooks_src/external-action-gate.js` passes
- [ ] Start a new Claude Code session in any repo with the plugin — no startup hook error

🤖 Generated with [Claude Code](https://claude.com/claude-code)