### PR TITLE
docs: add Citadel demo workflow

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -1,0 +1,100 @@
+# Citadel Demo Workflow
+
+This demo takes an existing repository, initializes Citadel, then asks it to improve confidence in the project by routing a real task, using local memory, verifying safely, and reporting cost or telemetry where the runtime supports it.
+
+The point is not to tour every feature. The point is to show what changes when Claude Code or OpenAI Codex has a repo-local operating layer: setup, memory, routing, safety, verification, and reporting become part of the project instead of one-off chat discipline.
+
+## Core Demo: 5 minutes, works in most repos
+
+Open the repository you want Citadel to manage in Claude Code or OpenAI Codex.
+
+If Citadel is not installed yet, paste the install prompt from [README.md](README.md#quick-install), follow any runtime-specific plugin enable step, then start a fresh session if the runtime asks for one.
+
+Run these commands:
+
+```text
+/do setup --express
+/do review README.md for first-time developer friction
+/do identify the project's safest verification command and run it
+/cost
+```
+
+### What each command demonstrates
+
+**`/do setup --express`** creates or refreshes repo-local Citadel state. It detects the project, sets up the harness state Citadel uses, and installs or refreshes hooks where the runtime supports them.
+
+**`/do review README.md for first-time developer friction`** demonstrates `/do` routing. The user describes an engineering intent, and Citadel routes the work to the right review workflow instead of requiring the user to pick a skill first.
+
+**`/do identify the project's safest verification command and run it`** demonstrates disciplined verification without assuming a stack. In a Node repo this might be `npm test`; in another repo it may be a lint command, typecheck, unit test, docs check, or a read-only verification path.
+
+**`/cost`** demonstrates visibility into usage where telemetry is available. If the current runtime has no cost data yet, the useful result is still explicit: Citadel should report what it can see and what is unavailable.
+
+## What to Look For
+
+After the core demo, check for concrete evidence:
+
+- `.planning/` exists or was refreshed.
+- Project memory, campaign, verification, telemetry, or handoff files are created or updated when available for the runtime and task.
+- Verification output is captured, summarized, or turned into a clear next step.
+- Cost telemetry is visible when supported by the runtime.
+- The agent produces a concrete report: what it found, what it changed or did not change, what passed, and what should happen next.
+
+The important behavior is continuity. A later session should be able to inspect local Citadel state and continue from project evidence instead of starting from a blank chat.
+
+## Canonical Example
+
+Citadel itself is the canonical proof target because it has real docs, real skills, real hooks, and a real test suite.
+
+From a Citadel clone, the verification command the agent should discover is:
+
+```bash
+npm run test
+```
+
+You can substitute your own repository. The core demo is intentionally written around project intent, not Citadel-specific file paths, so the same workflow works on most repos:
+
+```text
+/do setup --express
+/do review README.md for first-time developer friction
+/do identify the project's safest verification command and run it
+/cost
+```
+
+## Advanced Demo: parallel orchestration
+
+Use this only when you are ready for multiple agents to work in isolated git worktrees and produce changes you will review before accepting.
+
+Fleet has stable user-facing commands. A believable advanced demo is:
+
+```text
+/fleet split a polish pass across docs, install flow, and verification in isolated worktrees
+```
+
+What to look for:
+
+- Fleet creates or updates state under `.planning/fleet/`.
+- Agents work on independent scopes rather than stepping on the same files.
+- Discoveries and handoffs are summarized back to the coordinator.
+- Merge review remains explicit; do not accept parallel changes blindly.
+
+If the task is not actually parallel, Citadel should downgrade or recommend a lighter workflow. That is a feature, not a failure: Fleet is for independent streams, not every task.
+
+## Before and After
+
+**Before Citadel:** every agent session starts from scratch. You re-explain project context, choose workflows manually, remember safety rules yourself, and reconstruct what happened after the session ends.
+
+**After Citadel:** setup, memory, routing, safety, verification, and cost visibility are part of the repo. The agent still does the work, but Citadel gives it an operating loop that can be inspected and repeated.
+
+## Recording the demo
+
+For a 90-second proof clip, record the core demo in a real terminal or agent window:
+
+1. Open a real repository.
+2. Paste the install prompt if needed.
+3. Run `/do setup --express`.
+4. Run the README friction review.
+5. Run the safest verification command.
+6. Show `/cost` or the explicit message that telemetry is not available yet.
+7. Show the final report and the `.planning/` evidence.
+
+Keep the recording practical: real repo, real commands, real output.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="assets/citadel-hero.svg" width="100%" alt="Citadel - The Operating System for Autonomous Engineering" />
+<img src="assets/citadel-hero.svg" width="100%" alt="Citadel - agent orchestration for Claude Code and OpenAI Codex" />
 
 <div align="center">
 
@@ -6,42 +6,55 @@
 ![Node.js 18+](https://img.shields.io/badge/Node.js-18%2B-green.svg)
 ![Claude Code](https://img.shields.io/badge/Claude_Code-compatible-blueviolet.svg)
 ![Codex](https://img.shields.io/badge/Codex-compatible-5865F2.svg)
-[![Interactive Demo](https://img.shields.io/badge/▶_Try_the_Router-00d2ff.svg)](https://sethgammon.github.io/Citadel/)
+[![GitHub stars](https://img.shields.io/github/stars/SethGammon/Citadel?style=social)](https://github.com/SethGammon/Citadel/stargazers)
+[![Interactive Demo](https://img.shields.io/badge/Try_the_Router-00d2ff.svg)](https://sethgammon.github.io/Citadel/)
 
-*Stop re-explaining your codebase every session. Start compounding what your agents learn.*
+**Citadel is an open-source orchestration layer for Claude Code and OpenAI Codex.**
 
----
+It gives your coding agent durable project memory, `/do` intent routing, safety hooks, cost telemetry, and parallel agents in isolated git worktrees.
 
-**[Follow on X](https://x.com/SethGammon)** for updates · **[Join the discussion](https://github.com/SethGammon/Citadel/discussions)**
+Citadel is for developers who want AI coding agents to work across real projects, not just isolated chats.
+
+**Fast path:** open your project in Claude Code or Codex, paste the install prompt below, then run:
+
+```text
+/do setup --express
+```
+
+[Install](#quick-install) | [Demo Workflow](DEMO.md) | [Why It Exists](#why-citadel-exists) | [Roadmap](#roadmap)
 
 </div>
 
-## What Is Citadel
-
-Citadel is an agent orchestration harness for Claude Code and OpenAI Codex. It gives your coding agent durable project memory, installable skills, safety hooks, and parallel campaign coordination.
-
-In practice, that means:
-
-- `/do` routes plain-English requests to the right workflow.
-- Campaign state survives new sessions and context resets.
-- Fleet mode can split large work across isolated worktrees.
-- Hooks enforce quality, safety, telemetry, and handoff rules automatically.
-
-## Why Citadel Exists
-
-**Without Citadel**, every agent session starts from zero. You re-explain architecture decisions. You re-discover that the auth module is fragile. You copy-paste the same review checklist. When a task is too big for one agent, you manually split it and lose context between the pieces. Your agents never get better at your codebase — you just get better at prompting them.
-
-**With Citadel**, sessions resume where they left off. A `/do review` runs a structured 5-pass review that remembers what broke last time. A `/do overhaul the API layer` spawns parallel agents in isolated worktrees, shares discoveries between them, and merges the results. Skills you build once compound across every future session. The system learns from its own mistakes through campaign persistence and telemetry.
-
-The difference: `CLAUDE.md` and `AGENTS.md` tell the runtime about your project. Citadel gives the runtime the *infrastructure to work autonomously* — routing, memory, safety hooks, and coordination that a single guidance file can't provide.
-
 ---
+
+## What Is Citadel?
+
+Citadel turns one-off coding-agent chats into repeatable engineering workflows.
+
+Claude Code and OpenAI Codex are strong at local reasoning and code edits, but each session still needs project context, safe operating rules, task routing, and a way to continue work after context resets. Citadel provides that harness layer:
+
+- **Project memory:** project state, decisions, discoveries, telemetry, and handoffs live in repo-local `.planning/` files.
+- **Routing:** `/do` classifies plain-English requests and dispatches to the right skill or orchestrator.
+- **Hooks:** lifecycle checks enforce file protection, quality gates, telemetry, and safety policies.
+- **Parallelism:** Fleet mode splits large work across agents running in isolated git worktrees.
+
+If `CLAUDE.md` and `AGENTS.md` tell the runtime what your project is, Citadel tells the runtime how to operate on it.
 
 ## Quick Install
 
-**Prerequisites:** Claude Code or OpenAI Codex already installed, plus Node.js 18+.
+**Prerequisites:** Claude Code or OpenAI Codex, Node.js 18+, and a git repository you want Citadel to manage.
 
-Open your target project in your agent and paste this message:
+### Recommended: Paste This Into Your Agent
+
+The setup sequence is:
+
+1. Open the repository you want Citadel to manage in Claude Code or OpenAI Codex.
+2. Paste the install prompt below.
+3. Let the installer run and follow any plugin enable step it prints.
+4. Start a fresh session if the runtime asks for one.
+5. Run `/do setup --express`.
+
+Paste this:
 
 ```text
 Install Citadel in this repository.
@@ -59,26 +72,120 @@ Use the current repository as the target project. Do not require placeholder
 path edits.
 ```
 
-The agent will clone or update Citadel, install it for the current runtime, use the current repo as the target, and tell you if a plugin approval step is required.
+That prompt is intentionally path-free. The agent should clone or update Citadel, choose the correct runtime installer, and use the repository it is already running in as the target.
 
-Want to install it yourself instead? Read [INSTALL.md](INSTALL.md). That page has the manual Codex and Claude Code commands, dry-run commands, and verification steps.
+### Manual Fallback
 
-After setup, try:
+Only use this path if you want to run the installer yourself.
 
-```text
-/do review src/main.ts
+First, clone Citadel once:
+
+```bash
+git clone https://github.com/SethGammon/Citadel.git ~/Citadel
 ```
 
-What gets checked: plugin manifest, local marketplace, skill paths, hook bundle, MCP config, project guidance, runtime shell or sandbox settings, and readiness evidence under `.planning/verification/`.
+Then run exactly one installer from the target project root.
 
----
+For OpenAI Codex:
+
+```bash
+node ~/Citadel/scripts/install.js --runtime codex --add-marketplace
+```
+
+For Claude Code:
+
+```bash
+node ~/Citadel/scripts/install.js --runtime claude --install --scope local
+```
+
+Then start a fresh Codex or Claude Code session in the same project and run:
+
+```text
+/do setup --express
+```
+
+That is the important command. Express setup auto-detects the project, installs or refreshes hooks, scaffolds Citadel state, and gets you to a working `/do` command without a tour.
+
+For a copyable first-run walkthrough, see [DEMO.md](DEMO.md). For runtime-specific details, dry runs, and troubleshooting, see [INSTALL.md](INSTALL.md) and [QUICKSTART.md](QUICKSTART.md).
+
+## Demo Workflow
+
+After install, copy this into Claude Code or Codex from your project root:
+
+```text
+/do setup --express
+/do review README.md
+/do identify the project's safest verification command and run it
+/do generate tests for the changed files
+/cost
+```
+
+Then try a larger task:
+
+```text
+/do audit the auth module and fix the highest-risk issue
+/do continue
+```
+
+For a live visual of the router tiers, open the [interactive routing demo](https://sethgammon.github.io/Citadel/).
+
+## Why Citadel Exists
+
+Claude Code and Codex made local agentic development practical. The next problem is operational: how do you make those agents reliable across real projects, repeated sessions, and larger tasks?
+
+Without a harness, you keep solving the same coordination problems by hand:
+
+- Re-explaining architecture and project conventions in every session.
+- Asking the agent to choose between review, debugging, refactor, test generation, or planning workflows.
+- Losing decisions and discoveries when context compresses or a session ends.
+- Manually splitting large tasks across branches or worktrees.
+- Rebuilding safety rules, cost checks, and handoff discipline in prompts.
+
+Citadel exists to make Claude Code and Codex easier to operate as engineering systems. It adds the missing layer around the runtime: persistent state, intent routing, lifecycle enforcement, telemetry, and coordinated multi-agent execution.
+
+## Core Features
+
+**Durable project memory.** Citadel stores campaign files, fleet sessions, discoveries, intake, and telemetry under `.planning/` so work can resume after a fresh thread or context reset.
+
+**`/do` routing.** Describe the task once. The router handles cheap pattern matching first, then skill lookup, then LLM classification only when needed.
+
+**Safety hooks.** Node-based hooks run across lifecycle events to protect files, gate risky external actions, track edits, enforce policy, and record handoffs.
+
+**Cost tracking.** Runtime-native telemetry feeds `/cost`, `/dashboard`, and local reports so token usage and session spend are visible instead of guessed.
+
+**Parallel agents in isolated worktrees.** Fleet mode decomposes broad work, assigns scopes to agents, shares discoveries between waves, and keeps merge review organized.
+
+**Repeatable setup.** Runtime-specific installers plus `/do setup --express` produce the same project state on Codex and Claude Code without copying prompt fragments between repos.
+
+## Proof It Is Real
+
+Citadel is not a pitch deck. The repository contains the harness:
+
+- Dozens of built-in skills under [`skills/`](skills/), including review, refactor, test generation, Fleet, Archon, QA, telemetry, and setup.
+- Hook source under [`hooks_src/`](hooks_src/) and generated hook manifests under [`hooks/`](hooks/) for project installation.
+- Runtime adapters for Claude Code and Codex under [`runtimes/`](runtimes/) plus package surfaces under [`packages/`](packages/).
+- Installer and verification scripts under [`scripts/`](scripts/), including `scripts/test-all.js`, hook verification, runtime checks, and skill linting.
+- Public docs for [campaigns](docs/CAMPAIGNS.md), [fleet coordination](docs/FLEET.md), [hooks](docs/HOOKS.md), [Codex install](docs/CODEX_INSTALLATION_GUIDE.md), and [Claude Code install](docs/CLAUDE_INSTALLATION_GUIDE.md).
+
+Run the local verification suite from a Citadel clone:
+
+```bash
+npm test
+```
+
+## Current Traction
+
+- **Open source:** MIT-licensed public repo at [github.com/SethGammon/Citadel](https://github.com/SethGammon/Citadel).
+- **GitHub interest:** see the live stars badge at the top of this README.
+- **Community surface area:** discussion happens through [GitHub Discussions](https://github.com/SethGammon/Citadel/discussions) and [X](https://x.com/SethGammon).
+- **External discovery:** Citadel is discoverable through Claude Code plugin and skill directory surfaces, with GitHub as the canonical source for install and contribution.
 
 ## How It Works
 
 Say what you want. `/do` routes it to the lightest workflow that can handle it.
 
-```
-/do fix the typo on line 42        # Direct edit, no model call
+```text
+/do fix the typo on line 42        # Fast local routing path
 /do review the auth module         # 5-pass structured code review
 /do why is the API returning 500   # Root cause analysis
 /do build a caching layer          # Multi-step orchestrated build
@@ -87,101 +194,64 @@ Say what you want. `/do` routes it to the lightest workflow that can handle it.
 
 Classification runs across four tiers:
 
-1. **Pattern match** — catches trivial commands with regex. Zero tokens, zero model calls, instant.
-2. **Session state** — checks if you're mid-campaign and resumes it. Still zero tokens.
-3. **Keyword lookup** — scans your input against installed skill keywords ("review", "test", "refactor") and routes directly. Still zero tokens.
-4. **LLM classification** — only when tiers 1-3 don't match, a structured complexity analysis (~500 tokens) determines whether you need a single-step Marshal, a multi-session Archon, or a parallel Fleet.
+1. **Pattern match** - catches trivial commands with regex. Zero tokens, zero model calls.
+2. **Session state** - checks whether you are mid-campaign and resumes it.
+3. **Keyword lookup** - routes known task language to installed skill keywords.
+4. **LLM classification** - only when tiers 1-3 do not match, analyzes complexity and chooses Skill, Marshal, Archon, or Fleet.
 
-Most requests resolve at tiers 1-3 for free. Tier 4 is the exception, not the default. You never have to choose the tool.
+Most requests resolve before tier 4. You describe the task; Citadel chooses the workflow.
 
-**[See it route live](https://sethgammon.github.io/Citadel/)**
+## Orchestration Ladder
 
-## The Orchestration Ladder
-
-Four tiers. Use the lightest one that fits.
+Four tiers let Citadel scale from a small edit to a multi-session campaign:
 
 - **Skill:** direct domain workflow for focused tasks.
 - **Marshal:** single-session commander for multi-step work.
 - **Archon:** multi-session campaign planner and executor.
 - **Fleet:** parallel agents in isolated worktrees with shared discoveries.
 
----
+## Roadmap
 
-## What You Get
+Citadel is being developed around practical builder needs:
 
-**Cost transparency.** Citadel reads runtime-native session artifacts and computes real cost from API pricing. Use `/cost` for a breakdown or `/dashboard` for the overview.
+- **Campaign recovery:** better rollback, resume, and repair tools for interrupted long-running work.
+- **Codex parity:** tighter native support for Codex plugin packaging, hooks, MCP wiring, and app verification.
+- **Fleet merge discipline:** clearer merge-review queues, conflict handling, and branch hygiene for parallel agents.
+- **Team workflows:** shared campaign visibility, project policy templates, and safer defaults for repositories with multiple operators.
+- **Observability:** better local dashboards for hook activity, cost, campaign health, and agent throughput.
 
-**Safety hooks.** 32 hooks across 29 lifecycle events guard file access, external actions, protected branches, secrets, and repeated tool failures. Project policy lives in `harness.json`.
-
-**Campaign persistence.** Multi-session work survives context compression and session boundaries. `/do continue` resumes saved state, decisions, and progress.
-
-**Parallel coordination.** Fleet mode spawns multiple agents in isolated git worktrees, shares discoveries between them, and keeps merge work organized.
-
-**Autonomous quality improvement.** `/evolve` scores a target against a rubric, validates improvement hypotheses, runs focused cycles, and records reusable lessons for later sessions.
-
-## FAQ
-
-**Is this for me?** If you're running Claude Code or Codex on a real codebase and finding that agents lose context, repeat mistakes, or can't work in parallel, yes. If you're still exploring either runtime for the first time, Citadel is most useful once you have a real repository and repeat workflows.
-
-**How is this different from `CLAUDE.md` or `AGENTS.md`?** Those files tell the runtime about your project. Citadel tells the runtime *how to work*: durable state, intelligent routing, automated safety, and native parallelism — the infrastructure layer those files assume someone else built.
-
-**Do I need to learn all 45 skills?** No. Just use `/do` and describe what you want in plain English. The router picks the right skill. You can go months without ever typing a skill name directly.
-
-**What if `/do` routes to the wrong tool?** Tell it "wrong tool" or invoke the skill directly: `/review`, `/archon`, `/fleet`, and so on. The router is a convenience, not a gate.
-
-**How much does it cost in tokens?** Citadel adds ~2.5% overhead to your session cost. Skills cost zero when not loaded. The `/do` router costs ~500 tokens only at Tier 4. Use `/cost` to see real token data and exact spend for any session or campaign.
-
-**How is this different from CrewAI, LangChain, or Aider?** Those are agent frameworks: they give you primitives for building agents from scratch. Citadel is an *operating system for an existing coding agent*. You install a plugin and get routing, persistence, parallelism, and safety hooks on top of the agent you already use.
-
-**Does it work with Claude Code?** Yes. Citadel ships a Claude Code marketplace and plugin manifest, and `scripts/claude-install.js --install --scope local` validates the marketplace, installs the plugin into the target project scope, and writes resolved hook paths before you run `/do setup`.
-
-**Does it work with OpenAI Codex?** Yes. Citadel ships as a Codex plugin with bundled skills, hooks, MCP config, and install-surface metadata. `scripts/codex-install.js` prepares the local marketplace and verifies the target project so the remaining Codex app step is the normal **Add to Codex** install click.
-
-**Does this work on Windows?** Yes. All hooks and scripts run on Node.js. The Codex installer also runs the Windows sandbox/shell readiness check when it runs on Windows.
+The priority is reliability over novelty: make the harness easier to install, easier to verify, and harder to misuse.
 
 ## Learn More
 
-- [**Interactive routing demo**](https://sethgammon.github.io/Citadel/) — type any task, watch the tier cascade animate
-- [Install](INSTALL.md) — manual setup for Codex or Claude Code
-- [Quickstart](QUICKSTART.md) — first-run paths for both runtimes
-- [Skills reference](docs/SKILLS.md) — all 45 skills with invocation and examples
-- [Hooks reference](docs/HOOKS.md) — 29 lifecycle events, 32 hooks, what each one enforces
-- [Campaign guide](docs/CAMPAIGNS.md) — persistent state, phases, AI amnesia prevention
-- [Fleet guide](docs/FLEET.md) — parallel agents, worktree isolation, discovery relay
-- [Security model](SECURITY.md) — path traversal, shell injection, and defensive measures
-- [Contributing](CONTRIBUTING.md) — how to submit issues, PRs, and new skills
+- [Install](INSTALL.md) - manual setup for Codex and Claude Code
+- [Demo workflow](DEMO.md) - copyable operating-loop demo for a real repo
+- [Quickstart](QUICKSTART.md) - first-run paths for both runtimes
+- [Interactive routing demo](https://sethgammon.github.io/Citadel/) - watch the tier cascade animate
+- [Skills reference](docs/SKILLS.md) - all built-in skills with invocation and examples
+- [Hooks reference](docs/HOOKS.md) - lifecycle events and enforcement behavior
+- [Campaign guide](docs/CAMPAIGNS.md) - persistent state, phases, and handoffs
+- [Fleet guide](docs/FLEET.md) - parallel agents, worktree isolation, discovery relay
+- [Security model](SECURITY.md) - path traversal, shell injection, and defensive measures
+- [Contributing](CONTRIBUTING.md) - issues, PRs, skills, and docs
+
+## FAQ
+
+**Is this for me?** If you use Claude Code or Codex on a real repository and keep hitting context loss, repeated setup, weak handoffs, or manual coordination overhead, yes. Citadel is most useful once you have repeated workflows.
+
+**How is this different from `CLAUDE.md` or `AGENTS.md`?** Those files describe your project. Citadel adds the operating layer around the agent: routing, memory, hooks, telemetry, and parallel coordination.
+
+**Do I need to learn all 45 skills?** No. Use `/do` and describe what you want. Direct skill commands are available when you want explicit control.
+
+**How much token overhead does it add?** Skills cost zero when not loaded. Router tiers 1-3 are local checks; tier 4 uses a small LLM classification only when needed. Use `/cost` to inspect real usage.
+
+**Does it work on Windows?** Yes. Hooks and scripts run on Node.js, and the Codex installer includes Windows readiness checks.
 
 ## Community
 
-- **[X / Twitter](https://x.com/SethGammon)** — follow for updates and what's being built
-- **[GitHub Discussions](https://github.com/SethGammon/Citadel/discussions)** — use cases, questions, requests, show and tell
-
-Have a use case, a bug, or a workflow you want optimized? Open a Discussion. If you're using this in production, say so — it helps prioritize what gets built next.
-
-[![Star on GitHub](https://img.shields.io/github/stars/SethGammon/Citadel?style=social)](https://github.com/SethGammon/Citadel)
-
-### Roadmap
-
-- [x] Multi-runtime support (Claude Code + Codex CLI)
-- [x] Fleet mode with worktree isolation
-- [x] Campaign persistence across sessions
-- [x] Desktop app for campaign management
-- [x] Autonomous quality improvement engine (`/evolve` — research-driven multi-cycle director)
-- [x] Governance layer (3-tier policy constitution, policy-enforcer agent, immutable audit log)
-- [ ] Campaign recovery and rollback
-- [ ] Web dashboard (Citadel Cloud)
-- [ ] Team collaboration features
-
-### Contributing
-
-Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for how to:
-- Submit issues with bug reports or feature requests
-- Create pull requests for skills, hooks, or docs
-- Share your use cases and workflows
-
----
+- [GitHub Discussions](https://github.com/SethGammon/Citadel/discussions) - questions, use cases, bugs, and workflow requests
+- [X / Twitter](https://x.com/SethGammon) - project updates
 
 ## License
 
 MIT
-


### PR DESCRIPTION
## Summary
- add a copyable Citadel demo workflow focused on a real operating loop
- link the demo from the README near the top, after Quick Install, and in Learn More
- keep the core demo repo-agnostic and move Fleet into an optional advanced section

## Verification
- npm run test