### PR TITLE
Allow explicit PR readiness branch

### DIFF
--- a/scripts/pr-ready.js
+++ b/scripts/pr-ready.js
@@ -14,6 +14,7 @@ function parseArgs(argv) {
     verification: '',
     verificationSpecified: false,
     runVerification: false,
+    branch: '',
     json: false,
     help: false,
   };
@@ -27,6 +28,7 @@ function parseArgs(argv) {
       args.verificationSpecified = true;
     }
     else if (arg === '--run-verification') args.runVerification = true;
+    else if (arg === '--branch') args.branch = argv[++index] || '';
     else if (arg === '--json') args.json = true;
     else if (arg === '--help' || arg === '-h') args.help = true;
   }
@@ -39,6 +41,7 @@ function usage() {
     'Usage:',
     '  node scripts/pr-ready.js --pr <pull-request-url> --run-verification',
     '  node scripts/pr-ready.js --pr <pull-request-url> --verification "npm run test"',
+    '  node scripts/pr-ready.js --pr <pull-request-url> --branch <branch-name> --run-verification',
     '',
     'Writes .planning/pr-readiness/<branch>.md and exits 0 only when local readiness gates pass.',
     'When --verification is omitted, Citadel selects a verification profile from changed paths.',
@@ -172,7 +175,7 @@ function renderReport(readiness) {
 
 function assessReadiness(projectRoot, options = {}) {
   const root = path.resolve(projectRoot || process.cwd());
-  const branch = runGit(root, ['branch', '--show-current']) || 'detached';
+  const branch = options.branch || runGit(root, ['branch', '--show-current']) || 'detached';
   const head = runGit(root, ['rev-parse', '--short', 'HEAD']);
   const verificationProfile = selectVerificationProfile(root, {
     changedFiles: options.changedFiles,
@@ -252,6 +255,7 @@ function main() {
     pr: args.pr,
     verification: args.verification,
     runVerification: args.runVerification,
+    branch: args.branch,
   });
 
   if (args.json) {

--- a/scripts/test-pr-ready.js
+++ b/scripts/test-pr-ready.js
@@ -88,6 +88,29 @@ withTempProject((projectRoot) => {
 
   const readiness = assessReadiness(projectRoot, {
     pr: 'https://github.com/acme/repo/pull/12',
+    runVerification: true,
+    verification: 'npm run test',
+    branch: 'codex/explicit-pr-branch',
+  });
+
+  assert.equal(readiness.ready, true);
+  assert.equal(readiness.branch, 'codex/explicit-pr-branch');
+  assert.equal(readiness.reportPath, '.planning/pr-readiness/codex-explicit-pr-branch.md');
+  assert(fs.existsSync(path.join(projectRoot, readiness.reportPath)));
+});
+
+withTempProject((projectRoot) => {
+  initGit(projectRoot);
+  initPlanning(projectRoot);
+  write(path.join(projectRoot, 'package.json'), JSON.stringify({
+    scripts: { test: 'node test.js' },
+  }, null, 2));
+  write(path.join(projectRoot, 'test.js'), 'process.exit(0);\n');
+  childProcess.execFileSync('git', ['add', '.'], { cwd: projectRoot, stdio: 'ignore' });
+  childProcess.execFileSync('git', ['commit', '-m', 'init'], { cwd: projectRoot, stdio: 'ignore' });
+
+  const readiness = assessReadiness(projectRoot, {
+    pr: 'https://github.com/acme/repo/pull/12',
     runVerification: false,
     verification: 'npm run test',
     now: '2026-06-05T00:00:00.000Z',
@@ -123,6 +146,36 @@ withTempProject((projectRoot) => {
   assert.equal(readiness.ready, false);
   assert.equal(readiness.gates.prUrl.pass, false);
   assert.equal(readiness.gates.verification.pass, false);
+});
+
+withTempProject((projectRoot) => {
+  initGit(projectRoot);
+  initPlanning(projectRoot);
+  write(path.join(projectRoot, 'package.json'), JSON.stringify({
+    scripts: { test: 'node test.js' },
+  }, null, 2));
+  write(path.join(projectRoot, 'test.js'), 'process.exit(0);\n');
+  childProcess.execFileSync('git', ['add', '.'], { cwd: projectRoot, stdio: 'ignore' });
+  childProcess.execFileSync('git', ['commit', '-m', 'init'], { cwd: projectRoot, stdio: 'ignore' });
+
+  const output = childProcess.spawnSync(process.execPath, [
+    path.join(__dirname, 'pr-ready.js'),
+    '--project-root',
+    projectRoot,
+    '--pr',
+    'https://github.com/acme/repo/pull/12',
+    '--branch',
+    'codex/cli-pr-branch',
+    '--run-verification',
+    '--verification',
+    'npm run test',
+    '--json',
+  ], { encoding: 'utf8' });
+
+  assert.equal(output.status, 0);
+  const readiness = JSON.parse(output.stdout);
+  assert.equal(readiness.branch, 'codex/cli-pr-branch');
+  assert.equal(readiness.reportPath, '.planning/pr-readiness/codex-cli-pr-branch.md');
 });
 
 withTempProject((projectRoot) => {


### PR DESCRIPTION
## Summary

Adds an explicit `--branch` option to `scripts/pr-ready.js`. This lets stacked PR readiness reports be written under the intended PR branch name even when the local checkout is on a child branch or another temporary review branch.

## Decision

Closed as superseded after full open-PR review. The same `pr-ready --branch` behavior is already included and verified in the accepted first-use/operator stack (#140) and in the final clean stack verification through #151.

No branch deletion was performed by this close action.