### PR TITLE
chore: update demo site stats to 45 skills / 29 hook events

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1676,7 +1676,7 @@
   <!-- Stats bar -->
   <div class="stat-bar">
     <div class="stat">
-      <div class="stat-num">34</div>
+      <div class="stat-num">45</div>
       <div class="stat-label">Skills</div>
       <div class="stat-caption">covering code quality, debugging, research, orchestration, and more</div>
     </div>
@@ -1686,7 +1686,7 @@
       <div class="stat-caption">Marshal, Archon, Fleet, Autopilot</div>
     </div>
     <div class="stat">
-      <div class="stat-num">14</div>
+      <div class="stat-num">29</div>
       <div class="stat-label">Hook Events</div>
       <div class="stat-caption">automatic quality gates without agent intervention</div>
     </div>
@@ -1806,7 +1806,7 @@
   <!-- Skills panel -->
   <div class="side-panel" id="panel-skills">
     <div class="panel-header">
-      <span class="panel-title">Skills — 34 installed</span>
+      <span class="panel-title">Skills — 45 installed</span>
       <button class="panel-close" onclick="closePanel()">✕</button>
     </div>
     <div class="panel-body">


### PR DESCRIPTION
Stats row on the public demo page was showing 34 skills and 14 hook events. Updated to reflect the current state: 45 skills, 29 lifecycle events.

Three spots updated: stat bar (×2) and Skills panel header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)