### PR TITLE
docs: add COMMUNITY.md for third-party skills (refs #107)

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -1,0 +1,38 @@
+# Community Skills and Extensions
+
+This is a directory of third-party skills, frameworks, and tools built by the community on top of Citadel. They are not part of the Citadel distribution and not maintained by the Citadel team.
+
+## How to Use This List
+
+Entries here are pointers, not endorsements. Each project is owned and maintained by its author. Before installing anything from this list:
+
+- Read the linked repo's README and license
+- Review the skill source before running it on a real codebase
+- Open issues with the project's author, not in the Citadel issue tracker
+
+The Citadel team does not vet these contributions for security, correctness, or compatibility. Install at your own discretion.
+
+## How to Get Listed
+
+Open a GitHub Discussion or PR adding your entry to the list below. We'll review for fit (built on Citadel, complementary scope, working install path) and merge. Listing order is alphabetical.
+
+To keep the bar consistent:
+
+- The project must be public and have its own repo
+- It must work with Citadel's skill spec or plug into a documented extension point
+- The README must explain what it does and how to install it
+- One-line description in this file, link to the project for the rest
+
+## Listed Projects
+
+### Acui — Workspace routing for research, brainstorming, learning, and production
+
+Four-workspace pipeline (Research → Brainstorming → Production, with Learning as an orthogonal layer) packaged as Citadel-compatible skills. Adds structured pre-code workflows: source-first research, devil's-advocate brainstorming with quality gates, and grasp-tracked learning. Outputs `---HANDOFF---` blocks so Marshal and Archon can chain workspaces as campaign phases.
+
+Repo: [github.com/Acquiredl/Acui-public](https://github.com/Acquiredl/Acui-public)
+
+Author: [@Acquiredl](https://github.com/Acquiredl)
+
+---
+
+If you've built something on Citadel and want it listed, open a Discussion or send a PR.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Four tiers. Use the cheapest one that fits.
 - [Fleet guide](docs/FLEET.md) — parallel agents, worktree isolation, discovery relay
 - [Security model](SECURITY.md) — path traversal, shell injection, and defensive measures
 - [Contributing](CONTRIBUTING.md) — how to submit issues, PRs, and new skills
+- [Community projects](COMMUNITY.md) — third-party skills and extensions built on Citadel
 - [External overview](https://repo-explainer.com/SethGammon/Citadel/) — third-party writeup on the architecture and philosophy
 
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,6 @@ Four tiers. Use the cheapest one that fits.
 - [Fleet guide](docs/FLEET.md) — parallel agents, worktree isolation, discovery relay
 - [Security model](SECURITY.md) — path traversal, shell injection, and defensive measures
 - [Contributing](CONTRIBUTING.md) — how to submit issues, PRs, and new skills
-- [Community projects](COMMUNITY.md) — third-party skills and extensions built on Citadel
 - [External overview](https://repo-explainer.com/SethGammon/Citadel/) — third-party writeup on the architecture and philosophy
 
 


### PR DESCRIPTION
## Summary
- Adds `COMMUNITY.md` listing third-party skills and extensions built on Citadel
- First listing: Acui workspace pipeline (issue #107)
- README links to it from the Learn More section

## Why
Establishes a pointer-not-endorsement directory for community contributions without bundling third-party skills in-tree. Keeps the bar consistent for what ships in `skills/` (maintained by me) versus what's discoverable to users (community-owned).

## Test plan
- [x] `COMMUNITY.md` renders correctly on GitHub
- [x] README link resolves
- [ ] No further changes needed before posting reply on #107