### PR TITLE
fix(telemetry): prompt /do setup when harness.json is missing

### DIFF
--- a/skills/telemetry/SKILL.md
+++ b/skills/telemetry/SKILL.md
@@ -118,6 +118,9 @@ TELEMETRY SETTINGS
   Cost alerts:      {on | off}  at thresholds: {list or "default ($5,$15,$30...)"}
   Hook timing:      {on | off}
   Audit log:        {on | off}
+  — or, when harness.json is absent —
+  (harness.json not found — defaults active)
+  → Run /do setup to unlock cost tracking, configure thresholds, and register your install.
 
 COMMAND DIRECTORY
   /telemetry                            This screen
@@ -207,7 +210,9 @@ Never blend real and estimated in the same total without flagging it.
 
 - **`.planning/telemetry/` missing:** Show empty state. Note: "Run `/do setup` to initialize telemetry."
 - **`session-tokens.js` unavailable:** Fall back to session-costs.jsonl, mark as `(est)`.
-- **harness.json missing:** Show settings as "not configured (defaults active)".
+- **harness.json missing:** In the TELEMETRY SETTINGS section, replace the values with
+  "(harness.json not found — defaults active)" and add on the next line:
+  "→ Run /do setup to unlock cost tracking, configure thresholds, and register your install."
 - **`telemetry.enabled: false` in harness.json:** Show a banner: "Telemetry is disabled. Run `/telemetry on` to re-enable."
 
 ## Exit Protocol


### PR DESCRIPTION
## Context

Kyle ran `/telemetry` for the first time and got useful output — but the TELEMETRY SETTINGS section just said "not configured (defaults active)" with no clear next step.

He had hooks firing correctly but no `harness.json`, which means no cost tracking, no registered thresholds, no session summaries. The fix is to run `/do setup`, but that wasn't surfaced.

## Change

When `harness.json` is absent, the TELEMETRY SETTINGS section now shows:

```
TELEMETRY SETTINGS
  (harness.json not found — defaults active)
  → Run /do setup to unlock cost tracking, configure thresholds, and register your install.
```

That's it. One actionable line instead of a silent dead end.

The fringe case documentation in the skill is also updated to be explicit about what to render in this state.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)