### PR TITLE
fix: quote node script paths with spaces in install-hooks.js

### DIFF
--- a/scripts/install-hooks.js
+++ b/scripts/install-hooks.js
@@ -38,7 +38,24 @@ function resolveHooks() {
   const resolved = raw.replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, citadelPath);
   // Also strip single quotes that wrapped the variable (leftover from plugin convention)
   const cleaned = resolved.replace(/node\s+'([^']+)'/g, 'node "$1"');
-  return JSON.parse(cleaned);
+  const hooks = JSON.parse(cleaned);
+
+  // Quote script paths that contain spaces (Windows installs with spaces in directory names)
+  for (const entries of Object.values(hooks.hooks)) {
+    for (const entry of entries) {
+      if (!entry.hooks) continue;
+      for (const hook of entry.hooks) {
+        if (hook.command) {
+          hook.command = hook.command.replace(/^node\s+(.+)$/, (_, script) => {
+            if (script.includes(' ') && !script.startsWith('"')) return `node "${script}"`;
+            return `node ${script}`;
+          });
+        }
+      }
+    }
+  }
+
+  return hooks;
 }
 
 function readExistingSettings() {


### PR DESCRIPTION
Windows users with spaces in their Citadel install path (e.g. "Programming Applications/Citadel") got silently broken hooks because the shell splits on the space. Now quotes any node <script> command where the resolved path contains spaces.