### PR TITLE
fix: generate delegate wrappers in .citadel/scripts/ instead of copying verbatim

### DIFF
--- a/hooks_src/init-project.js
+++ b/hooks_src/init-project.js
@@ -95,6 +95,25 @@ function copyDirIfMissing(src, dest) {
   }
 }
 
+/**
+ * Generate a thin delegate wrapper that forwards execution to the real script
+ * in the Citadel install. This avoids copying scripts that import from
+ * ../core/ and ../runtimes/ — paths that only exist inside the Citadel repo.
+ */
+function generateDelegate(scriptName) {
+  return (
+    "#!/usr/bin/env node\n" +
+    "'use strict';\n" +
+    "const { spawnSync } = require('child_process');\n" +
+    "const fs = require('fs');\n" +
+    "const path = require('path');\n" +
+    "const pluginRoot = fs.readFileSync(path.join(__dirname, '..', 'plugin-root.txt'), 'utf8').trim();\n" +
+    "const real = path.join(pluginRoot, 'scripts', " + JSON.stringify(scriptName) + ");\n" +
+    "const r = spawnSync(process.execPath, [real, ...process.argv.slice(2)], { stdio: 'inherit', env: process.env });\n" +
+    "process.exit(r.status ?? 0);\n"
+  );
+}
+
 function main() {
   try {
     // 1. Create .planning/ directory tree
@@ -131,6 +150,12 @@ function main() {
     }
 
     // 4. Sync utility scripts to .citadel/scripts/ (version-gated to avoid unnecessary I/O)
+    //
+    // Scripts are generated as thin delegates rather than copied verbatim.
+    // Copied scripts import from ../core/ and ../runtimes/ which only exist
+    // inside the Citadel install, not inside the target project. Delegates
+    // read plugin-root.txt at runtime and spawn the real script via the
+    // Citadel install, so imports always resolve correctly.
     if (shouldSyncScripts()) {
       const pluginScripts = path.join(PLUGIN_ROOT, 'scripts');
       const projectScripts = path.join(PROJECT_ROOT, '.citadel', 'scripts');
@@ -138,9 +163,9 @@ function main() {
         ensureDir(projectScripts);
         for (const file of fs.readdirSync(pluginScripts)) {
           if (file.endsWith('.js') || file.endsWith('.cjs')) {
-            fs.copyFileSync(
-              path.join(pluginScripts, file),
-              path.join(projectScripts, file)
+            fs.writeFileSync(
+              path.join(projectScripts, file),
+              generateDelegate(file)
             );
           }
         }

--- a/scripts/verify-hooks.js
+++ b/scripts/verify-hooks.js
@@ -209,11 +209,19 @@ test('.planning/ directory tree created', () => {
   if (missing.length) return `missing dirs: ${missing.join(', ')}`;
 });
 
-test('.citadel/scripts/ populated', () => {
+test('.citadel/scripts/ populated with delegates', () => {
   const scripts = path.join(initDir, '.citadel', 'scripts');
   if (!fs.existsSync(scripts)) return '.citadel/scripts/ not created';
   const files = fs.readdirSync(scripts);
   if (files.length === 0) return '.citadel/scripts/ is empty';
+  // Each file should be a thin delegate (reads plugin-root.txt, not a verbatim copy)
+  const delegateMarker = 'plugin-root.txt';
+  const nonDelegate = files.filter(f => {
+    if (!f.endsWith('.js') && !f.endsWith('.cjs')) return false;
+    const content = fs.readFileSync(path.join(scripts, f), 'utf8');
+    return !content.includes(delegateMarker);
+  });
+  if (nonDelegate.length > 0) return `non-delegate scripts found: ${nonDelegate.join(', ')}`;
 });
 
 test('.citadel/plugin-root.txt written', () => {


### PR DESCRIPTION
## Summary
- Scripts in `scripts/` import from `../core/` and `../runtimes/` which only
  exist inside the Citadel repo. Copying them verbatim into a target project's
  `.citadel/scripts/` broke those imports at runtime.
- `init-project.js` now generates thin `spawnSync` delegate wrappers instead.
  Each delegate reads `plugin-root.txt` and forwards execution to the real
  script in the Citadel install — stdin/stdout/stderr and exit codes all pass
  through transparently.
- Updated `verify-hooks.js` to assert that generated scripts are delegates
  (contain `plugin-root.txt` reference) rather than verbatim copies.

## Self-healing
Existing projects with broken copied scripts fix themselves automatically on
next session start — `init-project.js` overwrites `.citadel/scripts/` whenever
the Citadel version changes.

## Test plan
- [ ] `node scripts/test-all.js` — all suites pass
- [ ] `node scripts/verify-hooks.js` — `.citadel/scripts/ populated with delegates` passes
- [ ] Manually confirm a delegate script executes correctly (coordination.js status)