### PR TITLE
feat: local runner is the default, routine path is opt-in

### DIFF
--- a/skills/daemon/SKILL.md
+++ b/skills/daemon/SKILL.md
@@ -14,30 +14,48 @@ last-updated: 2026-03-28
 
 # /daemon -- Continuous Autonomous Operation
 
-## ⚠️ Prefer the local runner
+## Default execution path (READ FIRST)
 
-`/daemon start` uses `RemoteTrigger`, which counts against Anthropic's **15
-routine runs / 24h** cap. A single overnight run can exhaust the quota and
-pause every other routine on the account.
+**`/daemon start` does NOT call `RemoteTrigger` by default.** The local
+runner is the default. Only pass `--remote` to use Anthropic's routine
+system, and only after explicit user confirmation.
 
-**Default to the local runner instead:**
+**Why:** `RemoteTrigger` counts against the account-wide **15 routine runs /
+24h** cap. A single overnight run can exhaust the quota and pause every other
+routine on the account (including unrelated ones). See
+[docs/ROUTINE-QUOTA.md](../../docs/ROUTINE-QUOTA.md).
 
-```bash
-node scripts/local-daemon.js           # cross-platform tick loop, zero quota
-npm run daemon:local                   # same, via npm
-```
+### Default flow — `/daemon start` (no `--remote` flag)
+1. Do Steps 1, 2, and 4 below (validate, check existing, write `daemon.json`).
+2. **Skip Step 3** — do NOT create any `RemoteTrigger`. Leave `chainTriggerId`
+   and `watchdogTriggerId` as `null` in the state file.
+3. Instead of Step 5's trigger-confirmation, output:
+   ```
+   Daemon state created: .planning/daemon.json
+     Campaign:  {slug}
+     Budget:    ${N}
 
-The runner spawns `claude -p "/do continue"` subprocesses in a loop. The
-`SessionStart` hook (`init-project.js`) handles continuation automatically on
-every session start, so this replicates the full daemon behavior without any
-`RemoteTrigger` calls. Run it in a terminal you leave open, or wrap it in
-PM2 / Task Scheduler / systemd for true background operation.
+   To start the tick loop, run in a separate terminal:
+     npm run daemon:local
 
-Still call `/daemon start` first to populate `.planning/daemon.json` with the
-campaign, budget, and cooldown — the local runner reads that state file.
-Only use the `RemoteTrigger` path below if the user genuinely needs the
-campaign to keep running while the machine is off and has Extra Usage
-enabled. See [docs/ROUTINE-QUOTA.md](../../docs/ROUTINE-QUOTA.md).
+   Leave that terminal open. It spawns `claude -p "/do continue"` each
+   session, respects daemon.json status, and consumes zero Anthropic
+   routine quota. Stop with Ctrl+C or `/daemon stop`.
+
+   For true unattended background operation (machine sleeps, user away):
+     /daemon start --remote    (uses RemoteTrigger, counts against 15/day cap)
+   ```
+
+### Opt-in routine flow — `/daemon start --remote`
+Only when the user has explicitly passed `--remote`:
+1. Before proceeding, confirm: "This will use Anthropic's `RemoteTrigger`,
+   which counts against your 15 routine runs / 24h quota. A single overnight
+   daemon can exhaust it. Continue? (y/N)"
+2. If the user confirms, run the full Step 1–5 protocol below (including
+   Step 3's trigger creation).
+
+The rest of the protocol in this file documents the full routine-path flow
+for reference and for `--remote` invocations.
 
 ## Identity
 
@@ -62,8 +80,9 @@ Do NOT use `/daemon` for:
 
 | Command | Behavior |
 |---|---|
-| `/daemon start` | Start continuous mode on the active campaign |
-| `/daemon start --campaign {slug}` | Start on a specific campaign |
+| `/daemon start` | Default: create state file, prompt user to run `npm run daemon:local` (zero routine cost) |
+| `/daemon start --remote` | Use `RemoteTrigger` instead (counts against 15/day routine quota — requires confirmation) |
+| `/daemon start --campaign {slug}` | Target a specific campaign |
 | `/daemon start --budget {N}` | Set budget cap in dollars (default: $50) |
 | `/daemon start --budget unlimited` | Explicitly disable budget cap |
 | `/daemon start --interval {N}m` | Set watchdog interval (default: 30m) |

--- a/skills/schedule/SKILL.md
+++ b/skills/schedule/SKILL.md
@@ -11,27 +11,35 @@ last-updated: 2026-03-26
 
 # /schedule — Task Scheduling
 
-## ⚠️ Prefer the local runner
+## Default execution path (READ FIRST)
 
-`/schedule add` uses `CronCreate`, which counts against Anthropic's **15
-routine runs / 24h** cap. Every fire of a scheduled task counts.
+**`/schedule add` does NOT call `CronCreate` by default.** It shells out to
+`node scripts/local-schedule.js` which installs a native OS entry (Windows
+Task Scheduler or Unix cron). Only pass `--remote` to use Anthropic's routine
+system, and only after explicit user confirmation.
 
-**Default to the local runner instead:**
-
-```bash
-node scripts/local-schedule.js add "every 30m" "/pr-watch"
-node scripts/local-schedule.js list
-node scripts/local-schedule.js remove <id>
-```
-
-It installs native OS entries — Windows Task Scheduler or Unix cron —
-consuming zero Anthropic quota, surviving session end and reboot. Each fire
-spawns `claude -p "<command>"` against this project as a subprocess, which
-does not count as a routine.
-
-Only use `/schedule add` below when the user explicitly wants session-scoped
-scheduling (cleared on session end) and has Extra Usage enabled. See
+**Why:** `CronCreate` counts against the account-wide **15 routine runs / 24h**
+cap; every fire of the scheduled task counts. See
 [docs/ROUTINE-QUOTA.md](../../docs/ROUTINE-QUOTA.md).
+
+### Default flow — `/schedule add "<expr>" "<command>"` (no `--remote`)
+Run:
+```bash
+node scripts/local-schedule.js add "<expr>" "<command>"
+```
+Then report the returned ID and the removal command. This survives session
+end, machine reboot, and consumes zero routine quota. Use
+`/schedule list` and `/schedule remove {id}` (which also shell out to
+`local-schedule.js`) by default.
+
+### Opt-in routine flow — `/schedule add --remote ...`
+Only when `--remote` is explicitly passed:
+1. Confirm: "This will use `CronCreate`, which counts against your 15 routine
+   runs / 24h quota and is cleared at session end. Continue? (y/N)"
+2. On confirmation, run the `CronCreate`-based flow documented below.
+
+The rest of the protocol documents the full `CronCreate` flow for reference
+and for `--remote` invocations.
 
 ## Identity
 

--- a/skills/watch/SKILL.md
+++ b/skills/watch/SKILL.md
@@ -13,23 +13,47 @@ last-updated: 2026-03-29
 
 # /watch -- File Sentinel
 
-## ⚠️ Prefer the local runner
+## Default execution path (READ FIRST)
 
-`/watch start` uses `CronCreate`, which counts against Anthropic's **15 routine
-runs / 24h** cap. At the default 5-minute interval a watch exhausts the quota
-in under an hour and pauses every other routine on the account.
+**`/watch start` does NOT call `CronCreate` by default.** The local runner is
+the default. Only pass `--remote` to use Anthropic's routine system, and only
+after explicit user confirmation.
 
-**Default to the local runner instead:**
+**Why:** `CronCreate` counts against the account-wide **15 routine runs / 24h**
+cap. At the default 5-minute interval a watch exhausts the quota in under an
+hour and pauses every other routine on the account. See
+[docs/ROUTINE-QUOTA.md](../../docs/ROUTINE-QUOTA.md).
 
-```bash
-node scripts/local-watch.js            # real-time fs events, zero quota
-npm run watch:local                    # same, via npm
-```
+### Default flow — `/watch start` (no `--remote` flag)
+1. Do Steps 1 and 2 below (check existing watch, determine baseline commit).
+2. **Skip Step 3** — do NOT call `CronCreate`. Leave `cronId: null` in the
+   state file.
+3. Write the state file (Step 4) with `status: "watching"`.
+4. Output (instead of Step 5):
+   ```
+   Watch state created: .planning/watch-state.json
+     Baseline: {commit hash, first 7 chars}
 
-It uses the same `scripts/watch.js --scan` engine, triggers on filesystem
-events (not polls), and consumes no routine quota. Only use `/watch start`
-below if the user needs cloud-persistent polling with Extra Usage enabled.
-See [docs/ROUTINE-QUOTA.md](../../docs/ROUTINE-QUOTA.md).
+   To start real-time watching, run in a separate terminal:
+     npm run watch:local
+
+   It uses filesystem events (not polling), triggers scans on change, and
+   consumes zero Anthropic routine quota. Stop with Ctrl+C.
+
+   For cloud-persistent polling (machine off, user away):
+     /watch start --remote     (uses CronCreate, counts against 15/day cap)
+   ```
+
+### Opt-in routine flow — `/watch start --remote`
+Only when `--remote` is explicitly passed:
+1. Confirm: "This will use `CronCreate`, which counts against your 15 routine
+   runs / 24h quota. At a 5-minute interval this exhausts the quota in under
+   an hour. Continue? (y/N)"
+2. On confirmation, run the full Step 1–5 protocol below including Step 3's
+   `CronCreate` call.
+
+The rest of the protocol documents the full routine-path flow for reference
+and for `--remote` invocations.
 
 ## Identity
 
@@ -55,8 +79,9 @@ Do NOT use `/watch` for:
 
 | Command | Behavior |
 |---|---|
-| `/watch start` | Start watching (poll via CronCreate, default 5m interval) |
-| `/watch start --interval {N}m` | Set poll interval (default: 5m) |
+| `/watch start` | Default: create state, prompt user to run `npm run watch:local` (real-time, zero routine cost) |
+| `/watch start --remote` | Use `CronCreate` polling instead (counts against 15/day routine quota — requires confirmation) |
+| `/watch start --interval {N}m` | Set poll interval for `--remote` mode (default: 5m) |
 | `/watch stop` | Stop watching, tear down cron |
 | `/watch status` | Show watch state, last scan time, pending actions |
 | `/watch scan` | Run a single scan now (manual trigger) |


### PR DESCRIPTION
## Summary
Prior PR #108 added local runners but marked them as "preferred" — the routine path still fired automatically on `/daemon start`, `/watch start`, and `/schedule add`. An agent that reads a warning and then calls `RemoteTrigger` anyway isn't real protection.

This PR flips the defaults so users cannot accidentally burn their 15/day routine quota.

## Behavior change
| Command | Before | After |
|---|---|---|
| `/daemon start` | Creates `RemoteTrigger` chain + watchdog automatically | Writes `daemon.json`, prompts user to run `npm run daemon:local` |
| `/watch start` | Creates `CronCreate` poll automatically | Writes watch state, prompts user to run `npm run watch:local` |
| `/schedule add` | Calls `CronCreate` | Shells out to `scripts/local-schedule.js` (OS-native cron / Task Scheduler) |

All three now support `--remote` to opt into the Anthropic-scheduled path, gated behind an explicit confirmation prompt stating the 15/day consequence.

## Why
A user typing `/daemon start` on a fresh install should spend **zero** routine quota. Only someone who explicitly types `--remote` and confirms the quota cost should burn it.

## Test plan
- [x] `node scripts/skill-lint.js` — 43/43 clean
- [ ] Manual: `/daemon start` on a test campaign does not create triggers and prints the local-runner instructions
- [ ] Manual: `/daemon start --remote` prompts for confirmation before creating triggers
- [ ] Manual: `/watch start` and `/watch start --remote` follow the same pattern
- [ ] Manual: `/schedule add "every 30m" "/pr-watch"` goes through `local-schedule.js`