### PR TITLE
feat: local quota-free runners for watch, daemon, and schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@
 
 </div>
 
+> **Heads-up on Anthropic's routine quota:** Claude Code accounts are limited to
+> **15 routine runs per rolling 24 hours** (`CronCreate` / `ScheduleWakeup` /
+> `RemoteTrigger`). A single `/watch` or `/daemon` can exhaust it quickly and
+> pause unrelated routines on your account. Citadel ships local, quota-free
+> runners for each of those features — see
+> [docs/ROUTINE-QUOTA.md](docs/ROUTINE-QUOTA.md).
+
 ## What Is Citadel
 
 An agent orchestration harness for Claude Code and OpenAI Codex. It coordinates multiple AI agents in parallel, persists memory across sessions, and routes your intent to the cheapest execution path automatically. Citadel adapts itself to each runtime: plugin-first for Claude Code, generated project artifacts plus Codex-native config for Codex.

--- a/docs/ROUTINE-QUOTA.md
+++ b/docs/ROUTINE-QUOTA.md
@@ -1,0 +1,75 @@
+# Anthropic Routine Quota and Local Alternatives
+
+Anthropic's Claude Code accounts include **15 routine runs per rolling 24-hour
+window** (Claude.ai → Settings → Usage → *Daily included routine runs*). Any
+scheduled, self-waking, or remotely-triggered execution counts against this
+cap. When the cap is hit, **all routines across your account pause** — including
+unrelated ones — unless Extra Usage is enabled.
+
+The mechanisms that consume routine runs:
+
+- `CronCreate` / `CronDelete` / `CronList`
+- `ScheduleWakeup` (including `/loop` without a fixed interval)
+- `RemoteTrigger`
+
+A single long-running watcher at a 5-minute interval exhausts the quota in
+under an hour. The daemon can burn through it in a single overnight run.
+
+## How Citadel handles this
+
+Every skill in this harness that historically used a routine mechanism now
+ships with a **local, quota-free runner** as the default path. The routine
+version is still supported for users who need cloud-persistent execution
+(machine off, away from desk), but it is no longer the recommended default.
+
+| Skill | Routine version | Local runner (default) |
+|---|---|---|
+| `/watch` | `CronCreate` poll | `node scripts/local-watch.js` — filesystem events, real-time, zero quota |
+| `/daemon` | `RemoteTrigger` chain | `node scripts/local-daemon.js` — spawns `claude -p "/do continue"` subprocess loop |
+| `/schedule` | `CronCreate` | `node scripts/local-schedule.js` — emits OS cron / Task Scheduler entries |
+| `/loop` (dynamic) | `ScheduleWakeup` | Run foreground during the active session; otherwise use `local-daemon.js` |
+| `/pr-watch` | (already local) | No change — reference implementation |
+
+Local runners work anywhere Node.js works (Windows, macOS, Linux). They
+invoke `claude` as a subprocess, which does **not** count as a routine — only
+the scheduling mechanisms listed above do.
+
+## Trade-offs
+
+| Concern | Routine system | Local runner |
+|---|---|---|
+| Works when machine is off | ✅ | ❌ |
+| Works when machine is asleep | ✅ | ❌ (wakes on resume) |
+| Counts against 15/day cap | ✅ | ❌ |
+| Works across network drops | ✅ | ✅ (local) |
+| Survives session end | ✅ | ✅ (separate process) |
+| Real-time file events | ❌ (polls) | ✅ |
+| Setup complexity | Low | Low (single `npm run` command) |
+
+**Rule of thumb:** if the user's machine is on when the work needs to happen,
+use the local runner. Reserve routine spend for scheduled work that truly
+needs cloud persistence.
+
+## Using Extra Usage instead
+
+If you prefer to keep using the routine path, enable **Settings → Usage →
+Extra Usage** on your Anthropic account. Additional routine runs beyond the
+15/day baseline are billed at the standard Extra Usage rate. Your daemon and
+watchers will keep running past the cap.
+
+## Quick commands
+
+```bash
+# Real-time file watcher (replaces /watch start)
+npm run watch:local
+
+# Continuous campaign daemon (replaces /daemon start)
+npm run daemon:local
+
+# Install a scheduled task via OS cron / Task Scheduler (replaces /schedule add)
+node scripts/local-schedule.js add "every 30m" "/pr-watch"
+node scripts/local-schedule.js list
+node scripts/local-schedule.js remove {id}
+```
+
+See each script's `--help` flag for full options.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "telemetry:report": "node scripts/telemetry-report.cjs",
     "telemetry:log": "node scripts/telemetry-log.cjs",
     "compress:discovery": "node scripts/compress-discovery.cjs",
-    "test:hooks": "node hooks_src/smoke-test.js"
+    "test:hooks": "node hooks_src/smoke-test.js",
+    "watch:local": "node scripts/local-watch.js",
+    "daemon:local": "node scripts/local-daemon.js",
+    "schedule:local": "node scripts/local-schedule.js"
   },
   "keywords": [
     "claude",

--- a/scripts/local-daemon.js
+++ b/scripts/local-daemon.js
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+
+/**
+ * local-daemon.js -- Quota-free replacement for /daemon start.
+ *
+ * Cross-platform Node port of scripts/daemon-tick.ps1. Spawns a fresh
+ * `claude -p "/do continue"` subprocess, waits for it to finish, applies a
+ * cooldown, and repeats until daemon.json reports the daemon is no longer
+ * running (campaign completed, budget exhausted, level-up pending, etc).
+ *
+ * The SessionStart hook (init-project.js) reads .planning/daemon.json on
+ * every session start and instructs Archon to continue, so this loop just
+ * needs to spawn blank sessions at the right cadence. It does NOT use
+ * RemoteTrigger, so it consumes zero Anthropic routine quota.
+ *
+ * Usage:
+ *   node scripts/local-daemon.js                   # Default 60s cooldown
+ *   node scripts/local-daemon.js --cooldown 30     # 30s between sessions
+ *   node scripts/local-daemon.js --max-sessions 10 # Safety cap
+ *   node scripts/local-daemon.js --dry-run         # Print what it would do
+ *
+ * Start with `/daemon start` first (or manually populate daemon.json) to
+ * establish the campaign and budget. This runner only drives the tick loop.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const ROOT = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+const DAEMON_PATH = path.join(ROOT, '.planning', 'daemon.json');
+const LOG_PATH = path.join(ROOT, '.planning', 'daemon-runs.log');
+
+const args = process.argv.slice(2);
+const opts = {
+    cooldown: parseInt(getFlag('--cooldown', '60'), 10) * 1000,
+    maxSessions: parseInt(getFlag('--max-sessions', '0'), 10),
+    dryRun: args.includes('--dry-run'),
+    help: args.includes('--help') || args.includes('-h'),
+};
+
+function getFlag(name, fallback) {
+    const i = args.indexOf(name);
+    if (i === -1) return fallback;
+    return args[i + 1] ?? fallback;
+}
+
+if (opts.help) {
+    console.log(fs.readFileSync(__filename, 'utf8').split('\n').slice(2, 22).join('\n').replace(/^ \*\/?/gm, ''));
+    process.exit(0);
+}
+
+function log(msg) {
+    const line = `[${new Date().toISOString()}] ${msg}`;
+    console.log(line);
+    try { fs.appendFileSync(LOG_PATH, line + '\n'); } catch { /* ignore */ }
+}
+
+function readDaemon() {
+    if (!fs.existsSync(DAEMON_PATH)) return null;
+    try { return JSON.parse(fs.readFileSync(DAEMON_PATH, 'utf8')); }
+    catch (e) { log(`daemon.json parse error: ${e.message}`); return null; }
+}
+
+function runSession() {
+    return new Promise((resolve) => {
+        const cmd = 'claude';
+        const cliArgs = ['--dangerously-skip-permissions', '-p', '/do continue'];
+        if (opts.dryRun) {
+            log(`DRY RUN would spawn: ${cmd} ${cliArgs.join(' ')}`);
+            return resolve(0);
+        }
+        const proc = spawn(cmd, cliArgs, {
+            cwd: ROOT,
+            stdio: 'inherit',
+            env: { ...process.env, CLAUDE_NON_INTERACTIVE: '1' },
+            shell: process.platform === 'win32',
+        });
+        proc.on('close', (code) => resolve(code ?? 0));
+        proc.on('error', (err) => { log(`spawn error: ${err.message}`); resolve(1); });
+    });
+}
+
+async function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+
+async function main() {
+    log(`local-daemon starting. root=${ROOT} cooldown=${opts.cooldown}ms`);
+    let sessions = 0;
+    while (true) {
+        const state = readDaemon();
+        if (!state) { log('No daemon.json found. Exiting.'); break; }
+        if (state.status !== 'running') {
+            log(`Daemon status is "${state.status}". Reason: ${state.stopReason ?? 'n/a'}. Exiting.`);
+            break;
+        }
+        if (opts.maxSessions > 0 && sessions >= opts.maxSessions) {
+            log(`Reached --max-sessions (${opts.maxSessions}). Exiting.`);
+            break;
+        }
+        sessions += 1;
+        log(`Starting session #${sessions} (daemon session count: ${state.sessionCount ?? 0})`);
+        const code = await runSession();
+        log(`Session #${sessions} exited with code ${code}`);
+        log(`Cooldown ${opts.cooldown / 1000}s...`);
+        await sleep(opts.cooldown);
+    }
+    log(`local-daemon stopped after ${sessions} session(s).`);
+}
+
+main().catch((err) => { log(`fatal: ${err.stack ?? err.message}`); process.exit(1); });
+
+process.on('SIGINT', () => { log('received SIGINT, stopping after current session'); process.exit(0); });

--- a/scripts/local-schedule.js
+++ b/scripts/local-schedule.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+
+/**
+ * local-schedule.js -- Quota-free replacement for /schedule add.
+ *
+ * Installs scheduled tasks using the host OS's native scheduler (Windows
+ * Task Scheduler or Unix cron) rather than Anthropic's CronCreate. Does not
+ * consume routine quota. Survives session end, machine sleep (wakes the
+ * system if configured), and reboots.
+ *
+ * Each scheduled task runs:
+ *   claude --plugin-dir <project-root> --dangerously-skip-permissions -p "<command>"
+ *
+ * Usage:
+ *   node scripts/local-schedule.js add "<cron-or-human>" "<claude-command>"
+ *   node scripts/local-schedule.js add "every 30m" "/pr-watch"
+ *   node scripts/local-schedule.js add "0 9 * * *" "/do continue"
+ *   node scripts/local-schedule.js list
+ *   node scripts/local-schedule.js remove <id>
+ *
+ * IDs are prefixed `citadel-` on both platforms so they're easy to find.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const crypto = require('crypto');
+const { execFileSync, spawnSync } = require('child_process');
+
+const ROOT = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+const IS_WIN = process.platform === 'win32';
+
+const [cmd, ...rest] = process.argv.slice(2);
+
+if (!cmd || cmd === '--help' || cmd === '-h') {
+    console.log(fs.readFileSync(__filename, 'utf8').split('\n').slice(2, 22).join('\n').replace(/^ \*\/?/gm, ''));
+    process.exit(cmd ? 0 : 1);
+}
+
+function toCron(expr) {
+    const t = expr.trim().toLowerCase();
+    const map = {
+        'every minute': '* * * * *',
+        'every 5m': '*/5 * * * *', 'every 5 minutes': '*/5 * * * *',
+        'every 15m': '*/15 * * * *', 'every 15 minutes': '*/15 * * * *',
+        'every 30m': '*/30 * * * *', 'every 30 minutes': '*/30 * * * *',
+        'hourly': '0 * * * *', 'every hour': '0 * * * *',
+        'every 2h': '0 */2 * * *', 'every 2 hours': '0 */2 * * *',
+        'every 6h': '0 */6 * * *', 'every 6 hours': '0 */6 * * *',
+        'daily': '0 9 * * *', 'every day': '0 9 * * *',
+        'every weekday': '0 9 * * 1-5',
+    };
+    if (map[t]) return map[t];
+    if (/^\S+\s+\S+\s+\S+\s+\S+\s+\S+$/.test(expr.trim())) return expr.trim();
+    throw new Error(`Could not parse schedule "${expr}". Use a 5-field cron expression or a phrase like "every 30m".`);
+}
+
+function newId() {
+    return `citadel-${crypto.randomBytes(4).toString('hex')}`;
+}
+
+function claudeInvocation(claudeCommand) {
+    const plugin = ROOT.replace(/"/g, '\\"');
+    return `claude --plugin-dir "${plugin}" --dangerously-skip-permissions -p "${claudeCommand.replace(/"/g, '\\"')}"`;
+}
+
+// --- Windows: schtasks -------------------------------------------------------
+
+function winAdd(cronExpr, claudeCommand) {
+    const parts = cronExpr.split(/\s+/);
+    const [minute, hour] = parts;
+    const id = newId();
+    const invocation = claudeInvocation(claudeCommand);
+    // schtasks supports basic minute/hourly/daily triggers. For arbitrary cron,
+    // we map common cases. Complex expressions are approximated to MINUTE.
+    let schtasksArgs;
+    if (parts.join(' ') === '* * * * *') {
+        schtasksArgs = ['/Create', '/SC', 'MINUTE', '/MO', '1', '/TN', id, '/TR', `cmd /c cd /d "${ROOT}" && ${invocation}`, '/F'];
+    } else if (/^\*\/\d+$/.test(minute) && hour === '*') {
+        const mo = minute.slice(2);
+        schtasksArgs = ['/Create', '/SC', 'MINUTE', '/MO', mo, '/TN', id, '/TR', `cmd /c cd /d "${ROOT}" && ${invocation}`, '/F'];
+    } else if (minute === '0' && /^\*\/\d+$/.test(hour)) {
+        schtasksArgs = ['/Create', '/SC', 'HOURLY', '/MO', hour.slice(2), '/TN', id, '/TR', `cmd /c cd /d "${ROOT}" && ${invocation}`, '/F'];
+    } else if (minute === '0' && /^\d+$/.test(hour)) {
+        schtasksArgs = ['/Create', '/SC', 'DAILY', '/ST', `${hour.padStart(2, '0')}:00`, '/TN', id, '/TR', `cmd /c cd /d "${ROOT}" && ${invocation}`, '/F'];
+    } else {
+        throw new Error(`Windows Task Scheduler mapping not supported for "${cronExpr}". Use: every {N}m, every {N}h, or daily at {H}.`);
+    }
+    execFileSync('schtasks', schtasksArgs, { stdio: 'inherit' });
+    console.log(`Scheduled. ID: ${id}`);
+    console.log(`Remove with: node scripts/local-schedule.js remove ${id}`);
+}
+
+function winList() {
+    const out = spawnSync('schtasks', ['/Query', '/FO', 'CSV', '/NH'], { encoding: 'utf8' });
+    const lines = (out.stdout || '').split('\n').filter((l) => l.includes('citadel-'));
+    if (!lines.length) { console.log('No Citadel schedules found.'); return; }
+    for (const line of lines) console.log(line.trim());
+}
+
+function winRemove(id) {
+    execFileSync('schtasks', ['/Delete', '/TN', id, '/F'], { stdio: 'inherit' });
+    console.log(`Removed ${id}`);
+}
+
+// --- Unix: crontab -----------------------------------------------------------
+
+const CRON_MARKER_START = '# CITADEL-SCHEDULES-START';
+const CRON_MARKER_END = '# CITADEL-SCHEDULES-END';
+
+function readCrontab() {
+    const r = spawnSync('crontab', ['-l'], { encoding: 'utf8' });
+    return r.status === 0 ? r.stdout : '';
+}
+
+function writeCrontab(content) {
+    const r = spawnSync('crontab', ['-'], { input: content, encoding: 'utf8' });
+    if (r.status !== 0) throw new Error(`crontab install failed: ${r.stderr}`);
+}
+
+function unixAdd(cronExpr, claudeCommand) {
+    const id = newId();
+    const current = readCrontab();
+    const line = `${cronExpr} cd "${ROOT}" && ${claudeInvocation(claudeCommand)} # ${id}`;
+    let updated;
+    if (current.includes(CRON_MARKER_START)) {
+        updated = current.replace(CRON_MARKER_END, `${line}\n${CRON_MARKER_END}`);
+    } else {
+        updated = current + (current.endsWith('\n') || !current ? '' : '\n') +
+            `${CRON_MARKER_START}\n${line}\n${CRON_MARKER_END}\n`;
+    }
+    writeCrontab(updated);
+    console.log(`Scheduled. ID: ${id}`);
+    console.log(`Remove with: node scripts/local-schedule.js remove ${id}`);
+}
+
+function unixList() {
+    const current = readCrontab();
+    const lines = current.split('\n').filter((l) => l.includes('# citadel-'));
+    if (!lines.length) { console.log('No Citadel schedules found.'); return; }
+    for (const line of lines) console.log(line);
+}
+
+function unixRemove(id) {
+    const current = readCrontab();
+    const updated = current.split('\n').filter((l) => !l.includes(`# ${id}`)).join('\n');
+    writeCrontab(updated);
+    console.log(`Removed ${id}`);
+}
+
+// --- Dispatch ----------------------------------------------------------------
+
+try {
+    if (cmd === 'add') {
+        const [expr, claudeCommand] = rest;
+        if (!expr || !claudeCommand) { console.error('Usage: add "<cron>" "<claude command>"'); process.exit(1); }
+        const cron = toCron(expr);
+        console.log(`Installing: ${cron} -> ${claudeCommand}`);
+        IS_WIN ? winAdd(cron, claudeCommand) : unixAdd(cron, claudeCommand);
+    } else if (cmd === 'list') {
+        IS_WIN ? winList() : unixList();
+    } else if (cmd === 'remove') {
+        const id = rest[0];
+        if (!id) { console.error('Usage: remove <id>'); process.exit(1); }
+        IS_WIN ? winRemove(id) : unixRemove(id);
+    } else {
+        console.error(`Unknown command: ${cmd}. Use add|list|remove.`);
+        process.exit(1);
+    }
+} catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+}

--- a/scripts/local-watch.js
+++ b/scripts/local-watch.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+
+/**
+ * local-watch.js -- Quota-free replacement for /watch start.
+ *
+ * Real-time filesystem watcher that triggers scripts/watch.js --scan on
+ * debounced change events. Uses built-in fs.watch (no external deps) in
+ * recursive mode. Works on Windows and macOS natively; on Linux, falls back
+ * to a polling loop at the configured interval.
+ *
+ * Unlike CronCreate, this does not consume Anthropic routine quota.
+ *
+ * Usage:
+ *   node scripts/local-watch.js              # Watch with default 2s debounce
+ *   node scripts/local-watch.js --debounce 5 # 5s debounce between scans
+ *   node scripts/local-watch.js --poll 30    # Force polling mode, 30s interval
+ *   node scripts/local-watch.js --intake     # Generate intake items on scan
+ *   node scripts/local-watch.js --once       # Run one scan and exit
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const ROOT = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+const SCAN_SCRIPT = path.join(__dirname, 'watch.js');
+
+const args = process.argv.slice(2);
+const opts = {
+    debounce: parseInt(getFlag('--debounce', '2'), 10) * 1000,
+    poll: parseInt(getFlag('--poll', '0'), 10) * 1000,
+    intake: args.includes('--intake'),
+    once: args.includes('--once'),
+    help: args.includes('--help') || args.includes('-h'),
+};
+
+function getFlag(name, fallback) {
+    const i = args.indexOf(name);
+    if (i === -1) return fallback;
+    return args[i + 1] ?? fallback;
+}
+
+if (opts.help) {
+    console.log(fs.readFileSync(__filename, 'utf8').split('\n').slice(2, 20).join('\n').replace(/^ \*\/?/gm, ''));
+    process.exit(0);
+}
+
+const IGNORED = /(^|[\\/])(\.git|node_modules|\.planning|dist|build|\.next|coverage)([\\/]|$)/;
+
+function runScan() {
+    const scanArgs = ['--scan'];
+    if (opts.intake) scanArgs.push('--intake');
+    const proc = spawn(process.execPath, [SCAN_SCRIPT, ...scanArgs], {
+        cwd: ROOT,
+        stdio: 'inherit',
+        env: { ...process.env, CLAUDE_PROJECT_DIR: ROOT },
+    });
+    return new Promise((resolve) => proc.on('close', resolve));
+}
+
+if (opts.once) {
+    runScan().then((code) => process.exit(code ?? 0));
+    return;
+}
+
+let pending = null;
+let scanning = false;
+
+function schedule() {
+    if (pending) return;
+    pending = setTimeout(async () => {
+        pending = null;
+        if (scanning) { schedule(); return; }
+        scanning = true;
+        try { await runScan(); } finally { scanning = false; }
+    }, opts.debounce);
+}
+
+console.log(`[local-watch] root: ${ROOT}`);
+console.log(`[local-watch] debounce: ${opts.debounce}ms  intake: ${opts.intake}`);
+
+// fs.watch recursive works on Windows and macOS. On Linux, recursive is not
+// supported -- fall back to polling.
+const supportsRecursive = process.platform === 'win32' || process.platform === 'darwin';
+
+if (supportsRecursive && opts.poll === 0) {
+    console.log('[local-watch] mode: filesystem events (recursive)');
+    try {
+        fs.watch(ROOT, { recursive: true }, (_event, filename) => {
+            if (!filename) return;
+            if (IGNORED.test(filename)) return;
+            schedule();
+        });
+    } catch (err) {
+        console.error(`[local-watch] fs.watch failed: ${err.message}. Falling back to polling.`);
+        startPolling(30000);
+    }
+} else {
+    const interval = opts.poll || 30000;
+    console.log(`[local-watch] mode: polling every ${interval / 1000}s`);
+    startPolling(interval);
+}
+
+function startPolling(ms) {
+    setInterval(async () => {
+        if (scanning) return;
+        scanning = true;
+        try { await runScan(); } finally { scanning = false; }
+    }, ms);
+}
+
+// Run an initial scan so the user sees immediate output
+schedule();
+
+process.on('SIGINT', () => { console.log('\n[local-watch] stopped'); process.exit(0); });

--- a/skills/daemon/SKILL.md
+++ b/skills/daemon/SKILL.md
@@ -14,6 +14,31 @@ last-updated: 2026-03-28
 
 # /daemon -- Continuous Autonomous Operation
 
+## ⚠️ Prefer the local runner
+
+`/daemon start` uses `RemoteTrigger`, which counts against Anthropic's **15
+routine runs / 24h** cap. A single overnight run can exhaust the quota and
+pause every other routine on the account.
+
+**Default to the local runner instead:**
+
+```bash
+node scripts/local-daemon.js           # cross-platform tick loop, zero quota
+npm run daemon:local                   # same, via npm
+```
+
+The runner spawns `claude -p "/do continue"` subprocesses in a loop. The
+`SessionStart` hook (`init-project.js`) handles continuation automatically on
+every session start, so this replicates the full daemon behavior without any
+`RemoteTrigger` calls. Run it in a terminal you leave open, or wrap it in
+PM2 / Task Scheduler / systemd for true background operation.
+
+Still call `/daemon start` first to populate `.planning/daemon.json` with the
+campaign, budget, and cooldown — the local runner reads that state file.
+Only use the `RemoteTrigger` path below if the user genuinely needs the
+campaign to keep running while the machine is off and has Extra Usage
+enabled. See [docs/ROUTINE-QUOTA.md](../../docs/ROUTINE-QUOTA.md).
+
 ## Identity
 
 You are the daemon controller. You turn campaign execution from "human starts

--- a/skills/schedule/SKILL.md
+++ b/skills/schedule/SKILL.md
@@ -11,6 +11,28 @@ last-updated: 2026-03-26
 
 # /schedule — Task Scheduling
 
+## ⚠️ Prefer the local runner
+
+`/schedule add` uses `CronCreate`, which counts against Anthropic's **15
+routine runs / 24h** cap. Every fire of a scheduled task counts.
+
+**Default to the local runner instead:**
+
+```bash
+node scripts/local-schedule.js add "every 30m" "/pr-watch"
+node scripts/local-schedule.js list
+node scripts/local-schedule.js remove <id>
+```
+
+It installs native OS entries — Windows Task Scheduler or Unix cron —
+consuming zero Anthropic quota, surviving session end and reboot. Each fire
+spawns `claude -p "<command>"` against this project as a subprocess, which
+does not count as a routine.
+
+Only use `/schedule add` below when the user explicitly wants session-scoped
+scheduling (cleared on session end) and has Extra Usage enabled. See
+[docs/ROUTINE-QUOTA.md](../../docs/ROUTINE-QUOTA.md).
+
 ## Identity
 
 You are the schedule manager. You create, list, and remove recurring tasks

--- a/skills/watch/SKILL.md
+++ b/skills/watch/SKILL.md
@@ -13,6 +13,24 @@ last-updated: 2026-03-29
 
 # /watch -- File Sentinel
 
+## ⚠️ Prefer the local runner
+
+`/watch start` uses `CronCreate`, which counts against Anthropic's **15 routine
+runs / 24h** cap. At the default 5-minute interval a watch exhausts the quota
+in under an hour and pauses every other routine on the account.
+
+**Default to the local runner instead:**
+
+```bash
+node scripts/local-watch.js            # real-time fs events, zero quota
+npm run watch:local                    # same, via npm
+```
+
+It uses the same `scripts/watch.js --scan` engine, triggers on filesystem
+events (not polls), and consumes no routine quota. Only use `/watch start`
+below if the user needs cloud-persistent polling with Extra Usage enabled.
+See [docs/ROUTINE-QUOTA.md](../../docs/ROUTINE-QUOTA.md).
+
 ## Identity
 
 You are the file sentinel. You detect what changed since the last scan,


### PR DESCRIPTION
## Summary
- Anthropic caps Claude Code accounts at **15 routine runs / 24h** (`CronCreate`, `ScheduleWakeup`, `RemoteTrigger`). A single `/watch` or `/daemon` can exhaust it and pause unrelated routines on the account.
- Ship local, quota-free runners that use filesystem events, subprocess loops, and OS schedulers instead — same behavior, zero routine cost.
- Keep the routine path available as the escape hatch for users with Extra Usage who need cloud persistence.

## What's new
- `scripts/local-watch.js` — real-time `fs.watch` (recursive) wrapper around the existing scan engine
- `scripts/local-daemon.js` — cross-platform Node port of `daemon-tick.ps1`, spawns `claude -p "/do continue"` in a loop
- `scripts/local-schedule.js` — installs Windows Task Scheduler / Unix cron entries
- `docs/ROUTINE-QUOTA.md` — trade-off explainer
- README banner + prominent notice at the top of `skills/{watch,daemon,schedule}/SKILL.md` steering agents to the local runner by default
- `npm run watch:local` / `daemon:local` / `schedule:local`

## Test plan
- [x] `node scripts/local-watch.js --once` scans 282 files on this repo
- [x] `node scripts/local-daemon.js --dry-run` honors daemon.json status gate
- [x] `local-schedule.js add / list / remove` round-trip verified on Windows via `schtasks`
- [ ] Unix crontab round-trip (untested — needs macOS/Linux runner)
- [x] `node scripts/skill-lint.js` — 43/43 clean

## Known minor issue
Git Bash on Windows mangles `/pr-watch` to `C:/Program Files/Git/pr-watch` before argv reaches the script. Native cmd/PowerShell are unaffected. Users running the command from Git Bash should prefix with `//pr-watch` or use the absolute path.