### PR TITLE
Prefer express setup in first-use operator path

### DIFF
--- a/scripts/dashboard.js
+++ b/scripts/dashboard.js
@@ -935,7 +935,7 @@ function buildRepairItems(snapshot) {
   if (!snapshot.planningExists) {
     repairs.push(action({
       label: 'Initialize Citadel state',
-      command: '/do setup',
+      command: '/do setup --express',
       why: '.planning/ is missing, so campaigns, intake, telemetry, and dashboard state cannot be trusted yet.',
       confidence: 'high',
       repairAvailable: true,
@@ -1103,7 +1103,7 @@ function renderDashboard(snapshot) {
   lines.push(`  Repair available: ${snapshot.nextAction.repairAvailable ? 'yes' : 'no'}`);
   if (snapshot.nextAction.runbook) lines.push(`  Runbook: ${snapshot.nextAction.runbook}`);
   if (!snapshot.planningExists) {
-    lines.push('  Run /do setup to initialize.');
+    lines.push('  Run /do setup --express to initialize.');
   }
 
   lines.push('');

--- a/scripts/next-action.js
+++ b/scripts/next-action.js
@@ -124,13 +124,17 @@ function compactTimestamp(value) {
   return date.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}Z$/, 'Z');
 }
 
+function isSetupCommand(command) {
+  return command === '/do setup' || command === '/do setup --express';
+}
+
 function approvalBoundaryFor(action) {
   const command = String(action?.command || '').trim();
   if (!command) return 'manual-review';
   if (command === '/autopilot') return 'campaign-intake';
   if (command === '/do continue') return 'agent-continuation';
   if (command === '/merge-review') return 'merge-review';
-  if (command === '/do setup') return 'project-setup';
+  if (isSetupCommand(command)) return 'project-setup';
   if (command === '/telemetry') return 'telemetry-review';
   if (command.startsWith('/')) return 'agent-route';
   if (command.startsWith('git status')) return 'worktree-review';
@@ -142,7 +146,7 @@ function approvalRiskFor(action) {
   if (command === '/autopilot') return 'medium-high';
   if (command === '/do continue') return 'medium';
   if (command === '/merge-review') return 'medium';
-  if (command === '/do setup') return 'medium';
+  if (isSetupCommand(command)) return 'medium';
   if (command === '/telemetry') return 'low';
   if (command.startsWith('git status')) return 'low';
   return 'medium';
@@ -171,7 +175,7 @@ function verificationPlanFor(action) {
       'Confirm dashboard merge-review queue count falls or the remaining blocker is documented.',
     ];
   }
-  if (command === '/do setup') {
+  if (isSetupCommand(command)) {
     return [
       'Run `node scripts/dashboard.js --json` and confirm `.planning/` exists.',
       'Confirm generated project guidance paths point at the current project root.',

--- a/scripts/test-dashboard.js
+++ b/scripts/test-dashboard.js
@@ -89,9 +89,9 @@ withTempProject((projectRoot) => {
 
   assert(output.includes('Citadel Dashboard'));
   assert(output.includes('NEXT ACTION'));
-  assert.equal(snapshot.nextAction.command, '/do setup');
+  assert.equal(snapshot.nextAction.command, '/do setup --express');
   assert.equal(snapshot.nextAction.repairAvailable, true);
-  assert(output.includes('Command: /do setup'));
+  assert(output.includes('Command: /do setup --express'));
   assert(output.includes('OPERATOR ARTIFACTS'));
   assert(output.includes('(none recorded yet - run npm run next)'));
   assert(output.includes('REPAIR CONSOLE'));

--- a/scripts/test-first-use-operator.js
+++ b/scripts/test-first-use-operator.js
@@ -28,7 +28,7 @@ withTempProject((projectRoot) => {
   const dashboard = collectDashboard({ projectRoot, now: '2026-06-05T12:00:00.000Z' });
   const dashboardOutput = renderDashboard(dashboard);
 
-  assert.equal(dashboard.nextAction.command, '/do setup');
+  assert.equal(dashboard.nextAction.command, '/do setup --express');
   assert(!dashboardOutput.includes('undefined'));
   assert(!dashboardOutput.includes('ENOENT'));
 });
@@ -38,14 +38,14 @@ withTempProject((projectRoot) => {
   const consoleOutput = renderConsole(consoleState);
 
   assert.equal(consoleState.status, 'approval-needed');
-  assert.equal(consoleState.summary.command, '/do setup');
+  assert.equal(consoleState.summary.command, '/do setup --express');
   assert.equal(consoleState.summary.boundary, 'project-setup');
   assert.equal(consoleState.summary.risk, 'medium');
   assert.equal(consoleState.summary.canRunNow, false);
   assert.equal(consoleState.summary.approvalCapsulePath.startsWith('.planning/approval-capsules/'), true);
   assert.equal(consoleState.summary.latestApprovalCapsulePath, '.planning/approval-capsules/latest.md');
   assert(fs.existsSync(path.join(projectRoot, '.planning', 'approval-capsules', 'latest.md')));
-  assert(consoleOutput.includes('Approve running `/do setup` for this project.'));
+  assert(consoleOutput.includes('Approve running `/do setup --express` for this project.'));
   assert(consoleOutput.includes('Runbook: skills/setup/SKILL.md'));
   assert(!consoleOutput.includes('undefined'));
   assert(!consoleOutput.includes('ENOENT'));

--- a/skills/dashboard/SKILL.md
+++ b/skills/dashboard/SKILL.md
@@ -230,7 +230,7 @@ QUICK COMMANDS
 
 ### Step 4: FRINGE CASE HANDLING
 
-**`.planning/` missing:** All zeros, "(none active)"; add "Run /do setup to initialize."
+**`.planning/` missing:** All zeros, "(none active)"; add "Run /do setup --express to initialize."
 **harness.json missing or malformed:** Show "not configured" for hooks count; do not crash.
 **Malformed campaign file:** Skip it; note `(N campaign file(s) skipped — malformed)`.
 **Large telemetry files:** Read last 50 lines only.


### PR DESCRIPTION
## Summary

Updates the first-use operator path to recommend `/do setup --express` when `.planning/` is missing. This keeps the dashboard, Operator Console approval capsule, and dashboard skill guidance aligned with the public README and demo flow.

The approval boundary still treats both `/do setup` and `/do setup --express` as project setup, so existing setup handling remains compatible.

## What Changed

- changes missing-`.planning/` dashboard next action from `/do setup` to `/do setup --express`
- updates rendered dashboard guidance to match
- keeps `next-action` project-setup boundary and risk handling compatible with either setup command
- updates dashboard and first-use operator tests
- updates the dashboard skill fringe-case guidance

## Verification

- `node scripts/test-dashboard.js` passed
- `node scripts/test-first-use-operator.js` passed
- `node scripts/skill-lint.js dashboard` passed
- `npm run test` passed

## Review Pass

- Scope checked: this PR only changes setup command selection, compatibility handling, focused tests, and the dashboard skill guidance
- Copy checked: wording is command-specific and avoids broader onboarding claims
- Risk checked: existing `/do setup` boundary behavior remains accepted through `isSetupCommand()`
- Open review threads: none at time of review

## Stack

Stacked on PR #140 (`codex/first-use-operator-journey`). This is the follow-up fix from reviewing PR #140 against the current public install path.