### PR TITLE
feat: /unharness skill with versioned archive export

### DIFF
--- a/scripts/unharness.js
+++ b/scripts/unharness.js
@@ -1,0 +1,265 @@
+#!/usr/bin/env node
+
+/**
+ * unharness.js — Exports valuable Citadel state then removes the harness from a project.
+ *
+ * Export: reads campaigns, postmortems, research, intake, discoveries, and project metadata,
+ * writes them to docs/citadel/ as human-readable markdown with citadel-archive frontmatter.
+ * Setup detects this archive on re-install and offers to restore it.
+ *
+ * Cleanup: removes .planning/, .citadel/, .claude/agent-context/, and strips all Citadel
+ * hook entries from .claude/settings.json.
+ *
+ * Usage:
+ *   node /path/to/Citadel/scripts/unharness.js                  # from project dir
+ *   node /path/to/Citadel/scripts/unharness.js /project          # explicit project path
+ *   node /path/to/Citadel/scripts/unharness.js --export-only     # export without deleting
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const options = {
+    projectRoot: process.env.CLAUDE_PROJECT_DIR || process.cwd(),
+    exportOnly: false,
+  };
+  for (const arg of args) {
+    if (arg === '--export-only') { options.exportOnly = true; continue; }
+    if (!arg.startsWith('--')) options.projectRoot = path.resolve(arg);
+  }
+  return options;
+}
+
+function readMarkdownFiles(dir, skip = []) {
+  if (!fs.existsSync(dir)) return [];
+  const results = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.md')) continue;
+    if (skip.some(s => entry.name.includes(s))) continue;
+    const content = fs.readFileSync(path.join(dir, entry.name), 'utf8').trim();
+    if (content) results.push({ name: entry.name, content });
+  }
+  return results;
+}
+
+function buildArchiveFile(source, files, exportedAt) {
+  if (!files.length) return null;
+  const frontmatter = `---\ncitadel-archive: true\nexported-at: ${exportedAt}\nsource: ${source}\n---`;
+  const body = files
+    .map(f => `## ${f.name.replace(/\.md$/, '')}\n\n${f.content}`)
+    .join('\n\n---\n\n');
+  return `${frontmatter}\n\n${body}\n`;
+}
+
+function removeCitadelHooks(settingsPath, citadelRoot) {
+  if (!fs.existsSync(settingsPath)) return { removed: 0, preserved: 0 };
+
+  let settings;
+  try {
+    settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+  } catch {
+    return { removed: 0, preserved: 0, error: 'could not parse settings.json' };
+  }
+
+  if (!settings.hooks || typeof settings.hooks !== 'object') {
+    return { removed: 0, preserved: 0 };
+  }
+
+  const citadelRootNorm = citadelRoot.replace(/\\/g, '/');
+  let removed = 0;
+  let preserved = 0;
+
+  for (const event of Object.keys(settings.hooks)) {
+    const hooks = settings.hooks[event];
+    if (!Array.isArray(hooks)) continue;
+    const filtered = hooks.filter(hook => {
+      const cmd = (hook.command || '').replace(/\\/g, '/');
+      const isCitadel = cmd.includes(citadelRootNorm) ||
+        cmd.includes('/hooks_src/') ||
+        cmd.includes('/.citadel/scripts/');
+      if (isCitadel) { removed++; return false; }
+      preserved++;
+      return true;
+    });
+    if (filtered.length === 0) {
+      delete settings.hooks[event];
+    } else {
+      settings.hooks[event] = filtered;
+    }
+  }
+
+  if (Object.keys(settings.hooks).length === 0) {
+    delete settings.hooks;
+  }
+
+  // Remove the env var Citadel injects
+  if (settings.env && settings.env.CLAUDE_CODE_SUBPROCESS_ENV_SCRUB) {
+    delete settings.env.CLAUDE_CODE_SUBPROCESS_ENV_SCRUB;
+    if (Object.keys(settings.env).length === 0) delete settings.env;
+  }
+
+  fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n');
+  return { removed, preserved };
+}
+
+function removeDir(dir) {
+  if (!fs.existsSync(dir)) return false;
+  fs.rmSync(dir, { recursive: true, force: true });
+  return true;
+}
+
+function countFiles(dir) {
+  if (!fs.existsSync(dir)) return 0;
+  let count = 0;
+  function walk(d) {
+    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+      if (entry.isDirectory()) walk(path.join(d, entry.name));
+      else count++;
+    }
+  }
+  walk(dir);
+  return count;
+}
+
+function isCitadelRepo(dir) {
+  // Refuse to run unharness against the Citadel plugin repo itself.
+  // Detect by presence of skills/ and hooks_src/ at the root.
+  return fs.existsSync(path.join(dir, 'hooks_src')) &&
+    fs.existsSync(path.join(dir, 'skills')) &&
+    fs.existsSync(path.join(dir, 'package.json')) &&
+    JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8')).name === 'citadel';
+}
+
+function main() {
+  const options = parseArgs(process.argv);
+  const { projectRoot, exportOnly } = options;
+
+  if (isCitadelRepo(projectRoot)) {
+    console.error('Error: unharness cannot run against the Citadel plugin repo itself.');
+    console.error('Run this from your project directory, or pass the project path as an argument:');
+    console.error('  node /path/to/Citadel/scripts/unharness.js /your/project');
+    process.exit(1);
+  }
+
+  const planning = path.join(projectRoot, '.planning');
+  const citadelDir = path.join(projectRoot, '.citadel');
+  const pluginRootFile = path.join(citadelDir, 'plugin-root.txt');
+  const citadelRoot = fs.existsSync(pluginRootFile)
+    ? fs.readFileSync(pluginRootFile, 'utf8').trim()
+    : path.resolve(__dirname, '..');
+
+  const exportedAt = new Date().toISOString();
+  const archiveDir = path.join(projectRoot, 'docs', 'citadel');
+
+  // --- SCAN ---
+  const campaigns = readMarkdownFiles(path.join(planning, 'campaigns', 'completed'));
+  const postmortems = readMarkdownFiles(path.join(planning, 'postmortems'));
+  const research = readMarkdownFiles(path.join(planning, 'research'));
+  const intake = readMarkdownFiles(path.join(planning, 'intake'), ['_TEMPLATE']);
+  const discoveries = readMarkdownFiles(path.join(planning, 'discoveries'));
+
+  const hasContent = campaigns.length + postmortems.length + research.length +
+    intake.length + discoveries.length > 0;
+
+  const projectMd = path.join(citadelDir, 'project.md');
+  const harnessJson = path.join(projectRoot, '.claude', 'harness.json');
+
+  console.log('');
+  console.log('Citadel Unharness');
+  console.log('=================');
+  console.log('');
+  console.log('Found:');
+  console.log(`  ${campaigns.length} completed campaigns`);
+  console.log(`  ${postmortems.length} postmortems`);
+  console.log(`  ${research.length} research notes`);
+  console.log(`  ${intake.length} backlog items`);
+  console.log(`  ${discoveries.length} discoveries`);
+
+  // --- EXPORT ---
+  if (hasContent || fs.existsSync(projectMd) || fs.existsSync(harnessJson)) {
+    fs.mkdirSync(archiveDir, { recursive: true });
+
+    const archives = [
+      { source: 'campaigns',    files: campaigns   },
+      { source: 'postmortems',  files: postmortems },
+      { source: 'research',     files: research    },
+      { source: 'backlog',      files: intake      },
+      { source: 'discoveries',  files: discoveries },
+    ];
+
+    let written = 0;
+    for (const { source, files } of archives) {
+      const content = buildArchiveFile(source, files, exportedAt);
+      if (!content) continue;
+      fs.writeFileSync(path.join(archiveDir, `${source}.md`), content);
+      written++;
+    }
+
+    if (fs.existsSync(projectMd)) {
+      const projectContent = fs.readFileSync(projectMd, 'utf8').trim();
+      const projectArchive = `---\ncitadel-archive: true\nexported-at: ${exportedAt}\nsource: project\n---\n\n${projectContent}\n`;
+      fs.writeFileSync(path.join(archiveDir, 'project.md'), projectArchive);
+      written++;
+    }
+
+    if (fs.existsSync(harnessJson)) {
+      const harnessContent = fs.readFileSync(harnessJson, 'utf8');
+      const harnessArchive = `---\ncitadel-archive: true\nexported-at: ${exportedAt}\nsource: harness-config\n---\n\n${harnessContent}\n`;
+      fs.writeFileSync(path.join(archiveDir, 'harness.json.md'), harnessArchive);
+      written++;
+    }
+
+    console.log('');
+    console.log(`Archive written to docs/citadel/ (${written} files)`);
+    console.log('  Review it, commit it, or delete it — your call.');
+    console.log('  Run /do setup again anytime; it will offer to restore from this archive.');
+  } else {
+    console.log('  Nothing to export.');
+  }
+
+  if (exportOnly) {
+    console.log('');
+    console.log('--export-only: harness files left in place.');
+    return;
+  }
+
+  // --- CLEANUP ---
+  console.log('');
+  console.log('Removing harness...');
+
+  const planningFileCount = countFiles(planning);
+  if (removeDir(planning)) {
+    console.log(`  Removed .planning/ (${planningFileCount} files)`);
+  }
+
+  if (removeDir(citadelDir)) {
+    console.log(`  Removed .citadel/`);
+  }
+
+  const agentContextDir = path.join(projectRoot, '.claude', 'agent-context');
+  if (removeDir(agentContextDir)) {
+    console.log(`  Removed .claude/agent-context/`);
+  }
+
+  const settingsPath = path.join(projectRoot, '.claude', 'settings.json');
+  const hookResult = removeCitadelHooks(settingsPath, citadelRoot);
+  if (hookResult.error) {
+    console.log(`  settings.json: ${hookResult.error}`);
+  } else if (hookResult.removed > 0) {
+    const preservedNote = hookResult.preserved > 0 ? ` (${hookResult.preserved} user hooks preserved)` : '';
+    console.log(`  Removed ${hookResult.removed} Citadel hooks from .claude/settings.json${preservedNote}`);
+  }
+
+  console.log('');
+  console.log('Done. Citadel has been removed from this project.');
+  if (hasContent) {
+    console.log('Your history is in docs/citadel/ — delete it or keep it.');
+  }
+  console.log('');
+}
+
+main();

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -40,6 +40,54 @@ Flag: `/do setup --express` skips mode selection and runs Express directly.
 
 ## Protocol
 
+### Step -1: ARCHIVE DETECTION (all modes, before anything else)
+
+Check whether a previous unharness left an archive in this project:
+
+```bash
+ls docs/citadel/ 2>/dev/null
+```
+
+If `docs/citadel/` exists and contains any `.md` files with `citadel-archive: true` in their
+frontmatter, read the first line of each to extract the `exported-at` date, then prompt once:
+
+```
+Found a Citadel archive from {exported-at date}.
+  Campaigns: {N}  Postmortems: {N}  Backlog items: {N}  Research: {N}
+
+Restore history into .planning/ during setup? [Y/n]
+```
+
+- **Y or Enter**: set `restoreArchive = true`. After hooks are installed in Step 1,
+  restore the archive (see ARCHIVE RESTORE below).
+- **n**: skip silently, proceed with fresh setup.
+
+If no archive is found, skip this step entirely — no output.
+
+**ARCHIVE RESTORE** (runs after Step 1 if `restoreArchive = true`):
+
+For each archive file in `docs/citadel/`:
+
+| File | Restore to |
+|---|---|
+| `campaigns.md` | Split sections back into `.planning/campaigns/completed/{name}.md` |
+| `postmortems.md` | Split sections back into `.planning/postmortems/{name}.md` |
+| `research.md` | Split sections back into `.planning/research/{name}.md` |
+| `backlog.md` | Split sections back into `.planning/intake/{name}.md` |
+| `discoveries.md` | Split sections back into `.planning/discoveries/{name}.md` |
+| `project.md` | Strip frontmatter, write to `.citadel/project.md` |
+| `harness.json.md` | Strip frontmatter, write to `.claude/harness.json` |
+
+Splitting: each `## Section Title` in the archive file becomes one restored file.
+Strip the frontmatter block (`---` ... `---`) before writing restored files.
+
+After restore, output one line:
+```
+  ✓ Archive restored — {N} campaigns, {N} postmortems, {N} backlog items
+```
+
+---
+
 ### Step 0: MODE SELECTION
 
 Before anything else, present three modes. This is the only required

--- a/skills/unharness/SKILL.md
+++ b/skills/unharness/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: unharness
+description: >-
+  Remove Citadel from a project. Exports valuable state (campaigns, postmortems,
+  research, backlog, discoveries) to docs/citadel/ as human-readable markdown,
+  then removes all harness files and hooks. The archive is detected by /do setup
+  on re-install and offered for restore.
+user-invocable: true
+auto-trigger: false
+trigger_keywords:
+  - unharness
+  - remove citadel
+  - uninstall citadel
+  - clean up citadel
+  - remove harness
+  - uninstall harness
+last-updated: 2026-04-30
+---
+
+# /unharness — Remove Citadel from a Project
+
+## Identity
+
+You are the clean exit. Your job is to export everything worth keeping, then
+remove every harness file and hook without leaving a mess. The user should end
+up with either a clean project or a clean project plus a readable archive —
+never a half-removed harness.
+
+## Invocation Forms
+
+```
+/unharness               # Export archive, then remove harness
+/unharness --export-only # Export to docs/citadel/ without removing anything
+```
+
+---
+
+## Protocol
+
+### Step 1: FIND CITADEL ROOT
+
+Read `.citadel/plugin-root.txt` to locate the Citadel install.
+If missing, use the directory containing this SKILL.md as the fallback.
+
+```bash
+cat .citadel/plugin-root.txt 2>/dev/null || echo "fallback"
+```
+
+Store as `{citadelRoot}`.
+
+---
+
+### Step 2: RUN UNHARNESS SCRIPT
+
+```bash
+node {citadelRoot}/scripts/unharness.js
+```
+
+For `--export-only`:
+
+```bash
+node {citadelRoot}/scripts/unharness.js --export-only
+```
+
+The script:
+1. Scans `.planning/` for valuable content (campaigns, postmortems, research, backlog, discoveries)
+2. Reads `.citadel/project.md` and `.claude/harness.json` for project metadata
+3. Writes `docs/citadel/{category}.md` files with `citadel-archive: true` frontmatter
+4. Removes `.planning/`, `.citadel/`, `.claude/agent-context/`
+5. Strips Citadel hook entries from `.claude/settings.json` (preserves user hooks)
+6. Prints a summary of what was exported and removed
+
+Print the script output verbatim.
+
+---
+
+### Step 3: CLOSING MESSAGE
+
+After the script completes, print:
+
+**If archive was written:**
+```
+Archive is at docs/citadel/ — commit it, delete it, or leave it.
+Run /do setup again anytime to reinstall Citadel.
+If you run setup in this project, it will find the archive and offer to restore your history.
+```
+
+**If nothing was exported (empty project):**
+```
+Citadel removed. No history to archive.
+Run /do setup again anytime to reinstall.
+```
+
+**If --export-only:**
+```
+Archive written to docs/citadel/. Harness files left in place.
+Run /unharness without --export-only to complete the removal.
+```
+
+---
+
+## Fringe Cases
+
+**Script not found:**
+Report the error and explain the user can run the hook installer manually:
+`node /path/to/Citadel/scripts/unharness.js`
+
+**No .planning/ directory (harness was installed but never used):**
+The script handles this gracefully — it skips the export and proceeds to cleanup.
+Nothing special needed.
+
+**docs/citadel/ already exists from a previous unharness:**
+The script overwrites with the current timestamp. Prior archives are replaced.
+If the user wants to keep prior archives, they should commit `docs/citadel/` to git first.
+
+**User runs unharness on a project that was never set up:**
+The script exits cleanly with "Nothing to export." and nothing is deleted that shouldn't be.
+
+---
+
+## Quality Gates
+
+- Never prompt the user before running — the export is the safety net, not a confirmation dialog
+- Always print the script output so the user can see exactly what happened
+- If the script errors, surface the error directly — don't swallow it
+
+## Exit Protocol
+
+After the closing message in Step 3, output nothing further. Unharness is a terminal action — no HANDOFF block, no next-step suggestions. The session is now running without hooks.


### PR DESCRIPTION
## Summary

- Adds `/unharness` skill and `scripts/unharness.js` to cleanly remove Citadel from any project
- Exports valuable state (campaigns, postmortems, research, backlog, discoveries, project metadata) to `docs/citadel/` as plain markdown with `citadel-archive: true` frontmatter before removing anything
- Updates `/do setup` to detect the archive on re-install and offer to restore history in a single prompt (Step -1), handling upgrade, fresh-install, and returning-user flows through the same path
- Includes a self-run guard that prevents the script from accidentally running against the Citadel repo itself

## Test plan

- [ ] Run `/unharness` on a project with campaign history — verify `docs/citadel/` is written and `.planning/`/`.citadel/` are removed
- [ ] Verify `.claude/settings.json` hook entries are stripped and user hooks preserved
- [ ] Re-run `/do setup` after unharness — verify archive detection prompt appears
- [ ] Run `node scripts/unharness.js` from the Citadel repo itself — verify guard fires and exits with error
- [ ] `node scripts/skill-lint.js unharness` passes
- [ ] `node scripts/test-all.js` passes

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)