### PR TITLE
Harden readiness setup checks

### DIFF
--- a/core/verification/profiles.js
+++ b/core/verification/profiles.js
@@ -15,7 +15,8 @@ function unique(values) {
 function readPackageScripts(projectRoot) {
   try {
     const packagePath = path.join(projectRoot, 'package.json');
-    const parsed = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+    const raw = fs.readFileSync(packagePath, 'utf8').replace(/^\uFEFF/, '');
+    const parsed = JSON.parse(raw);
     return parsed.scripts || {};
   } catch {
     return {};

--- a/docs/USEFULNESS_TRIAL.md
+++ b/docs/USEFULNESS_TRIAL.md
@@ -57,6 +57,11 @@ operator output, reporting, or public proof. It is stricter than a smoke test:
 it treats Citadel as an experience a builder has to understand, not only a set
 of scripts that pass.
 
+Installer output alone is not enough for `ready-for-dogfood`. A freshly
+prepared Codex project may have plugin files, hooks, and readiness artifacts but
+still need `/do setup --express` before Citadel has complete operating state.
+In that case the trial should return `setup-needed`, not `blocked`.
+
 The expected post-landing flow is:
 
 ```text

--- a/scripts/operating-proof.js
+++ b/scripts/operating-proof.js
@@ -48,6 +48,10 @@ function normalizePath(value) {
   return String(value || '').replace(/\\/g, '/');
 }
 
+function unique(values) {
+  return Array.from(new Set(values.filter(Boolean)));
+}
+
 function exists(filePath) {
   try {
     return fs.existsSync(filePath);
@@ -100,8 +104,10 @@ function checkSetup(projectRoot, dashboard) {
     '.planning/campaigns',
     '.planning/telemetry',
   ]);
+  const hasCompleteSetup = requiredState.includes('.planning/campaigns')
+    && requiredState.includes('.planning/telemetry');
 
-  if (dashboard.planningExists) {
+  if (hasCompleteSetup) {
     return {
       id: 'setup',
       status: 'pass',
@@ -111,13 +117,18 @@ function checkSetup(projectRoot, dashboard) {
   }
 
   const setupHint = dashboard.nextAction?.command === '/do setup --express';
+  const hasPartialSetup = requiredState.includes('.planning');
+  const partialEvidence = unique([
+    ...requiredState,
+    '/do setup --express',
+  ]);
   return {
     id: 'setup',
-    status: setupHint ? 'partial' : 'fail',
-    detail: setupHint
+    status: setupHint || hasPartialSetup ? 'partial' : 'fail',
+    detail: setupHint || hasPartialSetup
       ? 'project is not initialized yet; dashboard points to /do setup --express'
-      : 'project is not initialized and dashboard did not provide an express setup path',
-    evidence: setupHint ? ['/do setup --express'] : [],
+      : 'project is missing complete setup state and dashboard did not provide an express setup path',
+    evidence: setupHint || hasPartialSetup ? partialEvidence : requiredState,
   };
 }
 

--- a/scripts/test-operating-proof.js
+++ b/scripts/test-operating-proof.js
@@ -58,6 +58,25 @@ withTempProject((projectRoot) => {
       test: 'node -e "process.exit(0)"',
     },
   }, null, 2));
+  fs.mkdirSync(path.join(projectRoot, '.planning', 'verification'), { recursive: true });
+
+  const proof = buildProof(projectRoot, {
+    routeRequest: 'review README.md for first-time developer friction',
+    runVerification: true,
+  });
+
+  assert.equal(proof.status, 'partial');
+  assert.equal(proof.summary.setup, 'partial');
+  assert(proof.checks.find((check) => check.id === 'setup').evidence.includes('.planning'));
+});
+
+withTempProject((projectRoot) => {
+  write(path.join(projectRoot, 'README.md'), '# Fixture\n');
+  write(path.join(projectRoot, 'package.json'), JSON.stringify({
+    scripts: {
+      test: 'node -e "process.exit(0)"',
+    },
+  }, null, 2));
   fs.mkdirSync(path.join(projectRoot, '.planning', 'campaigns'), { recursive: true });
   fs.mkdirSync(path.join(projectRoot, '.planning', 'telemetry'), { recursive: true });
   write(path.join(projectRoot, '.planning', 'operator-console', 'latest.md'), 'operator evidence\n');

--- a/scripts/test-verification-plan.js
+++ b/scripts/test-verification-plan.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const { changedFilesFromGit, profileForFiles, selectVerificationProfile } = require('../core/verification/profiles');
+const { changedFilesFromGit, profileForFiles, readPackageScripts, selectVerificationProfile } = require('../core/verification/profiles');
 const { render } = require('./verification-plan');
 
 function withTempProject(run) {
@@ -49,6 +49,14 @@ withTempProject((projectRoot) => {
   assert(output.includes('Citadel Verification Plan'));
   assert(output.includes('Profile: operator-loop'));
   assert(output.includes('---HANDOFF---'));
+});
+
+withTempProject((projectRoot) => {
+  fs.writeFileSync(path.join(projectRoot, 'package.json'), `\uFEFF${JSON.stringify({
+    scripts: { test: 'node test.js' },
+  })}`, 'utf8');
+
+  assert.equal(readPackageScripts(projectRoot).test, 'node test.js');
 });
 
 withTempProject((projectRoot) => {


### PR DESCRIPTION
## Summary

- tolerate UTF-8 BOMs when reading package scripts for verification profiles
- classify partial `.planning` setup as `partial` in operating proof instead of treating plugin-only setup as blocked
- document the setup-needed behavior in the usefulness trial guide

## Verification

- `git diff --check`
- `npm run test`

## Branch cleanup note

This PR preserves the only local uncommitted readiness work found during branch cleanup. All previous stale remote branches were already merged, patch-equivalent, or superseded before deletion.