### PR TITLE
Document public positioning proof

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -102,3 +102,6 @@ For a 90-second proof clip, record the core demo in a real terminal or agent win
 7. Show the final report and the `.planning/` evidence.
 
 Keep the recording practical: real repo, real commands, real output.
+
+For the evidence checklist behind this recording, see
+[Operating Loop Proof](docs/OPERATING_LOOP_PROOF.md).

--- a/README.md
+++ b/README.md
@@ -229,9 +229,11 @@ The priority is reliability over novelty: make the harness easier to install, ea
 
 - [Install](INSTALL.md) - manual setup for Codex and Claude Code
 - [Demo workflow](DEMO.md) - copyable operating-loop demo for a real repo
+- [Operating loop proof](docs/OPERATING_LOOP_PROOF.md) - evidence checklist for demos and PRs
 - [Quickstart](QUICKSTART.md) - first-run paths for both runtimes
 - [Interactive routing demo](https://sethgammon.github.io/Citadel/) - watch the tier cascade animate
 - [Routing preview guide](docs/ROUTING_PREVIEW.md) - compare Skill, Marshal, Archon, and Fleet before heavier work
+- [Public positioning](docs/PUBLIC_POSITIONING.md) - how to describe Citadel without overclaiming
 - [Skill and memory visibility](docs/SKILL_MEMORY_VISIBILITY.md) - inspect available skills and compiled project memory
 - [Skills reference](docs/SKILLS.md) - all built-in skills with invocation and examples
 - [Hooks reference](docs/HOOKS.md) - lifecycle events and enforcement behavior

--- a/docs/OPERATING_LOOP_PROOF.md
+++ b/docs/OPERATING_LOOP_PROOF.md
@@ -1,0 +1,76 @@
+# Operating Loop Proof
+
+Citadel is easiest to evaluate by watching one complete operating loop in a
+real repository. The proof is not that an agent can describe features. The proof
+is that a later session can inspect what happened and continue from evidence.
+
+Use this checklist when recording a demo, reviewing a PR, or deciding whether a
+new workflow belongs in Citadel.
+
+## The Loop
+
+| Step | Command or surface | Evidence to inspect | What it proves |
+|---|---|---|---|
+| Install | installer plus `/do setup --express` | `.planning/`, runtime config, hook setup output | Citadel can attach to the current repository without placeholder paths. |
+| Orient | `/do next` or dashboard scripts | current state, next action, risk boundary, verification profile | The operator can see what Citadel thinks before approving work. |
+| Route | `/do <plain-English task>` | selected skill or orchestrator, handoff, changed files if any | Users do not need to memorize every skill before getting useful behavior. |
+| Verify | project-specific check selected by the agent | command output, verification plan, pass/fail summary | Work is tied to the repository's real quality gate, not a generic claim. |
+| Report | final answer, PR body, or `.planning/` report | summary, decisions, unresolved items, follow-up command | Another session can resume from a concrete record. |
+
+## Good Evidence
+
+Good proof is boring and inspectable:
+
+- the repository is real, not a synthetic fixture built only for the demo
+- commands are shown exactly as typed
+- setup uses the current project root
+- verification is chosen from the project, not guessed from Citadel docs
+- generated reports identify files, commands, and outcomes
+- unsupported runtime features are reported as unavailable instead of hidden
+
+Weak proof looks like a feature tour:
+
+- screenshots without commands
+- claims about routing without showing the selected workflow
+- reports that omit the verification command
+- demos that rely on local absolute paths or private setup steps
+- generated prose that cannot be checked against files or artifacts
+
+## Minimal Public Clip
+
+A short public proof clip should show this sequence:
+
+```text
+/do setup --express
+/do next
+/do review README.md for first-time developer friction
+/do identify the project's safest verification command and run it
+/cost
+```
+
+Then show one concrete artifact: a `.planning/` report, a PR body with
+verification, or a final handoff that names the files and commands involved.
+
+If cost telemetry is unavailable in the current runtime, show that message. The
+point is visibility, not pretending every adapter has the same data.
+
+## PR Review Rule
+
+When a change claims to improve the public demo, first ask what new evidence the
+viewer can inspect. Prefer small changes that make the loop clearer:
+
+- a more direct first command
+- a better next-action summary
+- a real verification command
+- a report with source paths and outcomes
+- a public doc that explains how to reproduce the loop
+
+Avoid changes that only add slogans, decorative screenshots, or broad claims
+without a command path.
+
+## Expected Outcome
+
+This proof framing keeps Citadel's public positioning anchored to the behavior
+builders care about: the agent sets up in the real repo, chooses the right
+workflow, verifies against the local project, and leaves evidence that survives
+the chat.

--- a/docs/PUBLIC_POSITIONING.md
+++ b/docs/PUBLIC_POSITIONING.md
@@ -1,0 +1,98 @@
+# Public Positioning
+
+Citadel should be explained as an operating layer for coding agents, not as a
+new agent runtime and not as a promise of unattended correctness.
+
+Use this guide when editing the README, writing demo copy, recording public
+clips, or reviewing contributor docs.
+
+## Core Position
+
+Citadel helps Claude Code and OpenAI Codex work across real repositories by
+adding the harness around the model:
+
+- durable project memory
+- `/do` intent routing
+- lifecycle hooks and approval boundaries
+- verification and report artifacts
+- multi-agent coordination through isolated worktrees
+
+The short version:
+
+```text
+Citadel is an open-source orchestration layer that makes coding agents easier
+to operate across real projects.
+```
+
+## Audience
+
+Citadel is for builders who already use local coding agents and are hitting
+operational limits:
+
+- repeated context setup across sessions
+- unclear workflow choice for review, debugging, refactor, or larger builds
+- weak handoffs after context reset
+- manual safety and verification discipline
+- ad hoc coordination when work needs multiple branches or agents
+
+It is less useful for one-off toy prompts, non-git folders, or teams that want a
+hosted SaaS dashboard before adopting a local harness.
+
+## Claims to Make
+
+Prefer claims that can be inspected in the repository:
+
+- Citadel stores project state under `.planning/`.
+- `/do` routes plain-language tasks to skills and orchestrators.
+- Hooks, approval capsules, and verification plans make local automation easier
+  to review.
+- Fleet coordinates independent work in isolated git worktrees.
+- Reports and handoffs make later sessions less dependent on chat memory.
+
+Tie claims to commands or files whenever possible.
+
+## Claims to Avoid
+
+Avoid language that overstates what the harness can guarantee:
+
+- "fully autonomous engineer"
+- "safe unattended execution"
+- "replaces code review"
+- "guarantees correct routing"
+- "secure sandbox"
+- "works identically across all runtimes"
+- "no human approval needed"
+
+Citadel can improve operating discipline. It does not remove the need for human
+review, repository-specific verification, or approval around risky actions.
+
+## Public Proof Standard
+
+When public copy says Citadel is real, point to evidence:
+
+- the install prompt and `/do setup --express`
+- the [demo workflow](../DEMO.md)
+- the [operating loop proof](OPERATING_LOOP_PROOF.md)
+- the [report artifact guide](REPORT_ARTIFACTS.md)
+- the local verification command, usually `npm test` for this repository
+
+Screenshots and videos are useful only when they show the command path, the
+selected workflow, and the resulting artifact or verification output.
+
+## Review Checklist
+
+Before merging public-facing copy, check:
+
+- Does it describe Citadel as a harness or operating layer?
+- Does it name at least one concrete command, file, or artifact?
+- Does it avoid unsupported autonomy or security guarantees?
+- Does it distinguish local repo state from publishable public docs?
+- Does it explain who benefits without claiming every coding-agent user needs
+  the full harness?
+
+## Expected Outcome
+
+Clear positioning helps the right users understand Citadel quickly: it is the
+repo-local operating layer around Claude Code and Codex, built for memory,
+routing, safety boundaries, verification, and coordinated work that survives a
+single chat session.


### PR DESCRIPTION
## Summary

Adds public positioning and operating-loop proof guidance so Citadel's external claims stay tied to inspectable behavior.

This is a documentation-only slice stacked on the route preview command. It gives contributors and reviewers a concrete standard for demo copy, public README edits, and public-facing claims: explain Citadel as a repo-local operating layer, avoid autonomy/security overclaims, and point to command-backed evidence.

## What Changed

- adds `docs/PUBLIC_POSITIONING.md`
- adds `docs/OPERATING_LOOP_PROOF.md`
- links the operating-loop proof checklist from `DEMO.md`
- links both guides from the README Learn More list

## Verification

- `git diff --check`
- `node scripts/test-demo.js`
- manual link/path check for README, DEMO, public positioning, and operating-loop proof docs
- `node scripts/pr-ready.js --pr https://github.com/SethGammon/Citadel/pull/150 --branch codex/public-positioning-proof --verification "node scripts/test-demo.js" --run-verification --json --project-root C:\Users\gammo\Desktop\Citadel`
- `node scripts/stack-plan.js --json`

## Readiness Evidence

- Head: `bd914dc`
- PR readiness report: `.planning/pr-readiness/codex-public-positioning-proof.md`
- Readiness gates: PR URL pass, git clean, dashboard clean, verification pass (`node scripts/test-demo.js exited 0`)
- Stack status: approval-needed, 10 PRs, 0 blocked
- Stack approval capsule: `.planning/approval-capsules/latest.md`

## Review Notes

- This PR deliberately stays docs-only.
- The proof guide favors boring, inspectable evidence: setup, `/do next`, route choice, project verification, and a durable artifact.
- The positioning guide explicitly avoids unsupported claims like safe unattended execution, replacing code review, or guaranteed routing.

## Stack

Landing order currently reported by `node scripts/stack-plan.js --json`:

1. #136 `codex/campaign-truth-loop`
2. #137 `codex/operator-next-loop`
3. #138 `codex/operator-console-v1`
4. #139 `codex/stack-readiness-plan`
5. #140 `codex/first-use-operator-journey`
6. #144 `codex/report-artifact-guide`
7. #145 `codex/routing-preview-guide`
8. #146 `codex/skill-memory-visibility`
9. #148 `codex/route-preview-command`
10. #150 `codex/public-positioning-proof`

Human approval is still required before marking drafts ready or merging.