### PR TITLE
Add route preview preflight command

### DIFF
--- a/docs/ROUTING_PREVIEW.md
+++ b/docs/ROUTING_PREVIEW.md
@@ -8,6 +8,12 @@ approval or verification boundary.
 Use this guide when a task could plausibly route to more than one level, such as
 a single skill, Marshal, Archon, or Fleet.
 
+Run it locally with:
+
+```bash
+node scripts/route-preview.js -- "audit the auth module and fix the highest-risk issue"
+```
+
 ## Preview Contract
 
 A useful preview answers:
@@ -50,6 +56,12 @@ Alternatives:
 
 Boundary: can run after worktree review.
 Verify: npm run test, or the project's selected auth/test profile.
+```
+
+The machine-readable version is:
+
+```bash
+node scripts/route-preview.js --json -- "review src/auth.ts"
 ```
 
 ## Proportionality Checks
@@ -97,6 +109,7 @@ Bad stops:
 - `/do next` and `node scripts/operator-console.js` show the next action,
   boundary, risk, and verification profile.
 - The public router demo visualizes tier selection.
+- `node scripts/route-preview.js` provides a local preflight for route choice.
 - PR bodies should describe route choice when a branch adds or changes an
   operator workflow.
-- Future dry-run routing features should follow the preview contract above.
+- Future dry-run routing features should preserve the same preview contract.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "next": "node scripts/next-action.js",
     "operator": "node scripts/operator-console.js",
     "operator:summary": "node scripts/operator-console.js --summary",
+    "route:preview": "node scripts/route-preview.js",
     "stack:plan": "node scripts/stack-plan.js",
     "stack:plan:json": "node scripts/stack-plan.js --json",
     "verify:plan": "node scripts/verification-plan.js",

--- a/scripts/route-preview.js
+++ b/scripts/route-preview.js
@@ -1,0 +1,464 @@
+#!/usr/bin/env node
+'use strict';
+
+const childProcess = require('child_process');
+const path = require('path');
+
+function parseArgs(argv) {
+  const args = {
+    input: [],
+    json: false,
+    projectRoot: process.cwd(),
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (arg === '--json') args.json = true;
+    else if (arg === '--project-root') args.projectRoot = path.resolve(argv[++index] || '.');
+    else if (arg === '--help' || arg === '-h') args.help = true;
+    else if (arg === '--') {
+      args.input.push(...argv.slice(index + 1));
+      break;
+    }
+    else args.input.push(arg);
+  }
+
+  return {
+    ...args,
+    input: args.input.join(' ').trim(),
+  };
+}
+
+function usage() {
+  return [
+    'Usage:',
+    '  node scripts/route-preview.js [--json] [--project-root <path>] -- <request>',
+    '',
+    'Shows the proportional /do route, alternatives, boundary, and verification before execution.',
+  ].join('\n');
+}
+
+const TIER0 = [
+  {
+    id: 'status',
+    pattern: /\b(status|dashboard|what'?s happening|what'?s going on|show activity)\b/i,
+    selected: '/dashboard',
+    command: 'node scripts/dashboard.js',
+    reason: 'status language maps directly to the dashboard without orchestration.',
+    verification: 'Confirm the dashboard renders the expected pending counts and next action.',
+  },
+  {
+    id: 'next',
+    pattern: /\b(next|what should i do next|fix harness state|repair harness)\b/i,
+    selected: '/do next',
+    command: 'node scripts/operator-console.js --run',
+    reason: 'operator language maps to the next-action cockpit and deterministic local repairs.',
+    verification: 'Confirm the operator report reaches idle or an explicit approval boundary.',
+  },
+  {
+    id: 'operator',
+    pattern: /\b(operator|operator console|approval capsule|what'?s up|what should happen next)\b/i,
+    selected: '/do operator',
+    command: 'node scripts/operator-console.js',
+    reason: 'operator-inspection language asks for the cockpit without running repairs.',
+    verification: 'Confirm the report names the next action, boundary, risk, and verification profile.',
+  },
+  {
+    id: 'continue',
+    pattern: /\b(continue|keep going)\b/i,
+    selected: '/do continue',
+    command: 'node scripts/continue-action.js --run',
+    reason: 'continuation language should resume active campaign or fleet state when present.',
+    verification: 'Confirm the continuation report either resumes work or says no active work exists.',
+  },
+  {
+    id: 'setup',
+    pattern: /\b(setup|first run|configure harness)\b/i,
+    selected: '/setup',
+    command: '/do setup --express',
+    reason: 'first-run language should initialize project harness state before deeper routing.',
+    verification: 'Run the dashboard and confirm `.planning/` exists for the current project.',
+  },
+  {
+    id: 'test',
+    pattern: /\b(test|tests)\b/i,
+    selected: 'direct-command',
+    command: 'npm run test',
+    reason: 'test language maps to the project verification command.',
+    verification: 'Confirm the command exits 0 or reports actionable failures.',
+  },
+  {
+    id: 'build',
+    pattern: /\b(build)\b/i,
+    selected: 'direct-command',
+    command: 'npm run build',
+    reason: 'build language maps to the project build command.',
+    verification: 'Confirm the command exits 0 or reports actionable failures.',
+  },
+  {
+    id: 'typecheck',
+    pattern: /\b(typecheck|type check)\b/i,
+    selected: 'direct-command',
+    command: 'npm run typecheck',
+    reason: 'typecheck language maps to the project type verification command.',
+    verification: 'Confirm the command exits 0 or reports actionable type errors.',
+  },
+];
+
+const SKILLS = [
+  skill('/review', ['review', 'code review'], 'Code Quality'),
+  skill('/test-gen', ['generate tests', 'write tests', 'test coverage'], 'Code Quality'),
+  skill('/doc-gen', ['document', 'docs', 'docstring', 'readme'], 'Documentation'),
+  skill('/refactor', ['refactor', 'extract', 'split file'], 'Code Quality'),
+  skill('/scaffold', ['scaffold', 'new module', 'new component', 'bootstrap'], 'Creation'),
+  skill('/create-skill', ['create skill', 'new skill', 'repeated pattern'], 'Harness'),
+  skill('/session-handoff', ['handoff', 'session summary'], 'Harness'),
+  skill('/research', ['research', 'investigate', 'look into', 'find out'], 'Research'),
+  skill('/research-fleet', ['research fleet', 'parallel research', 'multi-angle research'], 'Research'),
+  skill('/systematic-debugging', ['debug', 'root cause', 'diagnose', 'why is', 'investigate bug'], 'Debugging'),
+  skill('/live-preview', ['preview', 'screenshot', 'visual check', 'does it render'], 'Verification'),
+  skill('/qa', ['qa', 'click through', 'browser test', 'test the app'], 'Verification'),
+  skill('/triage', ['triage', 'open issues', 'investigate issue', 'review pr'], 'GitHub'),
+  skill('/pr-watch', ['watch pr', 'watch ci', 'fix ci', 'checks failing'], 'GitHub'),
+  skill('/telemetry', ['telemetry', 'session cost', 'spending', 'what hooks fired'], 'Observability'),
+  skill('/merge-review', ['merge review', 'safe to merge', 'pending branches'], 'Git'),
+  skill('/improve', ['improve', 'quality loop', 'rubric', 'score against'], 'Improvement'),
+  skill('/evolve', ['evolve', 'improve until', 'hypothesis', 'sustained improve'], 'Improvement'),
+  skill('/organize', ['organize', 'folder structure', 'project structure'], 'Maintenance'),
+  skill('/houseclean', ['houseclean', 'disk space', 'free space', 'orphaned worktrees'], 'Maintenance'),
+  skill('/daemon', ['daemon', 'continuous', 'overnight', '24/7'], 'Automation'),
+  skill('/map', ['map', 'index codebase', 'structural index'], 'Codebase'),
+  skill('/watch', ['watch files', 'marker comments', '@citadel'], 'Automation'),
+  skill('/infra-audit', ['infra', 'infrastructure', 'docker-compose'], 'Infrastructure'),
+  skill('/workspace', ['workspace', 'multi-repo', 'cross-repo', 'multiple repos'], 'Workspace'),
+  skill('/prd', ['prd', 'requirements', 'spec', 'plan an app'], 'Planning'),
+  skill('/architect', ['architect', 'architecture', 'design the system', 'file structure'], 'Planning'),
+  skill('/create-app', ['create app', 'build app', 'make an app', 'add auth', 'add payments'], 'Creation'),
+  skill('/marshal', ['orchestrate', 'chain skills', 'multi-step'], 'Orchestration'),
+  skill('/archon', ['campaign', 'multi-session', 'phases'], 'Orchestration'),
+  skill('/fleet --quick', ['parallel', 'simultaneous', 'multiple agents', 'at the same time'], 'Orchestration'),
+];
+
+function skill(route, keywords, category) {
+  return { route, keywords, category };
+}
+
+function normalized(value) {
+  return String(value || '').toLowerCase();
+}
+
+function words(value) {
+  return String(value || '').trim().split(/\s+/).filter(Boolean);
+}
+
+function matchesKeyword(input, keyword) {
+  const lower = normalized(input);
+  const needle = normalized(keyword);
+  if (needle.includes(' ')) return lower.includes(needle);
+  return new RegExp(`\\b${escapeRegExp(needle)}\\b`, 'i').test(input);
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function keywordMatches(input) {
+  return SKILLS
+    .map((entry) => ({
+      ...entry,
+      matches: entry.keywords.filter((keyword) => matchesKeyword(input, keyword)),
+    }))
+    .filter((entry) => entry.matches.length > 0)
+    .sort((a, b) => b.matches.length - a.matches.length || a.keywords.length - b.keywords.length);
+}
+
+function hasSingleFileSignal(input) {
+  return /\b[\w.-]+\.(js|jsx|ts|tsx|mjs|cjs|json|md|css|html|py|rb|go|rs|java|cs)\b/i.test(input);
+}
+
+function classifyComplexity(input, matches) {
+  const count = words(input).length;
+  const lower = normalized(input);
+  const parallel = /\b(parallel|simultaneous|multiple agents|at the same time|both\b.+\band)\b/i.test(input);
+  const persistent = /\b(campaign|multi-session|phases|overnight|continue until|run until)\b/i.test(input);
+  const crossDomain = /\b(platform|across|all|entire|multi-repo|cross-repo|multiple repos)\b/i.test(input);
+  const taste = /\b(design|experience|quality|polish|intuitive)\b/i.test(input);
+  const complexity = persistent || parallel || crossDomain ? 4 : count > 24 || taste ? 3 : matches.length > 1 ? 3 : count > 8 ? 2 : 1;
+
+  return {
+    scope: crossDomain ? 'cross-domain' : hasSingleFileSignal(input) ? 'single-file' : 'single-domain',
+    complexity,
+    requiresPersistence: persistent,
+    requiresParallel: parallel,
+    requiresTaste: taste,
+  };
+}
+
+function selectTier0(input) {
+  return TIER0.find((entry) => {
+    if (!entry.pattern.test(input)) return false;
+    if (entry.id === 'status' && hasSingleFileSignal(input)) return false;
+    return true;
+  }) || null;
+}
+
+function selectRoute(input) {
+  if (!input.trim()) {
+    return {
+      tier: 0,
+      selected: '/do --list',
+      command: '/do --list',
+      reason: 'empty input should show available routes instead of guessing.',
+      confidence: 'high',
+      alternatives: [],
+      verification: 'Confirm the skill list renders and asks for a direction.',
+      dimensions: classifyComplexity(input, []),
+    };
+  }
+
+  const tier0 = selectTier0(input);
+  if (tier0) {
+    return {
+      tier: 0,
+      selected: tier0.selected,
+      command: tier0.command,
+      reason: tier0.reason,
+      confidence: 'high',
+      alternatives: alternativesFor(input, []),
+      verification: tier0.verification,
+      dimensions: classifyComplexity(input, []),
+    };
+  }
+
+  const matches = keywordMatches(input);
+  const dimensions = classifyComplexity(input, matches);
+  if (matches.length === 1) {
+    let selected = matches[0].route;
+    let reason = `one high-confidence keyword group matched ${matches[0].route}: ${matches[0].matches.join(', ')}.`;
+    const proportional = applyProportionality(input, selected, dimensions);
+    selected = proportional.selected;
+    if (proportional.reason) reason = proportional.reason;
+
+    return {
+      tier: 2,
+      selected,
+      command: selected,
+      reason,
+      confidence: 'high',
+      alternatives: alternativesFor(input, matches),
+      verification: verificationFor(selected),
+      dimensions,
+    };
+  }
+
+  if (matches.length > 1) {
+    return {
+      tier: 3,
+      selected: '/marshal',
+      command: '/marshal',
+      reason: `multiple route families matched (${matches.slice(0, 3).map((item) => item.route).join(', ')}), so Marshal should sequence the work before escalating.`,
+      confidence: 'medium',
+      alternatives: alternativesFor(input, matches),
+      verification: verificationFor('/marshal'),
+      dimensions,
+    };
+  }
+
+  let selected = fallbackRoute(dimensions);
+  let reason = fallbackReason(selected, dimensions);
+  const proportional = applyProportionality(input, selected, dimensions);
+  selected = proportional.selected;
+  if (proportional.reason) reason = proportional.reason;
+
+  return {
+    tier: 3,
+    selected,
+    command: selected,
+    reason,
+    confidence: 'medium',
+    alternatives: alternativesFor(input, matches),
+    verification: verificationFor(selected),
+    dimensions,
+  };
+}
+
+function fallbackRoute(dimensions) {
+  if (dimensions.requiresParallel) return '/fleet --quick';
+  if (dimensions.requiresPersistence || dimensions.complexity >= 4) return '/archon';
+  if (dimensions.complexity <= 1) return 'direct-edit';
+  return '/marshal';
+}
+
+function fallbackReason(selected, dimensions) {
+  if (selected === '/fleet --quick') return 'the request signals independent parallel work.';
+  if (selected === '/archon') return 'the request appears persistent or campaign-sized.';
+  if (selected === 'direct-edit') return 'the request appears small enough for a direct edit.';
+  return 'the request needs sequencing but not campaign persistence yet.';
+}
+
+function applyProportionality(input, selected, dimensions) {
+  if (selected.startsWith('/fleet') && dimensions.scope === 'single-file') {
+    return {
+      selected: '/marshal',
+      reason: 'proportionality downgraded Fleet because the request mentions a single file.',
+    };
+  }
+  if ((selected === '/archon' || selected.startsWith('/fleet')) && words(input).length < 20) {
+    return {
+      selected: '/marshal',
+      reason: 'proportionality downgraded campaign-level routing because the input is brief.',
+    };
+  }
+  return { selected, reason: null };
+}
+
+function alternativesFor(_input, matches) {
+  const alternatives = [];
+  for (const item of matches.slice(0, 4)) {
+    alternatives.push({
+      route: item.route,
+      why: `matched ${item.matches.join(', ')}`,
+    });
+  }
+
+  if (!alternatives.some((item) => item.route === '/marshal')) {
+    alternatives.push({ route: '/marshal', why: 'safe fallback for unclear multi-step work' });
+  }
+  if (!alternatives.some((item) => item.route === '/archon')) {
+    alternatives.push({ route: '/archon', why: 'use only when persistence or phases are needed' });
+  }
+  if (!alternatives.some((item) => item.route === '/fleet --quick')) {
+    alternatives.push({ route: '/fleet --quick', why: 'use only for independent parallel scopes' });
+  }
+  return alternatives.slice(0, 5);
+}
+
+function verificationFor(route) {
+  if (route === '/marshal') return 'Confirm the selected skill sequence, changed files, and final verification command.';
+  if (route === '/archon') return 'Confirm campaign phases, claimed scope, exit evidence, and verification profile.';
+  if (route.startsWith('/fleet')) return 'Confirm independent scopes, merge order, and per-branch verification reports.';
+  if (route === 'direct-edit') return 'Inspect the diff and run the smallest relevant verification command.';
+  if (route.startsWith('/')) return `Confirm ${route} reports its own handoff and verification evidence.`;
+  return 'Run the command and confirm it exits 0 or reports actionable failures.';
+}
+
+function gitDirty(projectRoot) {
+  const result = childProcess.spawnSync('git', ['status', '--short'], {
+    cwd: projectRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  if (result.status !== 0) return false;
+  return Boolean(String(result.stdout || '').trim());
+}
+
+function boundaryFor(route, dirty) {
+  if (dirty && route !== '/dashboard' && route !== '/do operator') {
+    return {
+      canRunNow: false,
+      boundary: 'worktree-review',
+      risk: 'low',
+      approval: 'Review uncommitted worktree changes before starting the routed action.',
+    };
+  }
+  if (route === '/fleet --quick') {
+    return {
+      canRunNow: false,
+      boundary: 'parallel-agent-approval',
+      risk: 'medium-high',
+      approval: 'Approve Fleet only after scopes are independent and merge order is clear.',
+    };
+  }
+  if (route === '/archon') {
+    return {
+      canRunNow: false,
+      boundary: 'campaign-approval',
+      risk: 'medium',
+      approval: 'Approve campaign persistence after phases and exit evidence are clear.',
+    };
+  }
+  return {
+    canRunNow: true,
+    boundary: route.startsWith('/') ? 'agent-route' : 'local-command',
+    risk: route === 'direct-edit' ? 'low' : 'medium',
+    approval: null,
+  };
+}
+
+function buildPreview(input, options = {}) {
+  const projectRoot = path.resolve(options.projectRoot || process.cwd());
+  const selected = selectRoute(input);
+  const dirty = options.gitDirty === undefined ? gitDirty(projectRoot) : Boolean(options.gitDirty);
+  const boundary = boundaryFor(selected.selected, dirty);
+
+  return {
+    generatedAt: options.now || new Date().toISOString(),
+    projectRoot,
+    input: String(input || ''),
+    ...selected,
+    ...boundary,
+    gitDirty: dirty,
+  };
+}
+
+function render(preview) {
+  const lines = [
+    'Routing Preview',
+    '='.repeat(40),
+    `Input: ${preview.input || '(empty)'}`,
+    `Selected: ${preview.selected}`,
+    `Command: ${preview.command}`,
+    `Tier: ${preview.tier}`,
+    `Confidence: ${preview.confidence}`,
+    `Why: ${preview.reason}`,
+    '',
+    'Dimensions',
+    `  Scope: ${preview.dimensions.scope}`,
+    `  Complexity: ${preview.dimensions.complexity}`,
+    `  Persistence: ${preview.dimensions.requiresPersistence ? 'yes' : 'no'}`,
+    `  Parallel: ${preview.dimensions.requiresParallel ? 'yes' : 'no'}`,
+    `  Taste: ${preview.dimensions.requiresTaste ? 'yes' : 'no'}`,
+    '',
+    'Boundary',
+    `  Can run now: ${preview.canRunNow ? 'yes' : 'no'}`,
+    `  Boundary: ${preview.boundary}`,
+    `  Risk: ${preview.risk}`,
+  ];
+
+  if (preview.approval) lines.push(`  Approval: ${preview.approval}`);
+
+  lines.push('');
+  lines.push('Alternatives');
+  for (const alternative of preview.alternatives) {
+    lines.push(`  - ${alternative.route}: ${alternative.why}`);
+  }
+
+  lines.push('');
+  lines.push('Verify');
+  lines.push(`  ${preview.verification}`);
+  return `${lines.join('\n')}\n`;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(`${usage()}\n`);
+    return;
+  }
+
+  const preview = buildPreview(args.input, { projectRoot: args.projectRoot });
+  if (args.json) process.stdout.write(`${JSON.stringify(preview, null, 2)}\n`);
+  else process.stdout.write(render(preview));
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  buildPreview,
+  keywordMatches,
+  parseArgs,
+  render,
+  selectRoute,
+  usage,
+};

--- a/scripts/test-all.js
+++ b/scripts/test-all.js
@@ -39,6 +39,7 @@ const DELIVERY_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-deliver.js');
 const DELIVERY_PACKAGE_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-package-delivery.js');
 const CONTINUE_ACTION_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-continue-action.js');
 const NEXT_ACTION_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-next-action.js');
+const ROUTE_PREVIEW_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-route-preview.js');
 const OPERATOR_CONSOLE_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-operator-console.js');
 const OPERATOR_JOURNEY_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-operator-journey.js');
 const FIRST_USE_OPERATOR_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-first-use-operator.js');
@@ -70,7 +71,7 @@ const WORKTREE_READINESS_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-worktree
 const STRICT = process.argv.includes('--strict');
 
 console.log('\nCitadel Full Test Suite\n' + '='.repeat(40));
-console.log('Running: hook smoke test + security tests + runtime contract test + runtime registry test + runtime matrix test + hook event test + skill lint + demo routing check + telemetry core check + telemetry integrity check + memory block check + evidence contract check + sandbox provider check + skill packaging check + map substrate check + delivery preflight check + delivery package check + continue action check + next action check + operator console check + operator journey check + first-use operator check + verification plan check + PR readiness check + stack plan check + coordination core check + hook installer check + campaign core check + discovery core check + discovery writer check + momentum synthesizer check + policy core check + Claude runtime check + Codex runtime check + Codex native integration check + Codex operational improvement check + installer check + project bootstrap check + compat fixtures + backward compat + cost tracker + dashboard + doc-sync + fleet session + worktree readiness\n');
+console.log('Running: hook smoke test + security tests + runtime contract test + runtime registry test + runtime matrix test + hook event test + skill lint + demo routing check + telemetry core check + telemetry integrity check + memory block check + evidence contract check + sandbox provider check + skill packaging check + map substrate check + delivery preflight check + delivery package check + continue action check + next action check + route preview check + operator console check + operator journey check + first-use operator check + verification plan check + PR readiness check + stack plan check + coordination core check + hook installer check + campaign core check + discovery core check + discovery writer check + momentum synthesizer check + policy core check + Claude runtime check + Codex runtime check + Codex native integration check + Codex operational improvement check + installer check + project bootstrap check + compat fixtures + backward compat + cost tracker + dashboard + doc-sync + fleet session + worktree readiness\n');
 
 function run(label, scriptPath, extraArgs = []) {
   console.log(`\n> ${label}`);
@@ -108,6 +109,7 @@ const deliveryPassed = run('Delivery Preflight Check', DELIVERY_TEST);
 const deliveryPackagePassed = run('Delivery Package Check', DELIVERY_PACKAGE_TEST);
 const continueActionPassed = run('Continue Action Check', CONTINUE_ACTION_TEST);
 const nextActionPassed = run('Next Action Check', NEXT_ACTION_TEST);
+const routePreviewPassed = run('Route Preview Check', ROUTE_PREVIEW_TEST);
 const operatorConsolePassed = run('Operator Console Check', OPERATOR_CONSOLE_TEST);
 const operatorJourneyPassed = run('Operator Journey Check', OPERATOR_JOURNEY_TEST);
 const firstUseOperatorPassed = run('First-Use Operator Check', FIRST_USE_OPERATOR_TEST);
@@ -157,6 +159,7 @@ console.log(`  Delivery preflight: ${deliveryPassed ? 'PASS' : 'FAIL'}`);
 console.log(`  Delivery package:   ${deliveryPackagePassed ? 'PASS' : 'FAIL'}`);
 console.log(`  Continue action:    ${continueActionPassed ? 'PASS' : 'FAIL'}`);
 console.log(`  Next action:        ${nextActionPassed ? 'PASS' : 'FAIL'}`);
+console.log(`  Route preview:      ${routePreviewPassed ? 'PASS' : 'FAIL'}`);
 console.log(`  Operator console:   ${operatorConsolePassed ? 'PASS' : 'FAIL'}`);
 console.log(`  Operator journey:   ${operatorJourneyPassed ? 'PASS' : 'FAIL'}`);
 console.log(`  First-use operator: ${firstUseOperatorPassed ? 'PASS' : 'FAIL'}`);
@@ -186,7 +189,7 @@ console.log(`  Fleet session:      ${fleetSessionPassed ? 'PASS' : 'FAIL'}`);
 console.log(`  Worktree readiness: ${worktreeReadinessPassed ? 'PASS' : 'FAIL'}`);
 console.log('');
 
-if (hooksPassed && securityPassed && contractsPassed && runtimeRegistryPassed && runtimeMatrixPassed && hookEventsPassed && skillsPassed && demoPassed && telemetryPassed && telemetryIntegrityPassed && memoryBlockPassed && evidenceContractPassed && sandboxProviderPassed && skillPackagingPassed && mapSubstratePassed && deliveryPassed && deliveryPackagePassed && continueActionPassed && nextActionPassed && operatorConsolePassed && operatorJourneyPassed && firstUseOperatorPassed && verificationPlanPassed && prReadyPassed && stackPlanPassed && coordinationPassed && hookInstallerPassed && campaignPassed && discoveryPassed && discoveryWriterPassed && momentumPassed && momentumWatcherPassed && policyPassed && claudeRuntimePassed && codexRuntimePassed && codexNativeIntegrationPassed && codexOperationalImprovementPassed && installerPassed && projectBootstrapPassed && compatFixturePassed && backwardCompatPassed && costTrackerPassed && dashboardPassed && docSyncPassed && fleetSessionPassed && worktreeReadinessPassed) {
+if (hooksPassed && securityPassed && contractsPassed && runtimeRegistryPassed && runtimeMatrixPassed && hookEventsPassed && skillsPassed && demoPassed && telemetryPassed && telemetryIntegrityPassed && memoryBlockPassed && evidenceContractPassed && sandboxProviderPassed && skillPackagingPassed && mapSubstratePassed && deliveryPassed && deliveryPackagePassed && continueActionPassed && nextActionPassed && routePreviewPassed && operatorConsolePassed && operatorJourneyPassed && firstUseOperatorPassed && verificationPlanPassed && prReadyPassed && stackPlanPassed && coordinationPassed && hookInstallerPassed && campaignPassed && discoveryPassed && discoveryWriterPassed && momentumPassed && momentumWatcherPassed && policyPassed && claudeRuntimePassed && codexRuntimePassed && codexNativeIntegrationPassed && codexOperationalImprovementPassed && installerPassed && projectBootstrapPassed && compatFixturePassed && backwardCompatPassed && costTrackerPassed && dashboardPassed && docSyncPassed && fleetSessionPassed && worktreeReadinessPassed) {
   console.log('All tests pass.\n');
   console.log('Next steps:');
   console.log('  node scripts/skill-bench.js --list      see benchmark scenarios');
@@ -215,6 +218,7 @@ const deliveryFail = !deliveryPassed ? 16 : 0;
 const deliveryPackageFail = !deliveryPackagePassed ? 32 : 0;
 const continueActionFail = !continueActionPassed ? 64 : 0;
 const nextActionFail = !nextActionPassed ? 64 : 0;
+const routePreviewFail = !routePreviewPassed ? 64 : 0;
 const operatorConsoleFail = !operatorConsolePassed ? 128 : 0;
 const operatorJourneyFail = !operatorJourneyPassed ? 128 : 0;
 const firstUseOperatorFail = !firstUseOperatorPassed ? 128 : 0;
@@ -242,7 +246,7 @@ const dashboardFail = !dashboardPassed ? 33554432 : 0;
 const docSyncFail = !docSyncPassed ? 33554432 : 0;
 const fleetSessionFail = !fleetSessionPassed ? 67108864 : 0;
 const worktreeReadinessFail = !worktreeReadinessPassed ? 134217728 : 0;
-const code = hookFail | securityFail | contractFail | runtimeRegistryFail | runtimeMatrixFail | hookEventFail | skillFail | demoFail | telemetryFail | telemetryIntegrityFail | memoryBlockFail | evidenceContractFail | sandboxProviderFail | skillPackagingFail | mapSubstrateFail | deliveryFail | deliveryPackageFail | continueActionFail | nextActionFail | operatorConsoleFail | operatorJourneyFail | firstUseOperatorFail | verificationPlanFail | prReadyFail | stackPlanFail | coordinationFail | hookInstallerFail | campaignFail | discoveryFail | discoveryWriterFail | momentumFail | momentumWatcherFail | policyFail | claudeRuntimeFail | codexRuntimeFail | codexNativeIntegrationFail | codexOperationalImprovementFail | installerFail | projectBootstrapFail | compatFixtureFail | backwardCompatFail | costTrackerFail | dashboardFail | docSyncFail | fleetSessionFail | worktreeReadinessFail;
+const code = hookFail | securityFail | contractFail | runtimeRegistryFail | runtimeMatrixFail | hookEventFail | skillFail | demoFail | telemetryFail | telemetryIntegrityFail | memoryBlockFail | evidenceContractFail | sandboxProviderFail | skillPackagingFail | mapSubstrateFail | deliveryFail | deliveryPackageFail | continueActionFail | nextActionFail | routePreviewFail | operatorConsoleFail | operatorJourneyFail | firstUseOperatorFail | verificationPlanFail | prReadyFail | stackPlanFail | coordinationFail | hookInstallerFail | campaignFail | discoveryFail | discoveryWriterFail | momentumFail | momentumWatcherFail | policyFail | claudeRuntimeFail | codexRuntimeFail | codexNativeIntegrationFail | codexOperationalImprovementFail | installerFail | projectBootstrapFail | compatFixtureFail | backwardCompatFail | costTrackerFail | dashboardFail | docSyncFail | fleetSessionFail | worktreeReadinessFail;
 
 if (!hooksPassed) console.log('Hook smoke test failed. Fix hook issues before proceeding.');
 if (!securityPassed) console.log('Security tests failed. DO NOT SHIP - critical vulnerabilities present.');
@@ -263,6 +267,7 @@ if (!deliveryPassed) console.log('Delivery preflight check failed. Fix intake pa
 if (!deliveryPackagePassed) console.log('Delivery package check failed. Fix review package generation or campaign evidence updates before shipping.');
 if (!continueActionPassed) console.log('Continue action check failed. Fix /do continue routing or local package execution before shipping.');
 if (!nextActionPassed) console.log('Next action check failed. Fix operator routing or deterministic repair execution before shipping.');
+if (!routePreviewPassed) console.log('Route preview check failed. Fix /do routing preview proportionality before shipping.');
 if (!operatorConsolePassed) console.log('Operator console check failed. Fix decision-first operator rendering before shipping.');
 if (!operatorJourneyPassed) console.log('Operator journey check failed. Fix intake-to-package-to-archive operator flow before shipping.');
 if (!firstUseOperatorPassed) console.log('First-use operator check failed. Fix fresh-project /do next behavior before shipping.');

--- a/scripts/test-route-preview.js
+++ b/scripts/test-route-preview.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('assert');
+const childProcess = require('child_process');
+const path = require('path');
+
+const { buildPreview, keywordMatches, parseArgs, render, selectRoute } = require('./route-preview');
+
+assert.deepEqual(parseArgs(['--json', '--project-root', '.', '--', 'review', 'auth']).input, 'review auth');
+
+{
+  const preview = buildPreview('what should I do next', {
+    projectRoot: path.resolve(__dirname, '..'),
+    gitDirty: false,
+    now: '2026-06-05T12:00:00.000Z',
+  });
+  assert.equal(preview.selected, '/do next');
+  assert.equal(preview.command, 'node scripts/operator-console.js --run');
+  assert.equal(preview.tier, 0);
+  assert.equal(preview.canRunNow, true);
+}
+
+{
+  const route = selectRoute('review src/auth.ts');
+  assert.equal(route.selected, '/review');
+  assert.equal(route.tier, 2);
+  assert(route.reason.includes('/review'));
+}
+
+{
+  const route = selectRoute('research competitors and write implementation phases');
+  assert.equal(route.selected, '/marshal');
+  assert.equal(route.tier, 3);
+  assert(route.alternatives.some((item) => item.route === '/research'));
+}
+
+{
+  const route = selectRoute('use multiple agents at the same time on scripts/dashboard.js');
+  assert.equal(route.selected, '/marshal');
+  assert(route.reason.includes('single file') || route.reason.includes('single-file'));
+}
+
+{
+  const route = selectRoute('run a campaign');
+  assert.equal(route.selected, '/marshal');
+  assert(route.reason.includes('brief'));
+}
+
+{
+  const preview = buildPreview('review auth module', {
+    projectRoot: path.resolve(__dirname, '..'),
+    gitDirty: true,
+  });
+  assert.equal(preview.canRunNow, false);
+  assert.equal(preview.boundary, 'worktree-review');
+  assert(preview.approval.includes('uncommitted'));
+}
+
+{
+  const matches = keywordMatches('fix ci and watch pr checks');
+  assert(matches.some((item) => item.route === '/pr-watch'));
+}
+
+{
+  const rendered = render(buildPreview('review auth module', {
+    projectRoot: path.resolve(__dirname, '..'),
+    gitDirty: false,
+    now: '2026-06-05T12:00:00.000Z',
+  }));
+  assert(rendered.includes('Routing Preview'));
+  assert(rendered.includes('Selected: /review'));
+  assert(rendered.includes('Boundary'));
+  assert(rendered.includes('Verify'));
+}
+
+{
+  const output = childProcess.execFileSync(process.execPath, [
+    path.join(__dirname, 'route-preview.js'),
+    '--json',
+    '--',
+    'review auth module',
+  ], { encoding: 'utf8' });
+  const payload = JSON.parse(output);
+  assert.equal(payload.selected, '/review');
+  assert.equal(payload.input, 'review auth module');
+}
+
+console.log('route preview tests passed');

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -25,6 +25,7 @@ Use `/do` when the user wants something done but doesn't know (or care) which to
 | `/do status` | Show full harness dashboard (/dashboard) |
 | `/do next` | Run the decision-first operator console for the next useful harness action |
 | `/do operator` | Show the operator console without executing repairs |
+| `/do preview <request>` | Show route, alternatives, boundary, and verification without executing |
 | `/do continue` | Resolve and run the deterministic continuation action |
 | `/do --list` | Show all skills grouped by category with trigger keywords |
 | `/do setup` | First-run experience — configure the harness for this project |
@@ -67,6 +68,7 @@ Regex/keyword on raw input. Catches trivial commands:
 | "status", "dashboard", "what's happening", "what's going on", "show activity" | Show full harness dashboard (/dashboard) |
 | "next", "what should I do next", "fix harness state", "repair harness" | Run `node scripts/operator-console.js --run`; if it stops on a skill route or human-review action, report the boundary, risk, next command, and verification profile |
 | "operator", "operator console", "what's up", "what should happen next", "approval capsule" | Run `node scripts/operator-console.js`; report the decision, boundary, artifact freshness, and verification profile |
+| "preview route", "route preview", "dry run route", "what would /do do" | Run `node scripts/route-preview.js -- "<request>"`; report selected route, alternatives, boundary, and verification profile |
 | "continue" or "keep going" | Run `node scripts/continue-action.js --run`; invoke the returned skill route if it prints `/archon continue` or `/fleet continue` |
 | "setup" | Run `/do setup` first-run experience |
 | "deliver <intake-file>" | Run `node scripts/deliver.js --intake <file>` to create an evidence-backed delivery campaign |
@@ -143,6 +145,7 @@ and any project-level custom skills in `.claude/skills/`.
 | "pr ready", "ready for review", "finalize pr", "approval ready" | `node scripts/pr-ready.js --pr <pull-request-url> --run-verification` after the branch is pushed |
 | "next", "what should I do next", "repair harness", "fix harness state" | `node scripts/operator-console.js --run`; auto-runs deterministic local repairs and stops at skill/human routes with a console report |
 | "operator", "operator console", "what's up", "what should happen next", "approval capsule" | `node scripts/operator-console.js`; inspect-only decision cockpit |
+| "preview route", "route preview", "dry run route", "what would /do do" | `node scripts/route-preview.js -- "<request>"`; route preflight without execution |
 | "setup", "first run", "configure harness" | `/setup` |
 | "research", "investigate", "look into", "find out" | `/research` |
 | "experiment", "optimize", "try", "A/B", "measure" | `/experiment` |


### PR DESCRIPTION
## Summary

Adds a deterministic route preview command so `/do` route choice can be inspected before execution.

This turns the routing preview guide from PR #145 into an actual local preflight: it selects the lightest likely route, shows alternatives, names proportionality downgrades, reports the approval/worktree boundary, and tells the operator what verification should prove the choice.

## What Changed

- adds `scripts/route-preview.js`
- adds `scripts/test-route-preview.js`
- wires `route:preview` into `package.json`
- adds the route preview check to `scripts/test-all.js`
- updates `skills/do/SKILL.md` with `/do preview <request>` routing language
- updates `docs/ROUTING_PREVIEW.md` with command and JSON examples

## Verification

- `node scripts/test-route-preview.js`
- `node scripts/route-preview.js -- "review auth module"`
- `node scripts/skill-lint.js do`
- `npm run test`
- `node scripts/pr-ready.js --pr https://github.com/SethGammon/Citadel/pull/148 --branch codex/route-preview-command --run-verification --json --project-root C:\Users\gammo\Desktop\Citadel`
- `node scripts/stack-plan.js --json`

## Readiness Evidence

- Head: `9154793`
- PR readiness report: `.planning/pr-readiness/codex-route-preview-command.md`
- Readiness gates: PR URL pass, git clean, dashboard clean, verification pass (`npm run test exited 0`)
- Stack status: approval-needed, 9 PRs, 0 blocked
- Stack approval capsule: `.planning/approval-capsules/latest.md`

## Review Notes

- The previewer is intentionally deterministic and conservative. It covers cheap Tier 0 and keyword routes, falls back to Marshal for ambiguity, and applies proportionality checks before Archon/Fleet.
- Dirty worktrees produce a `worktree-review` boundary before target execution.
- This PR does not execute routes; it only previews the route decision and verification expectations.

## Stack

Landing order currently reported by `node scripts/stack-plan.js --json`:

1. #136 `codex/campaign-truth-loop`
2. #137 `codex/operator-next-loop`
3. #138 `codex/operator-console-v1`
4. #139 `codex/stack-readiness-plan`
5. #140 `codex/first-use-operator-journey`
6. #144 `codex/report-artifact-guide`
7. #145 `codex/routing-preview-guide`
8. #146 `codex/skill-memory-visibility`
9. #148 `codex/route-preview-command`

Human approval is still required before marking drafts ready or merging.