### PR TITLE
Add first-use operator journey check

### DIFF
--- a/scripts/dashboard.js
+++ b/scripts/dashboard.js
@@ -935,7 +935,7 @@ function buildRepairItems(snapshot) {
   if (!snapshot.planningExists) {
     repairs.push(action({
       label: 'Initialize Citadel state',
-      command: '/do setup',
+      command: '/do setup --express',
       why: '.planning/ is missing, so campaigns, intake, telemetry, and dashboard state cannot be trusted yet.',
       confidence: 'high',
       repairAvailable: true,
@@ -1103,7 +1103,7 @@ function renderDashboard(snapshot) {
   lines.push(`  Repair available: ${snapshot.nextAction.repairAvailable ? 'yes' : 'no'}`);
   if (snapshot.nextAction.runbook) lines.push(`  Runbook: ${snapshot.nextAction.runbook}`);
   if (!snapshot.planningExists) {
-    lines.push('  Run /do setup to initialize.');
+    lines.push('  Run /do setup --express to initialize.');
   }
 
   lines.push('');

--- a/scripts/next-action.js
+++ b/scripts/next-action.js
@@ -124,13 +124,17 @@ function compactTimestamp(value) {
   return date.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
 }
 
+function isSetupCommand(command) {
+  return command === '/do setup' || command === '/do setup --express';
+}
+
 function approvalBoundaryFor(action) {
   const command = String(action?.command || '').trim();
   if (!command) return 'manual-review';
   if (command === '/autopilot') return 'campaign-intake';
   if (command === '/do continue') return 'agent-continuation';
   if (command === '/merge-review') return 'merge-review';
-  if (command === '/do setup') return 'project-setup';
+  if (isSetupCommand(command)) return 'project-setup';
   if (command === '/telemetry') return 'telemetry-review';
   if (command.startsWith('/')) return 'agent-route';
   if (command.startsWith('git status')) return 'worktree-review';
@@ -142,7 +146,7 @@ function approvalRiskFor(action) {
   if (command === '/autopilot') return 'medium-high';
   if (command === '/do continue') return 'medium';
   if (command === '/merge-review') return 'medium';
-  if (command === '/do setup') return 'medium';
+  if (isSetupCommand(command)) return 'medium';
   if (command === '/telemetry') return 'low';
   if (command.startsWith('git status')) return 'low';
   return 'medium';
@@ -171,7 +175,7 @@ function verificationPlanFor(action) {
       'Confirm dashboard merge-review queue count falls or the remaining blocker is documented.',
     ];
   }
-  if (command === '/do setup') {
+  if (isSetupCommand(command)) {
     return [
       'Run `node scripts/dashboard.js --json` and confirm `.planning/` exists.',
       'Confirm generated project guidance paths point at the current project root.',

--- a/scripts/pr-ready.js
+++ b/scripts/pr-ready.js
@@ -14,6 +14,7 @@ function parseArgs(argv) {
     verification: '',
     verificationSpecified: false,
     runVerification: false,
+    branch: '',
     json: false,
     help: false,
   };
@@ -27,6 +28,7 @@ function parseArgs(argv) {
       args.verificationSpecified = true;
     }
     else if (arg === '--run-verification') args.runVerification = true;
+    else if (arg === '--branch') args.branch = argv[++index] || '';
     else if (arg === '--json') args.json = true;
     else if (arg === '--help' || arg === '-h') args.help = true;
   }
@@ -39,6 +41,7 @@ function usage() {
     'Usage:',
     '  node scripts/pr-ready.js --pr <pull-request-url> --run-verification',
     '  node scripts/pr-ready.js --pr <pull-request-url> --verification "npm run test"',
+    '  node scripts/pr-ready.js --pr <pull-request-url> --branch <branch-name> --run-verification',
     '',
     'Writes .planning/pr-readiness/<branch>.md and exits 0 only when local readiness gates pass.',
     'When --verification is omitted, Citadel selects a verification profile from changed paths.',
@@ -172,7 +175,7 @@ function renderReport(readiness) {
 
 function assessReadiness(projectRoot, options = {}) {
   const root = path.resolve(projectRoot || process.cwd());
-  const branch = runGit(root, ['branch', '--show-current']) || 'detached';
+  const branch = options.branch || runGit(root, ['branch', '--show-current']) || 'detached';
   const head = runGit(root, ['rev-parse', '--short', 'HEAD']);
   const verificationProfile = selectVerificationProfile(root, {
     changedFiles: options.changedFiles,
@@ -252,6 +255,7 @@ function main() {
     pr: args.pr,
     verification: args.verification,
     runVerification: args.runVerification,
+    branch: args.branch,
   });
 
   if (args.json) {

--- a/scripts/test-all.js
+++ b/scripts/test-all.js
@@ -41,6 +41,7 @@ const CONTINUE_ACTION_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-continue-ac
 const NEXT_ACTION_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-next-action.js');
 const OPERATOR_CONSOLE_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-operator-console.js');
 const OPERATOR_JOURNEY_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-operator-journey.js');
+const FIRST_USE_OPERATOR_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-first-use-operator.js');
 const VERIFICATION_PLAN_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-verification-plan.js');
 const PR_READY_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-pr-ready.js');
 const STACK_PLAN_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-stack-plan.js');
@@ -69,7 +70,7 @@ const WORKTREE_READINESS_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-worktree
 const STRICT = process.argv.includes('--strict');
 
 console.log('\nCitadel Full Test Suite\n' + '='.repeat(40));
-console.log('Running: hook smoke test + security tests + runtime contract test + runtime registry test + runtime matrix test + hook event test + skill lint + demo routing check + telemetry core check + telemetry integrity check + memory block check + evidence contract check + sandbox provider check + skill packaging check + map substrate check + delivery preflight check + delivery package check + continue action check + next action check + operator console check + operator journey check + verification plan check + PR readiness check + stack plan check + coordination core check + hook installer check + campaign core check + discovery core check + discovery writer check + momentum synthesizer check + policy core check + Claude runtime check + Codex runtime check + Codex native integration check + Codex operational improvement check + installer check + project bootstrap check + compat fixtures + backward compat + cost tracker + dashboard + doc-sync + fleet session + worktree readiness\n');
+console.log('Running: hook smoke test + security tests + runtime contract test + runtime registry test + runtime matrix test + hook event test + skill lint + demo routing check + telemetry core check + telemetry integrity check + memory block check + evidence contract check + sandbox provider check + skill packaging check + map substrate check + delivery preflight check + delivery package check + continue action check + next action check + operator console check + operator journey check + first-use operator check + verification plan check + PR readiness check + stack plan check + coordination core check + hook installer check + campaign core check + discovery core check + discovery writer check + momentum synthesizer check + policy core check + Claude runtime check + Codex runtime check + Codex native integration check + Codex operational improvement check + installer check + project bootstrap check + compat fixtures + backward compat + cost tracker + dashboard + doc-sync + fleet session + worktree readiness\n');
 
 function run(label, scriptPath, extraArgs = []) {
   console.log(`\n> ${label}`);
@@ -109,6 +110,7 @@ const continueActionPassed = run('Continue Action Check', CONTINUE_ACTION_TEST);
 const nextActionPassed = run('Next Action Check', NEXT_ACTION_TEST);
 const operatorConsolePassed = run('Operator Console Check', OPERATOR_CONSOLE_TEST);
 const operatorJourneyPassed = run('Operator Journey Check', OPERATOR_JOURNEY_TEST);
+const firstUseOperatorPassed = run('First-Use Operator Check', FIRST_USE_OPERATOR_TEST);
 const verificationPlanPassed = run('Verification Plan Check', VERIFICATION_PLAN_TEST);
 const prReadyPassed = run('PR Readiness Check', PR_READY_TEST);
 const stackPlanPassed = run('Stack Plan Check', STACK_PLAN_TEST);
@@ -157,6 +159,7 @@ console.log(`  Continue action:    ${continueActionPassed ? 'PASS' : 'FAIL'}`);
 console.log(`  Next action:        ${nextActionPassed ? 'PASS' : 'FAIL'}`);
 console.log(`  Operator console:   ${operatorConsolePassed ? 'PASS' : 'FAIL'}`);
 console.log(`  Operator journey:   ${operatorJourneyPassed ? 'PASS' : 'FAIL'}`);
+console.log(`  First-use operator: ${firstUseOperatorPassed ? 'PASS' : 'FAIL'}`);
 console.log(`  Verification plan:  ${verificationPlanPassed ? 'PASS' : 'FAIL'}`);
 console.log(`  PR readiness:       ${prReadyPassed ? 'PASS' : 'FAIL'}`);
 console.log(`  Stack plan:         ${stackPlanPassed ? 'PASS' : 'FAIL'}`);
@@ -183,7 +186,7 @@ console.log(`  Fleet session:      ${fleetSessionPassed ? 'PASS' : 'FAIL'}`);
 console.log(`  Worktree readiness: ${worktreeReadinessPassed ? 'PASS' : 'FAIL'}`);
 console.log('');
 
-if (hooksPassed && securityPassed && contractsPassed && runtimeRegistryPassed && runtimeMatrixPassed && hookEventsPassed && skillsPassed && demoPassed && telemetryPassed && telemetryIntegrityPassed && memoryBlockPassed && evidenceContractPassed && sandboxProviderPassed && skillPackagingPassed && mapSubstratePassed && deliveryPassed && deliveryPackagePassed && continueActionPassed && nextActionPassed && operatorConsolePassed && operatorJourneyPassed && verificationPlanPassed && prReadyPassed && stackPlanPassed && coordinationPassed && hookInstallerPassed && campaignPassed && discoveryPassed && discoveryWriterPassed && momentumPassed && momentumWatcherPassed && policyPassed && claudeRuntimePassed && codexRuntimePassed && codexNativeIntegrationPassed && codexOperationalImprovementPassed && installerPassed && projectBootstrapPassed && compatFixturePassed && backwardCompatPassed && costTrackerPassed && dashboardPassed && docSyncPassed && fleetSessionPassed && worktreeReadinessPassed) {
+if (hooksPassed && securityPassed && contractsPassed && runtimeRegistryPassed && runtimeMatrixPassed && hookEventsPassed && skillsPassed && demoPassed && telemetryPassed && telemetryIntegrityPassed && memoryBlockPassed && evidenceContractPassed && sandboxProviderPassed && skillPackagingPassed && mapSubstratePassed && deliveryPassed && deliveryPackagePassed && continueActionPassed && nextActionPassed && operatorConsolePassed && operatorJourneyPassed && firstUseOperatorPassed && verificationPlanPassed && prReadyPassed && stackPlanPassed && coordinationPassed && hookInstallerPassed && campaignPassed && discoveryPassed && discoveryWriterPassed && momentumPassed && momentumWatcherPassed && policyPassed && claudeRuntimePassed && codexRuntimePassed && codexNativeIntegrationPassed && codexOperationalImprovementPassed && installerPassed && projectBootstrapPassed && compatFixturePassed && backwardCompatPassed && costTrackerPassed && dashboardPassed && docSyncPassed && fleetSessionPassed && worktreeReadinessPassed) {
   console.log('All tests pass.\n');
   console.log('Next steps:');
   console.log('  node scripts/skill-bench.js --list      see benchmark scenarios');
@@ -214,6 +217,7 @@ const continueActionFail = !continueActionPassed ? 64 : 0;
 const nextActionFail = !nextActionPassed ? 64 : 0;
 const operatorConsoleFail = !operatorConsolePassed ? 128 : 0;
 const operatorJourneyFail = !operatorJourneyPassed ? 128 : 0;
+const firstUseOperatorFail = !firstUseOperatorPassed ? 128 : 0;
 const verificationPlanFail = !verificationPlanPassed ? 128 : 0;
 const prReadyFail = !prReadyPassed ? 128 : 0;
 const stackPlanFail = !stackPlanPassed ? 128 : 0;
@@ -238,7 +242,7 @@ const dashboardFail = !dashboardPassed ? 33554432 : 0;
 const docSyncFail = !docSyncPassed ? 33554432 : 0;
 const fleetSessionFail = !fleetSessionPassed ? 67108864 : 0;
 const worktreeReadinessFail = !worktreeReadinessPassed ? 134217728 : 0;
-const code = hookFail | securityFail | contractFail | runtimeRegistryFail | runtimeMatrixFail | hookEventFail | skillFail | demoFail | telemetryFail | telemetryIntegrityFail | memoryBlockFail | evidenceContractFail | sandboxProviderFail | skillPackagingFail | mapSubstrateFail | deliveryFail | deliveryPackageFail | continueActionFail | nextActionFail | operatorConsoleFail | operatorJourneyFail | verificationPlanFail | prReadyFail | stackPlanFail | coordinationFail | hookInstallerFail | campaignFail | discoveryFail | discoveryWriterFail | momentumFail | momentumWatcherFail | policyFail | claudeRuntimeFail | codexRuntimeFail | codexNativeIntegrationFail | codexOperationalImprovementFail | installerFail | projectBootstrapFail | compatFixtureFail | backwardCompatFail | costTrackerFail | dashboardFail | docSyncFail | fleetSessionFail | worktreeReadinessFail;
+const code = hookFail | securityFail | contractFail | runtimeRegistryFail | runtimeMatrixFail | hookEventFail | skillFail | demoFail | telemetryFail | telemetryIntegrityFail | memoryBlockFail | evidenceContractFail | sandboxProviderFail | skillPackagingFail | mapSubstrateFail | deliveryFail | deliveryPackageFail | continueActionFail | nextActionFail | operatorConsoleFail | operatorJourneyFail | firstUseOperatorFail | verificationPlanFail | prReadyFail | stackPlanFail | coordinationFail | hookInstallerFail | campaignFail | discoveryFail | discoveryWriterFail | momentumFail | momentumWatcherFail | policyFail | claudeRuntimeFail | codexRuntimeFail | codexNativeIntegrationFail | codexOperationalImprovementFail | installerFail | projectBootstrapFail | compatFixtureFail | backwardCompatFail | costTrackerFail | dashboardFail | docSyncFail | fleetSessionFail | worktreeReadinessFail;
 
 if (!hooksPassed) console.log('Hook smoke test failed. Fix hook issues before proceeding.');
 if (!securityPassed) console.log('Security tests failed. DO NOT SHIP - critical vulnerabilities present.');
@@ -261,6 +265,7 @@ if (!continueActionPassed) console.log('Continue action check failed. Fix /do co
 if (!nextActionPassed) console.log('Next action check failed. Fix operator routing or deterministic repair execution before shipping.');
 if (!operatorConsolePassed) console.log('Operator console check failed. Fix decision-first operator rendering before shipping.');
 if (!operatorJourneyPassed) console.log('Operator journey check failed. Fix intake-to-package-to-archive operator flow before shipping.');
+if (!firstUseOperatorPassed) console.log('First-use operator check failed. Fix fresh-project /do next behavior before shipping.');
 if (!verificationPlanPassed) console.log('Verification plan check failed. Fix profile selection before shipping.');
 if (!prReadyPassed) console.log('PR readiness check failed. Fix final readiness gates or report generation before shipping.');
 if (!stackPlanPassed) console.log('Stack plan check failed. Fix PR readiness ordering or approval-boundary reporting before shipping.');

--- a/scripts/test-dashboard.js
+++ b/scripts/test-dashboard.js
@@ -89,9 +89,9 @@ withTempProject((projectRoot) => {
 
   assert(output.includes('Citadel Dashboard'));
   assert(output.includes('NEXT ACTION'));
-  assert.equal(snapshot.nextAction.command, '/do setup');
+  assert.equal(snapshot.nextAction.command, '/do setup --express');
   assert.equal(snapshot.nextAction.repairAvailable, true);
-  assert(output.includes('Command: /do setup'));
+  assert(output.includes('Command: /do setup --express'));
   assert(output.includes('OPERATOR ARTIFACTS'));
   assert(output.includes('(none recorded yet - run npm run next)'));
   assert(output.includes('REPAIR CONSOLE'));

--- a/scripts/test-first-use-operator.js
+++ b/scripts/test-first-use-operator.js
@@ -28,7 +28,7 @@ withTempProject((projectRoot) => {
   const dashboard = collectDashboard({ projectRoot, now: '2026-06-05T12:00:00.000Z' });
   const dashboardOutput = renderDashboard(dashboard);
 
-  assert.equal(dashboard.nextAction.command, '/do setup');
+  assert.equal(dashboard.nextAction.command, '/do setup --express');
   assert(!dashboardOutput.includes('undefined'));
   assert(!dashboardOutput.includes('ENOENT'));
 });
@@ -38,14 +38,14 @@ withTempProject((projectRoot) => {
   const consoleOutput = renderConsole(consoleState);
 
   assert.equal(consoleState.status, 'approval-needed');
-  assert.equal(consoleState.summary.command, '/do setup');
+  assert.equal(consoleState.summary.command, '/do setup --express');
   assert.equal(consoleState.summary.boundary, 'project-setup');
   assert.equal(consoleState.summary.risk, 'medium');
   assert.equal(consoleState.summary.canRunNow, false);
   assert.equal(consoleState.summary.approvalCapsulePath.startsWith('.planning/approval-capsules/'), true);
   assert.equal(consoleState.summary.latestApprovalCapsulePath, '.planning/approval-capsules/latest.md');
   assert(fs.existsSync(path.join(projectRoot, '.planning', 'approval-capsules', 'latest.md')));
-  assert(consoleOutput.includes('Approve running `/do setup` for this project.'));
+  assert(consoleOutput.includes('Approve running `/do setup --express` for this project.'));
   assert(consoleOutput.includes('Runbook: skills/setup/SKILL.md'));
   assert(!consoleOutput.includes('undefined'));
   assert(!consoleOutput.includes('ENOENT'));

--- a/scripts/test-first-use-operator.js
+++ b/scripts/test-first-use-operator.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { collectDashboard, renderDashboard } = require('./dashboard');
+const { buildConsole, renderConsole } = require('./operator-console');
+
+function withTempProject(run) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'citadel-first-use-'));
+  try {
+    return run(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function scaffoldPlanning(projectRoot) {
+  fs.mkdirSync(path.join(projectRoot, '.planning', 'campaigns'), { recursive: true });
+  fs.mkdirSync(path.join(projectRoot, '.planning', 'intake'), { recursive: true });
+  fs.mkdirSync(path.join(projectRoot, '.planning', 'telemetry'), { recursive: true });
+}
+
+withTempProject((projectRoot) => {
+  const dashboard = collectDashboard({ projectRoot, now: '2026-06-05T12:00:00.000Z' });
+  const dashboardOutput = renderDashboard(dashboard);
+
+  assert.equal(dashboard.nextAction.command, '/do setup');
+  assert(!dashboardOutput.includes('undefined'));
+  assert(!dashboardOutput.includes('ENOENT'));
+});
+
+withTempProject((projectRoot) => {
+  const consoleState = buildConsole(projectRoot, { run: false });
+  const consoleOutput = renderConsole(consoleState);
+
+  assert.equal(consoleState.status, 'approval-needed');
+  assert.equal(consoleState.summary.command, '/do setup');
+  assert.equal(consoleState.summary.boundary, 'project-setup');
+  assert.equal(consoleState.summary.risk, 'medium');
+  assert.equal(consoleState.summary.canRunNow, false);
+  assert.equal(consoleState.summary.approvalCapsulePath.startsWith('.planning/approval-capsules/'), true);
+  assert.equal(consoleState.summary.latestApprovalCapsulePath, '.planning/approval-capsules/latest.md');
+  assert(fs.existsSync(path.join(projectRoot, '.planning', 'approval-capsules', 'latest.md')));
+  assert(consoleOutput.includes('Approve running `/do setup` for this project.'));
+  assert(consoleOutput.includes('Runbook: skills/setup/SKILL.md'));
+  assert(!consoleOutput.includes('undefined'));
+  assert(!consoleOutput.includes('ENOENT'));
+});
+
+withTempProject((projectRoot) => {
+  scaffoldPlanning(projectRoot);
+
+  const consoleState = buildConsole(projectRoot, { run: false });
+  const output = renderConsole(consoleState);
+
+  assert.equal(consoleState.status, 'idle');
+  assert.equal(consoleState.summary.command, 'npm run dashboard');
+  assert.equal(consoleState.summary.boundary, 'none');
+  assert.equal(consoleState.summary.risk, 'low');
+  assert.equal(consoleState.summary.pending.docSync, 0);
+  assert.equal(consoleState.summary.pending.mergeReviews, 0);
+  assert.equal(consoleState.summary.pending.intakeItems, 0);
+  assert.equal(consoleState.summary.artifactsNeedAttention, 0);
+  assert.equal(consoleState.summary.approvalCapsulePath, null);
+  assert(output.includes('No urgent Citadel action detected'));
+  assert(!output.includes('undefined'));
+  assert(!output.includes('ENOENT'));
+});
+
+console.log('first-use operator tests passed');

--- a/scripts/test-pr-ready.js
+++ b/scripts/test-pr-ready.js
@@ -88,6 +88,29 @@ withTempProject((projectRoot) => {
 
   const readiness = assessReadiness(projectRoot, {
     pr: 'https://github.com/acme/repo/pull/12',
+    runVerification: true,
+    verification: 'npm run test',
+    branch: 'codex/explicit-pr-branch',
+  });
+
+  assert.equal(readiness.ready, true);
+  assert.equal(readiness.branch, 'codex/explicit-pr-branch');
+  assert.equal(readiness.reportPath, '.planning/pr-readiness/codex-explicit-pr-branch.md');
+  assert(fs.existsSync(path.join(projectRoot, readiness.reportPath)));
+});
+
+withTempProject((projectRoot) => {
+  initGit(projectRoot);
+  initPlanning(projectRoot);
+  write(path.join(projectRoot, 'package.json'), JSON.stringify({
+    scripts: { test: 'node test.js' },
+  }, null, 2));
+  write(path.join(projectRoot, 'test.js'), 'process.exit(0);\n');
+  childProcess.execFileSync('git', ['add', '.'], { cwd: projectRoot, stdio: 'ignore' });
+  childProcess.execFileSync('git', ['commit', '-m', 'init'], { cwd: projectRoot, stdio: 'ignore' });
+
+  const readiness = assessReadiness(projectRoot, {
+    pr: 'https://github.com/acme/repo/pull/12',
     runVerification: false,
     verification: 'npm run test',
     now: '2026-06-05T00:00:00.000Z',
@@ -123,6 +146,36 @@ withTempProject((projectRoot) => {
   assert.equal(readiness.ready, false);
   assert.equal(readiness.gates.prUrl.pass, false);
   assert.equal(readiness.gates.verification.pass, false);
+});
+
+withTempProject((projectRoot) => {
+  initGit(projectRoot);
+  initPlanning(projectRoot);
+  write(path.join(projectRoot, 'package.json'), JSON.stringify({
+    scripts: { test: 'node test.js' },
+  }, null, 2));
+  write(path.join(projectRoot, 'test.js'), 'process.exit(0);\n');
+  childProcess.execFileSync('git', ['add', '.'], { cwd: projectRoot, stdio: 'ignore' });
+  childProcess.execFileSync('git', ['commit', '-m', 'init'], { cwd: projectRoot, stdio: 'ignore' });
+
+  const output = childProcess.spawnSync(process.execPath, [
+    path.join(__dirname, 'pr-ready.js'),
+    '--project-root',
+    projectRoot,
+    '--pr',
+    'https://github.com/acme/repo/pull/12',
+    '--branch',
+    'codex/cli-pr-branch',
+    '--run-verification',
+    '--verification',
+    'npm run test',
+    '--json',
+  ], { encoding: 'utf8' });
+
+  assert.equal(output.status, 0);
+  const readiness = JSON.parse(output.stdout);
+  assert.equal(readiness.branch, 'codex/cli-pr-branch');
+  assert.equal(readiness.reportPath, '.planning/pr-readiness/codex-cli-pr-branch.md');
 });
 
 withTempProject((projectRoot) => {

--- a/skills/dashboard/SKILL.md
+++ b/skills/dashboard/SKILL.md
@@ -230,7 +230,7 @@ QUICK COMMANDS
 
 ### Step 4: FRINGE CASE HANDLING
 
-**`.planning/` missing:** All zeros, "(none active)"; add "Run /do setup to initialize."
+**`.planning/` missing:** All zeros, "(none active)"; add "Run /do setup --express to initialize."
 **harness.json missing or malformed:** Show "not configured" for hooks count; do not crash.
 **Malformed campaign file:** Skip it; note `(N campaign file(s) skipped — malformed)`.
 **Large telemetry files:** Read last 50 lines only.


### PR DESCRIPTION
## Summary

Adds focused first-use Operator Console coverage and aligns the fresh-project next action with the documented fastest path: `/do setup --express`.

A fresh project with no `.planning/` state now surfaces `/do setup --express` as the next action, renders a project-setup approval boundary, writes the approval capsule, and avoids leaking `undefined` or filesystem errors in user-facing output. The test also covers the initialized-but-empty path: once minimal planning directories exist, the console reports idle state instead of continuing to request setup.

This PR also hardens `scripts/pr-ready.js` with an explicit `--branch` override so stacked PR readiness reports can use the intended PR head branch even when the local checkout branch name differs.

## What Changed

- adds `scripts/test-first-use-operator.js`
- verifies fresh dashboard empty-state behavior points to `/do setup --express`
- verifies fresh operator behavior reports `approval-needed`, `project-setup`, risk `medium`, setup runbook, and an approval capsule
- verifies initialized empty planning state reports idle with no pending queues or artifact attention
- changes the dashboard missing-planning repair command from `/do setup` to `/do setup --express`
- teaches approval-capsule boundary/risk/verification logic to treat `/do setup` and `/do setup --express` as project setup
- updates the dashboard skill missing-planning hint to recommend `/do setup --express`
- wires the first-use check into `scripts/test-all.js` as `First-Use Operator Check`
- adds `--branch <branch-name>` to `scripts/pr-ready.js`
- covers explicit branch override behavior through module and CLI tests in `scripts/test-pr-ready.js`

## Verification

- `node scripts/test-first-use-operator.js` passed
- `node scripts/test-dashboard.js` passed
- `node scripts/test-next-action.js` passed
- `node scripts/test-pr-ready.js` passed
- `node scripts/skill-lint.js dashboard` passed
- `npm run test` passed with `First-Use Operator Check` and PR readiness override coverage included
- `node scripts/pr-ready.js --pr https://github.com/SethGammon/Citadel/pull/140 --branch codex/first-use-operator-journey --run-verification --json --project-root C:\Users\gammo\Desktop\Citadel` passed with all gates green on head `086f780`

## Live Readiness Evidence

- head commit: `086f780`
- worktree: clean
- dashboard repairs: none queued
- dashboard pending queues: `docSync: 0`, `mergeReviews: 0`, `intakeItems: 0`
- verification: `npm run test` exited 0 from the PR finalizer
- PR finalizer report: `.planning/pr-readiness/codex-first-use-operator-journey.md`
- stack planner status: `approval-needed`, 5 PRs, 0 blocked

## Stack

Stacked on PR #139 (`codex/stack-readiness-plan`). Keep this draft until #136 -> #137 -> #138 -> #139 are landed or this branch is retargeted.