### PR TITLE
fix: ignore .citadel runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,7 @@
 .claude/settings.local.json
 
 # Per-project scaffolded state (created by init-project hook)
-.citadel/
-!.citadel/
+.citadel/*
 !.citadel/project.md
 !.citadel/project.template.md
 


### PR DESCRIPTION
## Summary

- Fixes broken `.gitignore` pattern that caused 56 scaffolded runtime files to appear as untracked
- `.citadel/` + `!.citadel/` negated the ignore entirely — git can't recurse into an ignored directory so negation exceptions never fired
- Correct pattern: `.citadel/*` ignores contents while letting git see into the directory, then the negation exceptions for `project.md` and `project.template.md` work as intended

## Test plan

- [ ] Confirm `git status` shows no untracked `.citadel/` files after install
- [ ] Confirm `.citadel/project.md` and `.citadel/project.template.md` are still tracked