### PR TITLE
fix: route plain-text Stop hook output to stderr for Codex (#111)

### DIFF
--- a/hooks_src/codex-adapter.js
+++ b/hooks_src/codex-adapter.js
@@ -34,8 +34,26 @@ function main() {
       encoding: 'utf8',
     });
 
-    if (result.stdout) process.stdout.write(result.stdout);
-    if (result.stderr) process.stderr.write(result.stderr);
+    const stdout = result.stdout || '';
+    const stderr = result.stderr || '';
+
+    // Codex's Stop hook spec requires JSON on stdout (or empty stdout) when
+    // exit is 0 — plain text is rejected. Inner hooks (quality-gate, session-end)
+    // emit human-readable text by default. Route non-JSON Stop output to stderr
+    // so Codex still logs the message without rejecting the hook contract.
+    if (envelope.native_event_name === 'Stop' && stdout.trim().length > 0) {
+      let isJson = false;
+      try { JSON.parse(stdout); isJson = true; } catch { /* not JSON */ }
+      if (isJson) {
+        process.stdout.write(stdout);
+      } else {
+        process.stderr.write(stdout);
+      }
+    } else if (stdout) {
+      process.stdout.write(stdout);
+    }
+
+    if (stderr) process.stderr.write(stderr);
     process.exit(typeof result.status === 'number' ? result.status : 0);
   });
 }

--- a/scripts/test-codex-runtime.js
+++ b/scripts/test-codex-runtime.js
@@ -41,4 +41,40 @@ try {
   fs.rmSync(tmpProject, { recursive: true, force: true });
 }
 
+// Codex Stop hook contract: plain text stdout from inner hooks must be
+// redirected to stderr (Codex rejects non-JSON stdout for Stop). JSON passes
+// through unchanged. Non-Stop events keep their plain-text stdout.
+const hooksDir = path.join(__dirname, '..', 'hooks_src');
+const plainHook = path.join(hooksDir, 'test-fixture-plain-stop.js');
+const jsonHook = path.join(hooksDir, 'test-fixture-json-stop.js');
+fs.writeFileSync(plainHook, "process.stdout.write('plain text from hook');\n");
+fs.writeFileSync(jsonHook, "process.stdout.write(JSON.stringify({decision:'block',reason:'keep going'}));\n");
+
+try {
+  const stopPlain = spawnSync(process.execPath, [adapterPath, 'test-fixture-plain-stop'], {
+    cwd: path.join(__dirname, '..'),
+    input: JSON.stringify({ hook_event_name: 'Stop' }),
+    encoding: 'utf8',
+  });
+  assert.equal(stopPlain.stdout, '', 'Stop hook plain text should not leak to stdout');
+  assert(stopPlain.stderr.includes('plain text from hook'), 'Stop hook plain text should be redirected to stderr');
+
+  const stopJson = spawnSync(process.execPath, [adapterPath, 'test-fixture-json-stop'], {
+    cwd: path.join(__dirname, '..'),
+    input: JSON.stringify({ hook_event_name: 'Stop' }),
+    encoding: 'utf8',
+  });
+  assert(stopJson.stdout.includes('"decision":"block"'), 'Stop hook JSON output should pass through stdout');
+
+  const nonStop = spawnSync(process.execPath, [adapterPath, 'test-fixture-plain-stop'], {
+    cwd: path.join(__dirname, '..'),
+    input: JSON.stringify({ hook_event_name: 'PostToolUse' }),
+    encoding: 'utf8',
+  });
+  assert(nonStop.stdout.includes('plain text from hook'), 'Non-Stop events should keep plain-text stdout behaviour');
+} finally {
+  fs.rmSync(plainHook, { force: true });
+  fs.rmSync(jsonHook, { force: true });
+}
+
 console.log('codex runtime tests passed');


### PR DESCRIPTION
## Summary
- Codex's Stop hook spec rejects non-JSON stdout. Inner hooks like `quality-gate` and `session-end` emit human-readable text on the default (non-`CITADEL_UI`) path, which broke every Codex Stop hook run with output.
- The `codex-adapter` now checks `envelope.native_event_name`. On `Stop`, plain-text stdout is redirected to stderr (Codex logs it without rejecting the hook), JSON passes through, and non-Stop events keep their existing behaviour.
- Adds three regression tests in `test-codex-runtime.js`: plain-text Stop, JSON Stop, and non-Stop pass-through.

Closes #111.

## Test plan
- [x] `node scripts/test-codex-runtime.js` — three new Stop-event assertions
- [x] `node scripts/test-all.js` — full suite green