### PR TITLE
Document Citadel threat model

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Citadel is not a pitch deck. The repository contains the harness:
 - Runtime adapters for Claude Code and Codex under [`runtimes/`](runtimes/) plus package surfaces under [`packages/`](packages/).
 - Installer and verification scripts under [`scripts/`](scripts/), including `scripts/test-all.js`, hook verification, runtime checks, and skill linting.
 - Public docs for [campaigns](docs/CAMPAIGNS.md), [fleet coordination](docs/FLEET.md), [hooks](docs/HOOKS.md), [Codex install](docs/CODEX_INSTALLATION_GUIDE.md), and [Claude Code install](docs/CLAUDE_INSTALLATION_GUIDE.md).
+- Trust-boundary docs in [SECURITY.md](SECURITY.md) and [THREAT_MODEL.md](THREAT_MODEL.md), covering local automation risk, generated state, hooks, approval gates, and public-artifact review.
 
 Run the local verification suite from a Citadel clone:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,168 +1,125 @@
 # Security
 
-This document describes Citadel's security model and defensive measures against common attack vectors.
+Citadel is a local agent orchestration harness. Installing it gives Claude Code
+or OpenAI Codex project-specific instructions, hooks, scripts, skills, and
+state files that help an agent operate on a repository.
 
-## Threat Model
+That is useful, but it is also privileged local automation. Treat an installed
+Citadel project like any other developer tool that can read project files, run
+commands, create branches, and write local state.
 
-Citadel hooks run in the same security context as Claude Code itself. The primary threats are:
+For the detailed trust-boundary map, see [THREAT_MODEL.md](THREAT_MODEL.md).
 
-1. **Path Traversal** — Malicious or confused agents attempting to access files outside the project root
-2. **Shell Injection** — Command injection via unsanitized user/agent input in shell commands
-3. **Secret Leakage** — Agents inadvertently reading .env files or other credential stores
-4. **Untracked Dependencies** — Installing packages not declared in version control
+## Supported Security Model
 
-## Defenses
+Citadel is designed for local developer machines and trusted repositories.
 
-### 1. Path Traversal Protection (`protect-files.js`)
+Supported:
 
-All file operations (Read/Write/Edit) are validated before execution:
+- local use inside a repository you control
+- Claude Code and OpenAI Codex sessions with normal tool approval boundaries
+- project-local state under `.planning/`, `.citadel/`, `.codex/`, `.claude/`,
+  and generated runtime configuration files
+- reviewable pull-request workflows for publishing harness changes
 
-```javascript
-// Blocks: ../../../etc/passwd
-// Blocks: /etc/passwd (absolute path outside project)
-// Allows: src/components/Button.tsx (relative to project root)
-```
+Not supported:
 
-**Implementation:**
-- Regex-based detection of `../` and `..\` sequences
-- Absolute path validation against `PROJECT_ROOT`
-- Fail-closed design: unexpected errors block the action
+- exposing Citadel-generated local dashboards, MCP servers, or helper services
+  to the public internet without additional authentication and review
+- installing Citadel in an untrusted repository without inspecting its existing
+  scripts, hooks, package tasks, and agent instructions
+- treating `.planning/` state as public by default
+- bypassing runtime approval prompts for destructive, networked, credential, or
+  publish actions
 
-**Test coverage:** `scripts/test-security.js` validates traversal attacks are blocked
+## Main Risks
 
-### 2. Shell Injection Prevention
+| Risk | Why it matters | Primary defenses |
+|---|---|---|
+| File overreach | Agents can request reads and edits across the project | protected path checks, project-root validation, reviewable diffs |
+| Secret leakage | Project files may contain tokens, `.env` values, or private planning notes | protected file rules, do-not-publish guidance, local-first state |
+| Shell command abuse | Hooks and scripts can run local commands | command validation, approval gates, non-shell argument APIs where possible |
+| Prompt injection | Repo docs, issues, PRs, web pages, or generated artifacts can contain hostile instructions | instruction hierarchy, explicit trust boundaries, review before automation |
+| Unattended automation drift | Long-running agents can make broad changes if scope is unclear | campaign state, handoffs, approval capsules, PR readiness checks |
+| Public artifact leakage | `.planning/` can contain project decisions, costs, logs, screenshots, or research | `.gitignore` coverage, private-state guidance, review before sharing |
 
-All git operations use `execFileSync` with array arguments instead of shell strings:
+## Defensive Hooks and Checks
 
-```javascript
-// ✅ Safe (no shell interpretation):
-execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' })
+Citadel includes defensive hooks and test coverage for common local automation
+risks:
 
-// ❌ Vulnerable (shell injection risk):
-execSync(`git rev-parse ${branch}`)  // if branch = "; rm -rf /"
-```
+- path traversal and protected-file checks in `hooks_src/protect-files.js`
+- external action and consent checks in `hooks_src/external-action-gate.js`
+- governance and policy checks in `hooks_src/governance.js`
+- post-edit tracking and quality checks in `hooks_src/post-edit.js` and related
+  lifecycle hooks
+- telemetry and audit records under `.planning/telemetry/`
+- security regression tests in `scripts/test-security.js`
 
-**Files using execFileSync:**
-- `quality-gate.js` — git operations for lint checks
-- `harness-health-util.js` — git status queries
-- `post-edit.js` — file tracking
-
-**Test coverage:** `scripts/test-security.js` verifies safe APIs are used
-
-### 3. Secret Protection
-
-`.env` files and variants (`.env.local`, `.env.production`, etc.) are blocked from Read operations:
-
-```javascript
-// Blocks: .env, .env.local, .env.production
-// Allows: README.md, src/config.ts
-```
-
-**Rationale:** Prevents accidental credential leakage in agent conversations or logs.
-
-**Test coverage:** `scripts/test-security.js` validates .env reads are blocked
-
-### 4. Pip Gate (Untracked Dependencies)
-
-Before allowing `pip install`, checks if `requirements.txt` is tracked by git:
-
-```javascript
-// ✅ Allows: pip install when requirements.txt is committed
-// ⚠️  Warns:  pip install when requirements.txt exists but is untracked
-// ✅ Allows: pip install when no requirements.txt exists yet
-```
-
-**Rationale:** Prevents dependency drift and ensures reproducible builds.
-
-**Implementation:** `quality-gate.js` checks `git ls-files requirements.txt`
-
-## Test Suite
-
-### Run Security Tests
+Run security checks with:
 
 ```bash
-# Security tests only
 node scripts/test-security.js
-
-# Full suite (includes security)
-node scripts/test-all.js
 ```
 
-### What Gets Tested
+Run the full harness suite with:
 
-1. **Path Traversal**
-   - `../../../etc/passwd` → blocked
-   - `/etc/passwd` → blocked
-   - `src/file.ts` → allowed
+```bash
+npm run test
+```
 
-2. **Shell Injection**
-   - Verify `execFileSync` usage (safe)
-   - Reject `execSync` usage (unsafe)
-   - Validate git commands use array args
+## Private State Guidance
 
-3. **Secret Protection**
-   - `.env` reads → blocked
-   - Regular file reads → allowed
+Do not assume generated Citadel state is safe to publish.
 
-4. **Glob Pattern Security**
-   - `secrets/**` patterns work correctly
-   - Recursive `**` globs match expected files
+Review these paths before committing, sharing logs, recording demos, or opening
+support issues:
 
-### Exit Codes
+- `.planning/`
+- `.citadel/`
+- `.codex/`
+- `.claude/`
+- `.mcp.json`
+- screenshots, browser captures, telemetry logs, research notes, and handoff
+  files
 
-- `0` — All tests pass
-- `1` — One or more tests failed (DO NOT SHIP)
-
-## Fail-Closed Design
-
-All security hooks follow a **fail-closed** approach:
-
-- Unexpected errors → **block** the action (exit 2)
-- Parse failures → **block** the action
-- Missing validation → **block** the action
-
-This prevents security bypasses via error conditions.
+Generated state can include repository structure, work plans, local paths, tool
+outputs, review findings, cost telemetry, screenshots, or links to private work.
 
 ## Reporting Vulnerabilities
 
-If you discover a security issue:
+Do not open a public issue for a vulnerability.
 
-1. **Do not** open a public GitHub issue
-2. Email: security@citadel.dev (or create private security advisory)
-3. Include: steps to reproduce, impact assessment, suggested fix
+Preferred reporting path:
 
-We'll respond within 48 hours and coordinate disclosure timing.
+1. Use GitHub private vulnerability reporting or a private security advisory for
+   this repository if available.
+2. Include the affected file or command, reproduction steps, expected impact,
+   and any suggested fix.
+3. If private reporting is unavailable, contact the maintainer through a private
+   channel listed on their GitHub profile.
 
-## Audit Log
+Please avoid posting exploit details, secret values, private project paths, or
+unredacted `.planning/` artifacts in public threads.
 
-All security-relevant events are logged to `.planning/telemetry/audit.jsonl`:
+## Security Checklist for Harness Changes
 
-```json
-{
-  "schema": 1,
-  "event": "blocked",
-  "hook": "protect-files",
-  "reason": "path traversal sequence",
-  "file": "../../../etc/passwd",
-  "timestamp": "2026-03-30T12:05:00.000Z"
-}
-```
+Before shipping changes to hooks, runtime adapters, installers, MCP surfaces, or
+unattended automation:
 
-Use this log for forensic analysis and security monitoring.
+- [ ] Identify the trust boundary being changed.
+- [ ] Confirm protected files and project-root checks still apply.
+- [ ] Use argument-array process APIs instead of shell-interpreted strings where
+      possible.
+- [ ] Keep destructive, networked, publish, credential, and cross-repository
+      actions behind explicit approval.
+- [ ] Add or update focused tests for the changed boundary.
+- [ ] Run `npm run test`.
+- [ ] Update [THREAT_MODEL.md](THREAT_MODEL.md) when capabilities or boundaries
+      change.
 
-## Security Checklist for New Hooks
+## Disclosure Expectations
 
-When adding a new hook that handles user/agent input:
-
-- [ ] Use `health.validatePath()` for all file paths
-- [ ] Use `health.validateCommand()` for all shell commands
-- [ ] Use `execFileSync` with array args (not `execSync` or `exec`)
-- [ ] Fail closed: unexpected errors exit 2 (block), not 0 (allow)
-- [ ] Add test cases to `scripts/test-security.js`
-- [ ] Document security assumptions in hook header comment
-
-## Further Reading
-
-- [OWASP Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal)
-- [Shell Injection Prevention](https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html)
-- [Principle of Least Privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege)
+Security fixes should be small, reviewable, and verified. If a fix changes hook
+behavior, generated config, installer output, approval gates, or command
+execution, include the exact verification commands in the PR body.

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -1,0 +1,169 @@
+# Threat Model
+
+Citadel is an agent orchestration harness for local coding runtimes. It adds
+skills, hooks, scripts, generated configuration, and repo-local state so an AI
+coding agent can route work, preserve context, coordinate campaigns, verify
+changes, and produce handoffs.
+
+This document describes the trust boundaries Citadel creates. It is not a
+guarantee that every downstream project is safe. The repository being worked on,
+the active coding runtime, installed tools, and user approvals remain part of
+the security boundary.
+
+## Security Goals
+
+Citadel should:
+
+- keep local project automation inspectable and reviewable
+- keep destructive or externally visible actions behind approval boundaries
+- avoid reading or publishing protected files by default
+- make generated state easy to find before a user shares or commits it
+- fail closed when a hook cannot validate a sensitive action
+- leave enough telemetry and handoff evidence to audit what happened
+
+Citadel does not try to:
+
+- sandbox the entire operating system
+- make an untrusted repository safe to run
+- prevent every possible prompt-injection attempt
+- replace the security model of Claude Code, OpenAI Codex, git, npm, shells, or
+  other local tools
+- guarantee that generated reports are free of private data
+
+## Primary Assets
+
+| Asset | Why it matters |
+|---|---|
+| Source files | The agent can modify code, docs, tests, and generated artifacts. |
+| Secrets and credentials | `.env` files, tokens, keys, and private config must not be copied into prompts, logs, or public artifacts. |
+| Repo-local planning state | `.planning/` can contain campaign details, research, screenshots, telemetry, cost data, local paths, and handoffs. |
+| Runtime configuration | `.codex/`, `.claude/`, `.mcp.json`, and generated hook config influence future agent behavior. |
+| Git branches and worktrees | Fleet and PR workflows can create, inspect, and coordinate parallel work. |
+| External services | GitHub, package registries, MCP servers, and browser targets may have side effects or expose data. |
+
+## Trust Boundaries
+
+### User and Runtime
+
+The user approves or denies actions through the active coding runtime. Citadel
+can recommend commands and write approval capsules, but it should not hide the
+scope or side effects of a privileged action.
+
+### Repository
+
+The current repository is trusted enough to inspect and modify. That does not
+mean its scripts are safe. Package scripts, hooks, test commands, and project
+instructions can still perform arbitrary local actions.
+
+### Citadel Hooks
+
+Hooks run inside the local development environment. They can inspect tool
+requests, block actions, write telemetry, and add context. Hook failures should
+prefer blocking or surfacing a repair over silently allowing sensitive actions.
+
+### Generated State
+
+Citadel writes state under paths such as `.planning/`, `.citadel/`, `.codex/`,
+and `.claude/`. These files are useful for continuity, but they may contain
+private project details. Users should review them before publishing.
+
+### Agents and Sub-Agents
+
+Parallel agents, Fleet sessions, and campaign continuations inherit project
+context and may produce independent diffs or discoveries. Their output should be
+merged only through reviewable branches, worktrees, review packages, or PRs.
+
+### External Inputs
+
+Issues, PR comments, webpages, dependency docs, local markdown, generated
+reports, and screenshots are untrusted content. They may contain instructions
+that conflict with user, system, runtime, or repository policy.
+
+## Threats and Mitigations
+
+| Threat | Example | Mitigation |
+|---|---|---|
+| Path traversal | A tool request tries to read `../../../secret` | protected-file and project-root validation |
+| Protected file read | A prompt asks the agent to dump `.env` | protected-file rules and secret guidance |
+| Shell injection | A branch name or file path is interpolated into a shell string | prefer argument-array process APIs and command validators |
+| Prompt injection | A README or issue tells the agent to ignore instructions | instruction hierarchy, review posture, explicit trust boundaries |
+| Unsafe package install | A task asks for dependency installation without durable project changes | approval gates and dependency drift checks |
+| Public leak | A PR includes `.planning/telemetry` or screenshots with private details | ignored generated paths and manual review before publishing |
+| Automation overreach | A campaign continues after scope has changed | campaign files, approval capsules, operator console, and PR readiness gates |
+| Stale evidence | A readiness report refers to an old branch head | stack readiness checks and rerun requirements |
+| Unreviewed merge | Fleet worktrees are accepted blindly | merge-review queues and explicit human approval boundaries |
+
+## Approval-Bound Actions
+
+Citadel should preserve approval boundaries around actions that are destructive,
+externally visible, networked, credential-sensitive, or hard to undo.
+
+Examples:
+
+- deleting, moving, or rewriting broad file trees
+- installing dependencies or changing lockfiles
+- running unfamiliar project scripts
+- pushing branches, opening PRs, merging PRs, publishing packages, or creating
+  releases
+- changing hook policy, runtime configuration, or MCP server setup
+- sending outreach, email, API requests, or other external communications
+- exposing local app servers outside loopback
+
+## Generated Artifact Review
+
+Before publishing a PR or sharing a demo, inspect generated artifacts for local
+paths, private project names, secrets, screenshots, or unrelated findings.
+
+High-risk generated paths include:
+
+- `.planning/research/`
+- `.planning/telemetry/`
+- `.planning/screenshots/`
+- `.planning/handoffs/`
+- `.planning/review-packages/`
+- `.planning/pr-readiness/`
+- `.planning/approval-capsules/`
+
+These paths are valuable evidence, not automatically public documentation.
+
+## Contributor Checklist
+
+When a PR changes security-sensitive behavior, the PR should answer:
+
+- Which trust boundary changed?
+- What user-visible approval or report proves the boundary?
+- What happens when validation fails?
+- Which tests cover the sensitive path?
+- Which generated files might contain private data?
+- Does the change affect Claude Code, OpenAI Codex, or both?
+
+Run:
+
+```bash
+npm run test
+```
+
+For hook-specific changes, also run:
+
+```bash
+node hooks_src/smoke-test.js
+node scripts/verify-hooks.js
+node scripts/integration-test.js
+```
+
+## Current Review Posture
+
+Citadel review should be strict around:
+
+- hook behavior
+- runtime adapters
+- installer output
+- generated config
+- file protection
+- command execution
+- MCP surfaces
+- Fleet and campaign automation
+- PR readiness and merge approval
+
+Documentation changes should avoid overclaiming safety. If a guarantee depends
+on the active runtime or project scripts, say so directly.


### PR DESCRIPTION
## Summary

Adds a first-class Citadel threat model and refreshes the top-level security guidance around local agent automation. The docs make the trust boundaries explicit: hooks, generated project state, approval gates, local command execution, untrusted external inputs, and public-artifact review.

This is the trust-boundary recommendation from the Odysseus research pass. The goal is not to claim Citadel is sandboxed; it is to state plainly what Citadel can touch, what must stay approval-bound, and which generated artifacts should be reviewed before publishing.

## What Changed

- adds `THREAT_MODEL.md`
- rewrites `SECURITY.md` around Citadel's supported local security model, main risks, private-state guidance, vulnerability reporting, and contributor checklist
- removes stale/encoding-damaged security copy from the older security page
- links `SECURITY.md` and `THREAT_MODEL.md` from the README proof section

## Verification

- `node scripts/test-security.js` passed
- `Select-String -Path SECURITY.md,THREAT_MODEL.md,README.md -Pattern '[^\x00-\x7F]'` returned no matches
- `git diff --check` passed

## Review Pass

- Scope checked: docs-only trust-boundary change; no hook/runtime behavior changed
- Copy checked: avoids unsupported guarantees, avoids public-internet safety claims, and removes the unsupported `security@citadel.dev` contact
- Risk checked: generated `.planning/` state is explicitly treated as private-by-default evidence, not public documentation

## Stack

Stacked on PR #140/#141 first-use operator work so the public onboarding/security story lands after the setup path is aligned with `/do setup --express`.