### PR TITLE
Normalize compatibility fixture newlines

### DIFF
--- a/scripts/test-compat-fixtures.js
+++ b/scripts/test-compat-fixtures.js
@@ -56,11 +56,16 @@ function readFixture(name) {
   return fs.readFileSync(p, 'utf8');
 }
 
+function normalizeSnapshot(str) {
+  return str.replace(/\r\n/g, '\n');
+}
+
 function compareFixture(label, fixtureName, generated) {
   check(label, () => {
-    const expected = readFixture(fixtureName);
-    if (generated !== expected) {
-      const genLines = generated.split('\n');
+    const expected = normalizeSnapshot(readFixture(fixtureName));
+    const actual = normalizeSnapshot(generated);
+    if (actual !== expected) {
+      const genLines = actual.split('\n');
       const expLines = expected.split('\n');
       let firstDiff = -1;
       for (let i = 0; i < Math.max(genLines.length, expLines.length); i++) {


### PR DESCRIPTION
## Summary
- Normalize line endings before comparing generated compatibility snapshots to checked-in fixtures
- Keep fresh Windows worktrees from failing fixture checks due to CRLF/LF checkout differences

## Verification
- `node scripts/test-compat-fixtures.js`
- `node scripts/test-all.js --strict`