### PR TITLE
fix(codex): idempotent session-end under Stop collapse

### DIFF
--- a/hooks_src/session-end.js
+++ b/hooks_src/session-end.js
@@ -34,6 +34,38 @@ try {
 
 const PROJECT_ROOT = health.PROJECT_ROOT;
 
+// Idempotency guard. In Claude Code this hook fires once at SessionEnd. In
+// Codex, the bridge maps SessionEnd → Stop because Codex has no native
+// SessionEnd event, so without a guard the hook would fire on every turn.
+// We mark which session_id has already run and short-circuit re-fires.
+//
+// The guard is keyed on session_id, not runtime. That means it works
+// uniformly across Claude Code (where it's a no-op) and Codex (where it
+// actually prevents duplicate fires) — and if Codex ever ships a real
+// SessionEnd event, the same code keeps working without changes.
+function alreadyFiredForSession(sessionId) {
+  if (!sessionId) return false; // can't guard without an id; allow through
+  try {
+    const markerPath = path.join(PROJECT_ROOT, '.planning', 'telemetry', 'session-end.lock');
+    if (!fs.existsSync(markerPath)) return false;
+    const content = fs.readFileSync(markerPath, 'utf8').trim();
+    // Marker holds the most recent session_id that ran session-end.
+    // If it matches, we've already fired for this session.
+    return content === sessionId;
+  } catch {
+    return false; // on any error, allow the hook to fire
+  }
+}
+
+function recordFiredForSession(sessionId) {
+  if (!sessionId) return;
+  try {
+    const telemetryDir = path.join(PROJECT_ROOT, '.planning', 'telemetry');
+    if (!fs.existsSync(telemetryDir)) fs.mkdirSync(telemetryDir, { recursive: true });
+    fs.writeFileSync(path.join(telemetryDir, 'session-end.lock'), sessionId, 'utf8');
+  } catch { /* non-critical */ }
+}
+
 function main() {
   let input = '';
   process.stdin.setEncoding('utf8');
@@ -42,12 +74,21 @@ function main() {
     let event = {};
     try { event = JSON.parse(input); } catch { /* partial input ok */ }
 
+    const sessionId = event.session_id || null;
+
+    // Idempotency: skip if we've already run for this session_id.
+    // This is what makes the hook safe under Codex's SessionEnd→Stop collapse.
+    if (alreadyFiredForSession(sessionId)) {
+      process.exit(0);
+    }
+    recordFiredForSession(sessionId);
+
     health.increment('session-end', 'count');
 
     // Log session end
     health.logTiming('session-end', 0, {
       event: 'session-end',
-      session_id: event.session_id || null,
+      session_id: sessionId,
     });
 
     // Log session cost data to telemetry


### PR DESCRIPTION
## Summary
Prevent `session-end.js` from firing on every turn-stop in Codex.

In Claude Code, `SessionEnd` fires once at session close. In Codex, the bridge maps `SessionEnd → Stop` because Codex has no native `SessionEnd` event, so without a guard the hook would re-run on every turn — re-logging cost, re-incrementing trust counters, re-marking campaign continuation, re-appending to the daemon log.

This adds a session_id-keyed marker at `.planning/telemetry/session-end.lock`. The hook checks it at the top of `main()` and exits early if the current session has already fired.

The guard is keyed on `session_id`, not runtime, so:
- In Claude Code it's a no-op (SessionEnd only fires once per session anyway).
- In Codex it suppresses duplicate fires under the `Stop` collapse.
- If Codex eventually ships a real `SessionEnd` event, the same code keeps working without changes.

## Context
This is the last of the bridge-hardening fixes I worked on this session. The other four (`install-hooks-codex --verbose/--json`, full-tree skill copy, full-schema MCP translation, observable agent truncation) are already on `main` — they were swept up into PR #115's squash-merge from earlier branch contamination, so the squash commit body lists their original messages even though the PR title doesn't. This PR contains only the session-end fix because that's all that wasn't already shipped.

## Test plan
- [x] `node scripts/test-all.js` — 20/20 PASS
- [x] `node hooks_src/smoke-test.js` — PASS
- [x] Manual: simulating two consecutive Stop events with the same session_id, the second exits early before any state mutation