### PR TITLE
Document Citadel report artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Citadel is not a pitch deck. The repository contains the harness:
 - Hook source under [`hooks_src/`](hooks_src/) and generated hook manifests under [`hooks/`](hooks/) for project installation.
 - Runtime adapters for Claude Code and Codex under [`runtimes/`](runtimes/) plus package surfaces under [`packages/`](packages/).
 - Installer and verification scripts under [`scripts/`](scripts/), including `scripts/test-all.js`, hook verification, runtime checks, and skill linting.
-- Public docs for [campaigns](docs/CAMPAIGNS.md), [fleet coordination](docs/FLEET.md), [hooks](docs/HOOKS.md), [Codex install](docs/CODEX_INSTALLATION_GUIDE.md), and [Claude Code install](docs/CLAUDE_INSTALLATION_GUIDE.md).
+- Public docs for [campaigns](docs/CAMPAIGNS.md), [report artifacts](docs/REPORT_ARTIFACTS.md), [fleet coordination](docs/FLEET.md), [hooks](docs/HOOKS.md), [Codex install](docs/CODEX_INSTALLATION_GUIDE.md), and [Claude Code install](docs/CLAUDE_INSTALLATION_GUIDE.md).
 
 Run the local verification suite from a Citadel clone:
 

--- a/docs/CAMPAIGNS.md
+++ b/docs/CAMPAIGNS.md
@@ -310,5 +310,7 @@ The dashboard reports campaign truth problems with executable repairs:
 ## See Also
 
 - `examples/campaign-example.md` — A complete, realistic campaign
+- [REPORT_ARTIFACTS.md](REPORT_ARTIFACTS.md) — Guide to Citadel's research,
+  verification, review, approval, readiness, and handoff reports
 - `.planning/_templates/campaign.md` — Campaign template
 - `.planning/_templates/intake-item.md` — Intake item template

--- a/docs/REPORT_ARTIFACTS.md
+++ b/docs/REPORT_ARTIFACTS.md
@@ -1,0 +1,107 @@
+# Report Artifacts
+
+Citadel workflows should leave evidence that another session can inspect. These
+artifacts are not a replacement for tests or code review. They are the paper
+trail that explains what the agent saw, what it did, what passed, and what
+still needs human judgment.
+
+Treat generated reports as project-private unless you have reviewed them.
+
+## Core Artifact Types
+
+| Artifact | Typical path | Producer | Purpose |
+|---|---|---|---|
+| Research brief | `.planning/research/<topic>.md` | `/research`, research workflows | Records sourced findings, confidence, actions, and open questions. |
+| Verification plan | `.planning/verification/` or PR readiness report | `scripts/verification-plan.js`, `scripts/pr-ready.js` | Shows which checks were selected and why. |
+| Review package | `.planning/review-packages/<campaign>.md` | `scripts/package-delivery.js` | Packages campaign evidence, changed files, verification rows, and handoff. |
+| PR readiness report | `.planning/pr-readiness/<branch>.md` | `scripts/pr-ready.js` | Proves a branch had a valid PR URL, clean worktree, clear dashboard repairs, and passing verification at the time of the run. |
+| Approval capsule | `.planning/approval-capsules/<timestamp>.md` | `scripts/next-action.js`, `scripts/operator-console.js`, `scripts/stack-plan.js` | Captures a human approval boundary with command, risk, runbook, and verification expectations. |
+| Operator report | `.planning/operator-console/latest.md` | `scripts/operator-console.js` | Summarizes current truth, next action, boundary, artifacts, and verification profile. |
+| Next-action report | `.planning/next-actions/latest.md` | `scripts/next-action.js` | Records the dashboard-derived next useful action and any local repair result. |
+| Handoff | `.planning/handoffs/` or final response block | skills, scripts, agents | Summarizes what changed, decisions, unresolved items, and next steps. |
+
+## What Good Reports Include
+
+A useful artifact is specific enough that a later agent or reviewer can continue
+without reconstructing the whole conversation.
+
+It should include:
+
+- the source command or workflow that produced it
+- the target project or branch
+- changed files or relevant paths
+- verification commands and results
+- confidence level or known uncertainty when judgment is involved
+- explicit next action or approval boundary
+- a short handoff when work is incomplete or review is required
+
+It should avoid:
+
+- unsupported product claims
+- hidden assumptions about runtime state
+- copying secrets, private customer data, or personal tokens
+- pretending a report is proof of correctness when it only records evidence
+- broad generated prose that does not identify files, commands, or outcomes
+
+## Public Sharing Review
+
+Before committing, posting, or recording generated reports, inspect for:
+
+- local absolute paths
+- secrets, tokens, keys, environment variables, or credential file names
+- private project names, customer names, roadmap details, or issue links
+- screenshots or browser captures with private information
+- unrelated findings from another task
+- stale command results that no longer match the branch head
+
+If an artifact is useful but contains private data, summarize the finding in a
+clean public document instead of publishing the raw generated report.
+
+## Recommended Flow
+
+Use reports as a chain of evidence:
+
+1. Start with the operator view:
+
+   ```bash
+   node scripts/operator-console.js
+   ```
+
+2. Run or inspect the selected verification profile:
+
+   ```bash
+   node scripts/verification-plan.js
+   ```
+
+3. For campaign delivery, create a review package:
+
+   ```bash
+   node scripts/package-delivery.js <campaign-slug>
+   ```
+
+4. For PR handoff, run the readiness finalizer:
+
+   ```bash
+   node scripts/pr-ready.js --pr <pull-request-url> --run-verification
+   ```
+
+5. For stacked PRs, generate the landing plan:
+
+   ```bash
+   npm run stack:plan
+   ```
+
+The final user-facing answer or PR body should cite the evidence that matters,
+not paste every generated artifact.
+
+## Maintenance Rule
+
+When adding a new workflow that writes `.planning/` reports, document:
+
+- path pattern
+- producer command
+- intended reviewer
+- stale/refresh behavior
+- whether the artifact is safe to publish by default
+
+If the answer to the last item is unclear, treat it as private by default.


### PR DESCRIPTION
## Summary

Adds a public guide to Citadel's report artifacts: research briefs, verification plans, review packages, PR readiness reports, approval capsules, operator reports, next-action reports, and handoffs.

This implements the report-artifact recommendation from the Odysseus research pass by making Citadel's evidence trail easier to inspect without turning generated `.planning/` state into public-by-default documentation.

## What Changed

- adds `docs/REPORT_ARTIFACTS.md`
- documents core artifact types, producers, paths, and intended purpose
- adds public sharing review guidance for generated reports
- documents a recommended operator-to-readiness evidence flow
- links the guide from README and `docs/CAMPAIGNS.md`

## Verification

- `node scripts/test-demo.js` passed
- `git diff --check HEAD~1..HEAD` passed

## Review Pass

- Scope checked: docs-only report/evidence guidance
- Copy checked: avoids claiming reports prove correctness; frames them as evidence for review
- Risk checked: generated `.planning/` reports are explicitly private-by-default until reviewed

## Stack

Opened against `codex/first-use-operator-journey` so the PR diff remains limited to the report artifact guide and links.