### PR TITLE
fix: relax overprotective hook gates

### DIFF
--- a/core/policy/external-actions.js
+++ b/core/policy/external-actions.js
@@ -45,7 +45,9 @@ const DEFAULT_HARD = [
   'gh api (mutating)', 'git push --delete',
 ];
 
-const DEFAULT_SOFT = [
+const DEFAULT_SOFT = [];
+
+const DEFAULT_ALLOW = [
   'git push',
   'gh pr create', 'gh pr comment/edit',
   'gh issue create/comment/edit',
@@ -59,12 +61,14 @@ function readExternalActionPolicy(config) {
       : DEFAULT_PROTECTED_BRANCHES,
     hard: externalActions.hard || DEFAULT_HARD,
     soft: externalActions.soft || DEFAULT_SOFT,
+    allow: externalActions.allow || DEFAULT_ALLOW,
   };
 }
 
 function getTier(label, policy) {
   if (policy.hard.includes(label)) return 'hard';
   if (policy.soft.includes(label)) return 'soft';
+  if (policy.allow.includes(label)) return 'allow';
   return 'allow';
 }
 
@@ -130,6 +134,7 @@ function detectExternalAction(command, policy) {
 
 module.exports = {
   ALL_PATTERNS,
+  DEFAULT_ALLOW,
   DEFAULT_HARD,
   DEFAULT_PROTECTED_BRANCHES,
   DEFAULT_SOFT,

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -2,44 +2,100 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Edit|Write",
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/protect-files.js",
-            "timeout": 5
+            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" protect-files",
+            "statusMessage": "Citadel: protect-files",
+            "timeout": 5,
+            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" protect-files"
           }
-        ]
+        ],
+        "matcher": "Edit"
       },
       {
-        "matcher": "Read",
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/protect-files.js",
-            "timeout": 5
+            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" protect-files",
+            "statusMessage": "Citadel: protect-files",
+            "timeout": 5,
+            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" protect-files"
           }
-        ]
+        ],
+        "matcher": "Write"
       },
       {
-        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/external-action-gate.js",
-            "timeout": 5
+            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" protect-files",
+            "statusMessage": "Citadel: protect-files",
+            "timeout": 5,
+            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" protect-files"
           }
-        ]
+        ],
+        "matcher": "Read"
       },
       {
-        "matcher": "Edit|Write|Bash|Agent",
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/governance.js",
-            "timeout": 3
+            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" external-action-gate",
+            "statusMessage": "Citadel: external-action-gate",
+            "timeout": 5,
+            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" external-action-gate"
           }
-        ]
+        ],
+        "matcher": "Bash"
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" governance",
+            "statusMessage": "Citadel: governance",
+            "timeout": 3,
+            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" governance"
+          }
+        ],
+        "matcher": "Edit"
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" governance",
+            "statusMessage": "Citadel: governance",
+            "timeout": 3,
+            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" governance"
+          }
+        ],
+        "matcher": "Write"
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" governance",
+            "statusMessage": "Citadel: governance",
+            "timeout": 3,
+            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" governance"
+          }
+        ],
+        "matcher": "Bash"
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" governance",
+            "statusMessage": "Citadel: governance",
+            "timeout": 3,
+            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" governance"
+          }
+        ],
+        "matcher": "Agent"
       }
     ],
     "PostToolUse": [
@@ -47,38 +103,10 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/post-edit.js",
-            "timeout": 30
-          }
-        ]
-      },
-      {
-        "matcher": "Edit|Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/organize-enforce.js",
-            "timeout": 5
-          }
-        ]
-      },
-      {
-        "matcher": "Edit|Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/complexity-check.js",
-            "timeout": 5
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/circuit-breaker.js",
-            "timeout": 5
+            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" post-edit",
+            "statusMessage": "Citadel: post-edit",
+            "timeout": 30,
+            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" post-edit"
           }
         ]
       },
@@ -86,32 +114,70 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/cost-tracker.js",
-            "timeout": 5
+            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" organize-enforce",
+            "statusMessage": "Citadel: organize-enforce",
+            "timeout": 5,
+            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" organize-enforce"
           }
-        ]
-      }
-    ],
-    "PostToolBatch": [
+        ],
+        "matcher": "Edit"
+      },
       {
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/post-tool-batch.js",
-            "timeout": 10,
-            "async": true,
-            "asyncRewake": true
+            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" organize-enforce",
+            "statusMessage": "Citadel: organize-enforce",
+            "timeout": 5,
+            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" organize-enforce"
           }
-        ]
-      }
-    ],
-    "PostToolUseFailure": [
+        ],
+        "matcher": "Write"
+      },
       {
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/circuit-breaker.js",
-            "timeout": 5
+            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" complexity-check",
+            "statusMessage": "Citadel: complexity-check",
+            "timeout": 5,
+            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" complexity-check"
+          }
+        ],
+        "matcher": "Edit"
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" complexity-check",
+            "statusMessage": "Citadel: complexity-check",
+            "timeout": 5,
+            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" complexity-check"
+          }
+        ],
+        "matcher": "Write"
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" circuit-breaker",
+            "statusMessage": "Citadel: circuit-breaker",
+            "timeout": 5,
+            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" circuit-breaker"
+          }
+        ],
+        "matcher": "Bash"
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" cost-tracker",
+            "statusMessage": "Citadel: cost-tracker",
+            "timeout": 5,
+            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" cost-tracker"
           }
         ]
       }
@@ -121,8 +187,10 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/pre-compact.js",
-            "timeout": 15
+            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" pre-compact",
+            "statusMessage": "Citadel: pre-compact",
+            "timeout": 15,
+            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" pre-compact"
           }
         ]
       }
@@ -132,8 +200,10 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/post-compact.js",
-            "timeout": 10
+            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" post-compact",
+            "statusMessage": "Citadel: post-compact",
+            "timeout": 10,
+            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" post-compact"
           }
         ]
       }
@@ -143,52 +213,21 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/quality-gate.js",
-            "timeout": 10
+            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" quality-gate",
+            "statusMessage": "Citadel: quality-gate",
+            "timeout": 10,
+            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" quality-gate"
           }
         ]
-      }
-    ],
-    "StopFailure": [
+      },
       {
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/stop-failure.js",
-            "timeout": 5
-          }
-        ]
-      }
-    ],
-    "Setup": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/init-project.js",
-            "timeout": 10
-          }
-        ]
-      }
-    ],
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/user-prompt-submit.js",
-            "timeout": 5
-          }
-        ]
-      }
-    ],
-    "UserPromptExpansion": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/user-prompt-expansion.js",
-            "timeout": 5
+            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" session-end",
+            "statusMessage": "Citadel: session-end",
+            "timeout": 10,
+            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" session-end"
           }
         ]
       }
@@ -198,18 +237,10 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/init-project.js",
-            "timeout": 10
-          }
-        ]
-      },
-      {
-        "matcher": "compact",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/restore-compact.js",
-            "timeout": 5
+            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" init-project",
+            "statusMessage": "Citadel: init-project",
+            "timeout": 10,
+            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" init-project"
           }
         ]
       },
@@ -217,19 +248,22 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/intake-scanner.js",
-            "timeout": 5
+            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" restore-compact",
+            "statusMessage": "Citadel: restore-compact",
+            "timeout": 5,
+            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" restore-compact"
           }
-        ]
-      }
-    ],
-    "SessionEnd": [
+        ],
+        "matcher": "compact"
+      },
       {
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/session-end.js",
-            "timeout": 10
+            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" intake-scanner",
+            "statusMessage": "Citadel: intake-scanner",
+            "timeout": 5,
+            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" intake-scanner"
           }
         ]
       }
@@ -239,8 +273,10 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/subagent-start.js",
-            "timeout": 5
+            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" subagent-start",
+            "statusMessage": "Citadel: subagent-start",
+            "timeout": 5,
+            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" subagent-start"
           }
         ]
       }
@@ -250,19 +286,10 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/subagent-stop.js",
-            "timeout": 5
-          }
-        ]
-      }
-    ],
-    "TeammateIdle": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/teammate-idle.js",
-            "timeout": 5
+            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" subagent-stop",
+            "statusMessage": "Citadel: subagent-stop",
+            "timeout": 5,
+            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" subagent-stop"
           }
         ]
       }
@@ -272,140 +299,10 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/permission-request.js",
-            "timeout": 3
-          }
-        ]
-      }
-    ],
-    "PermissionDenied": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/permission-request.js",
-            "timeout": 3
-          }
-        ]
-      }
-    ],
-    "InstructionsLoaded": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/instructions-loaded.js",
-            "timeout": 5
-          }
-        ]
-      }
-    ],
-    "FileChanged": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/file-changed.js",
-            "timeout": 5
-          }
-        ]
-      }
-    ],
-    "CwdChanged": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/cwd-changed.js",
-            "timeout": 5
-          }
-        ]
-      }
-    ],
-    "ConfigChange": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/config-change.js",
-            "timeout": 5
-          }
-        ]
-      }
-    ],
-    "Elicitation": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/elicitation.js",
-            "timeout": 5
-          }
-        ]
-      }
-    ],
-    "ElicitationResult": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/elicitation.js",
-            "timeout": 5
-          }
-        ]
-      }
-    ],
-    "Notification": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/notification.js",
-            "timeout": 5
-          }
-        ]
-      }
-    ],
-    "TaskCreated": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/task-events.js",
-            "timeout": 5
-          }
-        ]
-      }
-    ],
-    "TaskCompleted": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/task-events.js",
-            "timeout": 5
-          }
-        ]
-      }
-    ],
-    "WorktreeCreate": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/worktree-setup.js",
-            "timeout": 120
-          }
-        ]
-      }
-    ],
-    "WorktreeRemove": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/worktree-remove.js",
-            "timeout": 10
+            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" permission-request",
+            "statusMessage": "Citadel: permission-request",
+            "timeout": 3,
+            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" permission-request"
           }
         ]
       }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -2,100 +2,44 @@
   "hooks": {
     "PreToolUse": [
       {
+        "matcher": "Edit|Write",
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" protect-files",
-            "statusMessage": "Citadel: protect-files",
-            "timeout": 5,
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" protect-files"
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/protect-files.js",
+            "timeout": 5
           }
-        ],
-        "matcher": "Edit"
+        ]
       },
       {
+        "matcher": "Read",
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" protect-files",
-            "statusMessage": "Citadel: protect-files",
-            "timeout": 5,
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" protect-files"
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/protect-files.js",
+            "timeout": 5
           }
-        ],
-        "matcher": "Write"
+        ]
       },
       {
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" protect-files",
-            "statusMessage": "Citadel: protect-files",
-            "timeout": 5,
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" protect-files"
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/external-action-gate.js",
+            "timeout": 5
           }
-        ],
-        "matcher": "Read"
+        ]
       },
       {
+        "matcher": "Edit|Write|Bash|Agent",
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" external-action-gate",
-            "statusMessage": "Citadel: external-action-gate",
-            "timeout": 5,
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" external-action-gate"
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/governance.js",
+            "timeout": 3
           }
-        ],
-        "matcher": "Bash"
-      },
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" governance",
-            "statusMessage": "Citadel: governance",
-            "timeout": 3,
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" governance"
-          }
-        ],
-        "matcher": "Edit"
-      },
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" governance",
-            "statusMessage": "Citadel: governance",
-            "timeout": 3,
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" governance"
-          }
-        ],
-        "matcher": "Write"
-      },
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" governance",
-            "statusMessage": "Citadel: governance",
-            "timeout": 3,
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" governance"
-          }
-        ],
-        "matcher": "Bash"
-      },
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" governance",
-            "statusMessage": "Citadel: governance",
-            "timeout": 3,
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" governance"
-          }
-        ],
-        "matcher": "Agent"
+        ]
       }
     ],
     "PostToolUse": [
@@ -103,10 +47,38 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" post-edit",
-            "statusMessage": "Citadel: post-edit",
-            "timeout": 30,
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" post-edit"
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/post-edit.js",
+            "timeout": 30
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/organize-enforce.js",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/complexity-check.js",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/circuit-breaker.js",
+            "timeout": 5
           }
         ]
       },
@@ -114,70 +86,32 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" organize-enforce",
-            "statusMessage": "Citadel: organize-enforce",
-            "timeout": 5,
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" organize-enforce"
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/cost-tracker.js",
+            "timeout": 5
           }
-        ],
-        "matcher": "Edit"
-      },
+        ]
+      }
+    ],
+    "PostToolBatch": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" organize-enforce",
-            "statusMessage": "Citadel: organize-enforce",
-            "timeout": 5,
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" organize-enforce"
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/post-tool-batch.js",
+            "timeout": 10,
+            "async": true,
+            "asyncRewake": true
           }
-        ],
-        "matcher": "Write"
-      },
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" complexity-check",
-            "statusMessage": "Citadel: complexity-check",
-            "timeout": 5,
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" complexity-check"
-          }
-        ],
-        "matcher": "Edit"
-      },
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" complexity-check",
-            "statusMessage": "Citadel: complexity-check",
-            "timeout": 5,
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" complexity-check"
-          }
-        ],
-        "matcher": "Write"
-      },
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" circuit-breaker",
-            "statusMessage": "Citadel: circuit-breaker",
-            "timeout": 5,
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" circuit-breaker"
-          }
-        ],
-        "matcher": "Bash"
-      },
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" cost-tracker",
-            "statusMessage": "Citadel: cost-tracker",
-            "timeout": 5,
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" cost-tracker"
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/circuit-breaker.js",
+            "timeout": 5
           }
         ]
       }
@@ -187,10 +121,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" pre-compact",
-            "statusMessage": "Citadel: pre-compact",
-            "timeout": 15,
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" pre-compact"
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/pre-compact.js",
+            "timeout": 15
           }
         ]
       }
@@ -200,10 +132,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" post-compact",
-            "statusMessage": "Citadel: post-compact",
-            "timeout": 10,
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" post-compact"
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/post-compact.js",
+            "timeout": 10
           }
         ]
       }
@@ -213,21 +143,52 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" quality-gate",
-            "statusMessage": "Citadel: quality-gate",
-            "timeout": 10,
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" quality-gate"
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/quality-gate.js",
+            "timeout": 10
           }
         ]
-      },
+      }
+    ],
+    "StopFailure": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" session-end",
-            "statusMessage": "Citadel: session-end",
-            "timeout": 10,
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" session-end"
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/stop-failure.js",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Setup": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/init-project.js",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/user-prompt-submit.js",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "UserPromptExpansion": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/user-prompt-expansion.js",
+            "timeout": 5
           }
         ]
       }
@@ -237,10 +198,18 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" init-project",
-            "statusMessage": "Citadel: init-project",
-            "timeout": 10,
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" init-project"
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/init-project.js",
+            "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/restore-compact.js",
+            "timeout": 5
           }
         ]
       },
@@ -248,22 +217,19 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" restore-compact",
-            "statusMessage": "Citadel: restore-compact",
-            "timeout": 5,
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" restore-compact"
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/intake-scanner.js",
+            "timeout": 5
           }
-        ],
-        "matcher": "compact"
-      },
+        ]
+      }
+    ],
+    "SessionEnd": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" intake-scanner",
-            "statusMessage": "Citadel: intake-scanner",
-            "timeout": 5,
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" intake-scanner"
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/session-end.js",
+            "timeout": 10
           }
         ]
       }
@@ -273,10 +239,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" subagent-start",
-            "statusMessage": "Citadel: subagent-start",
-            "timeout": 5,
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" subagent-start"
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/subagent-start.js",
+            "timeout": 5
           }
         ]
       }
@@ -286,10 +250,19 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" subagent-stop",
-            "statusMessage": "Citadel: subagent-stop",
-            "timeout": 5,
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" subagent-stop"
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/subagent-stop.js",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "TeammateIdle": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/teammate-idle.js",
+            "timeout": 5
           }
         ]
       }
@@ -299,10 +272,140 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" permission-request",
-            "statusMessage": "Citadel: permission-request",
-            "timeout": 3,
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" permission-request"
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/permission-request.js",
+            "timeout": 3
+          }
+        ]
+      }
+    ],
+    "PermissionDenied": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/permission-request.js",
+            "timeout": 3
+          }
+        ]
+      }
+    ],
+    "InstructionsLoaded": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/instructions-loaded.js",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "FileChanged": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/file-changed.js",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "CwdChanged": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/cwd-changed.js",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "ConfigChange": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/config-change.js",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Elicitation": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/elicitation.js",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "ElicitationResult": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/elicitation.js",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/notification.js",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "TaskCreated": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/task-events.js",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "TaskCompleted": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/task-events.js",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/worktree-setup.js",
+            "timeout": 120
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks_src/worktree-remove.js",
+            "timeout": 10
           }
         ]
       }

--- a/hooks_src/external-action-gate.js
+++ b/hooks_src/external-action-gate.js
@@ -9,8 +9,10 @@
  *   SECRETS - Always blocked. Reading .env files via Bash.
  *   HARD    - Always blocked per-action. Irreversible by default (merge, close,
  *             delete, release, fork). Configurable via policy.externalActions.hard.
- *   SOFT    - Governed by consent preference. Reversible by default (push, PR
- *             create, comment). Configurable via policy.externalActions.soft.
+ *   SOFT    - Governed by consent preference. Empty by default; teams can opt
+ *             reversible actions into consent via policy.externalActions.soft.
+ *   ALLOW   - Reversible delivery actions by default (push, PR create/comment,
+ *             issue create/comment/edit). Configurable via policy.externalActions.allow.
  *
  * Policy overrides (harness.json):
  *   policy.externalActions.protectedBranches - branches that can never be deleted

--- a/hooks_src/organize-enforce.js
+++ b/hooks_src/organize-enforce.js
@@ -4,12 +4,12 @@
  * organize-enforce.js -- PostToolUse hook (runs on Edit/Write)
  *
  * Checks if newly written or edited files comply with the project's
- * organization manifest (harness.json -> organization). Warns or blocks
- * based on the manifest's `locked` flag.
+ * organization manifest (harness.json -> organization). Warns by default.
+ * A locked manifest blocks only when the file also matches organization.enforcePaths.
  *
  * Enforcement levels:
  *   - locked: false -> advisory warning (exit 0)
- *   - locked: true  -> hard block (exit 2)
+ *   - locked: true + enforcePaths match -> hard block (exit 2)
  *
  * Skips gracefully when:
  *   - No organization config exists
@@ -116,6 +116,19 @@ const COLLECTOR_DIRS = [
   'styles',
 ];
 
+const ADVISORY_ONLY_PREFIXES = [
+  'test/',
+  'tests/',
+  '__test__/',
+  '__tests__/',
+  'fixtures/',
+  '__fixtures__/',
+  'migrations/',
+  'generated/',
+  'tmp/',
+  'temp/',
+];
+
 /**
  * Strip companion suffixes from a filename to get the base source name.
  * e.g., "Button.test.tsx" -> "Button", "auth.spec.js" -> "auth"
@@ -145,6 +158,26 @@ function sourceExistsInDir(dir, baseName) {
     if (fs.existsSync(path.join(absDir, baseName + ext))) return true;
   }
   return false;
+}
+
+function matchesPathPattern(filePath, pattern) {
+  if (!pattern) return false;
+  const normalized = String(pattern).replace(/\\/g, '/');
+  if (normalized.endsWith('/')) return filePath.startsWith(normalized);
+  if (normalized.includes('*') || normalized.includes('?') || normalized.includes('{')) {
+    return globToRegex(normalized).test(filePath);
+  }
+  return filePath === normalized || filePath.startsWith(normalized.replace(/\/$/, '') + '/');
+}
+
+function shouldBlockViolation(org, relativePath) {
+  if (org.locked !== true) return false;
+  if (ADVISORY_ONLY_PREFIXES.some(prefix => relativePath.startsWith(prefix))) return false;
+
+  const enforcePaths = Array.isArray(org.enforcePaths) ? org.enforcePaths : [];
+  if (enforcePaths.length === 0) return false;
+
+  return enforcePaths.some(pattern => matchesPathPattern(relativePath, pattern));
 }
 
 function main() {
@@ -350,7 +383,7 @@ function main() {
     }
 
     // Report violations
-    const locked = org.locked === true;
+    const locked = shouldBlockViolation(org, relativePath);
     const severity = locked ? 'BLOCK' : 'WARN';
     const action = locked ? 'blocked' : 'warned';
 
@@ -368,7 +401,11 @@ function main() {
     }
 
     if (!locked) {
-      lines.push('  (advisory -- run /organize --lock to enforce)');
+      if (org.locked === true) {
+        lines.push('  (advisory -- locked enforcement only blocks paths in organization.enforcePaths)');
+      } else {
+        lines.push('  (advisory -- run /organize --lock with enforcePaths to enforce)');
+      }
     } else {
       lines.push('  Move the file to the correct location before continuing.');
     }

--- a/hooks_src/permission-request.js
+++ b/hooks_src/permission-request.js
@@ -14,8 +14,10 @@
  *
  * Known-safe patterns (auto-approve):
  *   - Bash: node .citadel/scripts/*.js (telemetry delegates)
+ *   - Bash: repo-local verification commands
  *   - Write/Edit: .planning/**  (campaign and fleet state)
  *   - Write/Edit: .citadel/**   (harness scaffolding)
+ *   - Write/Edit: .codex/**, .agents/**, hooks/** (generated harness artifacts)
  *
  * Exit codes:
  *   0 = always (decision communicated via JSON stdout, not exit code)
@@ -32,11 +34,19 @@ const PROJECT_ROOT = health.PROJECT_ROOT;
 const SAFE_BASH_PATTERNS = [
   /^node\s+\.citadel\/scripts\//,
   /^node\s+"[^"]*\.citadel[/\\]scripts[/\\]/,
+  /^npm\s+run\s+(test|lint|typecheck|docs:check|design:gate|codex:verify|verify:visual)(?:\s|$)/,
+  /^node\s+scripts\/(?:test[-\w]*|verify-hooks|integration-test|skill-lint)\.js(?:\s|$)/,
+  /^node\s+hooks_src\/smoke-test\.js(?:\s|$)/,
+  /^git\s+(status|diff)(?:\s|$)/,
 ];
 
 const SAFE_FILE_PREFIXES = [
   path.join(PROJECT_ROOT, '.planning').replace(/\\/g, '/'),
   path.join(PROJECT_ROOT, '.citadel').replace(/\\/g, '/'),
+  path.join(PROJECT_ROOT, '.codex').replace(/\\/g, '/'),
+  path.join(PROJECT_ROOT, '.Codex').replace(/\\/g, '/'),
+  path.join(PROJECT_ROOT, '.agents').replace(/\\/g, '/'),
+  path.join(PROJECT_ROOT, 'hooks').replace(/\\/g, '/'),
 ];
 
 function isSafeBashCommand(command) {
@@ -48,7 +58,7 @@ function isSafeBashCommand(command) {
 function isSafeFilePath(filePath) {
   if (!filePath) return false;
   const normalized = String(filePath).replace(/\\/g, '/');
-  return SAFE_FILE_PREFIXES.some(prefix => normalized.startsWith(prefix));
+  return SAFE_FILE_PREFIXES.some(prefix => normalized === prefix || normalized.startsWith(prefix + '/'));
 }
 
 function main() {

--- a/hooks_src/post-edit.js
+++ b/hooks_src/post-edit.js
@@ -18,7 +18,8 @@
  *
  * Exit codes:
  *   0 = success (or non-checkable file, or non-Edit/Write tool)
- *   2 = type errors found in edited file
+ *   0 = success, including advisory type errors by default
+ *   2 = type errors found when verification.hotBlockOnErrors is true
  */
 
 const { execFileSync } = require('child_process');
@@ -103,7 +104,9 @@ function main() {
       agent_type: agentType,
     });
 
-    process.exit(exitCode);
+    const config = health.readConfig();
+    const hotBlockOnErrors = config.verification?.hotBlockOnErrors === true;
+    process.exit(hotBlockOnErrors ? exitCode : 0);
   });
 }
 

--- a/hooks_src/protect-files.js
+++ b/hooks_src/protect-files.js
@@ -4,7 +4,8 @@
  * protect-files.js — PreToolUse hook (Edit/Write/Read)
  *
  * Blocks edits to files that should not be modified during agent sessions.
- * Blocks reads on .env files to prevent agents from reading secrets.
+ * Blocks reads on .env files to prevent agents from reading secrets, including
+ * .env files outside the project root.
  * Protected paths are configurable via harness.json protectedFiles array.
  *
  * Default protected: .claude/harness.json
@@ -101,10 +102,13 @@ function run(input) {
     process.exit(2);
   }
 
-  // Security: block absolute paths outside project root
+  // Security: block writes to absolute paths outside project root. Reads may
+  // inspect neighboring docs, vaults, and reference repos; .env reads are still
+  // blocked by basename below.
   const normalizedPath = path.normalize(path.resolve(filePath));
   const normalizedRoot = path.normalize(PROJECT_ROOT);
-  if (!normalizedPath.startsWith(normalizedRoot + path.sep) && normalizedPath !== normalizedRoot) {
+  const insideProject = normalizedPath.startsWith(normalizedRoot + path.sep) || normalizedPath === normalizedRoot;
+  if (toolName !== 'Read' && !insideProject) {
     health.logBlock('protect-files', 'blocked', `${toolName} ${filePath} (outside project root)`);
     hookOutput('protect-files', 'blocked',
       `[protect-files] Blocked: ${filePath} is outside project root (${PROJECT_ROOT})`,
@@ -113,7 +117,9 @@ function run(input) {
     process.exit(2);
   }
 
-  const relativePath = path.relative(PROJECT_ROOT, filePath).split(path.sep).join('/');
+  const relativePath = insideProject
+    ? path.relative(PROJECT_ROOT, filePath).split(path.sep).join('/')
+    : normalizedPath;
 
   // Read events: only block .env files (secrets protection)
   if (toolName === 'Read') {
@@ -179,16 +185,19 @@ function checkCampaignScope(relativePath, toolName, _filePath) {
 
     const rawName = campaign.slug || 'campaign';
     const campaignName = rawName.replace(/[^a-zA-Z0-9_\-]/g, '_');
+    const config = health.readConfig();
+    const blockRestricted = config.policy?.campaignRestrictions?.blockRestrictedFiles === true;
 
     for (const entry of campaign.restrictedFiles || []) {
       if (entry && matchPattern(relativePath, entry)) {
-        health.logBlock('protect-files', 'blocked-restricted', `${toolName} ${relativePath} (campaign: ${campaignName}, restricted: ${entry})`);
+        health.logBlock('protect-files', blockRestricted ? 'blocked-restricted' : 'warned-restricted', `${toolName} ${relativePath} (campaign: ${campaignName}, restricted: ${entry})`);
         hookOutput('protect-files', 'blocked',
-          `[protect-files] Blocked: ${relativePath} is declared RESTRICTED by campaign "${campaignName}". ` +
-          `Remove it from the campaign's "Restricted Files" section to allow edits.`,
+          `[protect-files] ${blockRestricted ? 'Blocked' : 'Warning'}: ${relativePath} is declared RESTRICTED by campaign "${campaignName}". ` +
+          `${blockRestricted ? 'Remove it from Restricted Files or set policy.campaignRestrictions.blockRestrictedFiles=false to allow edits.' : 'This is advisory; set policy.campaignRestrictions.blockRestrictedFiles=true to enforce.'}`,
           { file: relativePath, campaign: campaignName, restrictedEntry: entry, tool: toolName }
         );
-        process.exit(2);
+        if (blockRestricted) process.exit(2);
+        return;
       }
     }
 

--- a/scripts/integration-test.js
+++ b/scripts/integration-test.js
@@ -304,6 +304,12 @@ sequence('Edit .env.local: blocked by protect-files', (sb) => {
   if (!pre.blocked) return 'expected .env.local read to be blocked';
 }, sandbox);
 
+sequence('Read external non-env file: not blocked by protect-files', (sb) => {
+  const filePath = path.join(os.tmpdir(), `citadel-external-${process.pid}.md`);
+  const pre = preToolUse(sb, 'Read', { file_path: filePath });
+  if (pre.blocked) return `unexpected block: ${pre.blockMessage}`;
+}, sandbox);
+
 sequence('Edit normal file in .claude/: not blocked', (sb) => {
   // .claude/settings.json is not in protectedFiles — only harness.json
   const filePath = path.join(sb, '.claude', 'notes.md');
@@ -338,7 +344,7 @@ sequence('Edit out-of-scope file: warns but does not block', (sb) => {
   if (!r.stdout.includes('outside the claimed scope')) return `expected scope warning, got: ${r.stdout.slice(0, 200)}`;
 }, sandbox);
 
-sequence('Edit restricted file: hard-blocked by protect-files', (sb) => {
+sequence('Edit restricted file: warns by default in protect-files', (sb) => {
   const campaignDir = path.join(sb, '.planning', 'campaigns');
   const campaignFile = path.join(campaignDir, 'restricted-test.md');
   fs.writeFileSync(campaignFile, [
@@ -355,8 +361,7 @@ sequence('Edit restricted file: hard-blocked by protect-files', (sb) => {
   const filePath = path.join(sb, '.env.production');
   const pre = preToolUse(sb, 'Edit', { file_path: filePath });
   fs.rmSync(campaignFile);
-  if (!pre.blocked) return 'expected restricted file to be blocked';
-  if (!pre.blockMessage.includes('RESTRICTED')) return `expected RESTRICTED in message, got: ${pre.blockMessage}`;
+  if (pre.blocked) return `expected advisory warning, got block: ${pre.blockMessage}`;
 }, sandbox);
 
 console.log('\n── Bash flow ──');

--- a/scripts/test-backward-compat.js
+++ b/scripts/test-backward-compat.js
@@ -209,7 +209,7 @@ check('Default policy fills missing config', () => {
   const policy = readExternalActionPolicy({});
   assert(policy.protectedBranches.includes('main'));
   assert(policy.hard.includes('gh pr merge'));
-  assert(policy.soft.includes('git push'));
+  assert(policy.allow.includes('git push'));
 });
 
 check('Policy with merge moved to soft tier works', () => {

--- a/scripts/test-organize-enforce.js
+++ b/scripts/test-organize-enforce.js
@@ -179,7 +179,7 @@ test('root-dir: warns when file is outside target (unlocked)', (dir) => {
 });
 
 test('root-dir: blocks when file is outside target (locked)', (dir) => {
-  writeConfig(dir, { organization: { locked: true, placement: [{ glob: '*.ts', rule: 'root-dir', target: 'src' }] } });
+  writeConfig(dir, { organization: { locked: true, enforcePaths: ['lib/'], placement: [{ glob: '*.ts', rule: 'root-dir', target: 'src' }] } });
   writeFile(dir, 'lib/helper.ts');
   const r = fireHook(editEvent(dir, 'lib/helper.ts'), dir);
   if (r.exitCode !== 2) return `expected exit 2 (block), got ${r.exitCode}`;
@@ -353,7 +353,7 @@ test('unlocked: violations produce exit 0 (advisory)', (dir) => {
   if (!r.stdout.includes('advisory')) return `expected "advisory" hint, got: ${r.stdout.slice(0, 200)}`;
 });
 
-test('locked: violations produce exit 2 (block)', (dir) => {
+test('locked without enforcePaths remains advisory', (dir) => {
   writeConfig(dir, {
     organization: {
       locked: true,
@@ -362,8 +362,35 @@ test('locked: violations produce exit 2 (block)', (dir) => {
   });
   writeFile(dir, 'wrong/place.ts');
   const r = fireHook(editEvent(dir, 'wrong/place.ts'), dir);
+  if (r.exitCode !== 0) return `expected exit 0, got ${r.exitCode}`;
+  if (!r.stdout.includes('enforcePaths')) return `expected enforcePaths hint, got: ${r.stdout.slice(0, 200)}`;
+});
+
+test('locked with enforcePaths violations produce exit 2 (block)', (dir) => {
+  writeConfig(dir, {
+    organization: {
+      locked: true,
+      enforcePaths: ['wrong/'],
+      placement: [{ glob: '*.ts', rule: 'root-dir', target: 'src' }],
+    },
+  });
+  writeFile(dir, 'wrong/place.ts');
+  const r = fireHook(editEvent(dir, 'wrong/place.ts'), dir);
   if (r.exitCode !== 2) return `expected exit 2, got ${r.exitCode}`;
   if (!r.stdout.includes('Move the file')) return `expected move instruction, got: ${r.stdout.slice(0, 200)}`;
+});
+
+test('locked with enforcePaths keeps test paths advisory', (dir) => {
+  writeConfig(dir, {
+    organization: {
+      locked: true,
+      enforcePaths: ['tests/**'],
+      placement: [{ glob: '*.ts', rule: 'root-dir', target: 'src' }],
+    },
+  });
+  writeFile(dir, 'tests/place.ts');
+  const r = fireHook(editEvent(dir, 'tests/place.ts'), dir);
+  if (r.exitCode !== 0) return `expected exit 0, got ${r.exitCode}`;
 });
 
 // -- general root enforcement --

--- a/scripts/test-policy-core.js
+++ b/scripts/test-policy-core.js
@@ -27,7 +27,10 @@ const protectedBranch = detectExternalAction('git push origin --delete main', de
 assert.equal(protectedBranch.kind, 'protected-branch', 'protected branch deletion should be detected');
 
 const soft = detectExternalAction('git push origin feat/test', defaultPolicy);
-assert.equal(soft.tier, 'soft', 'git push should be soft-tier by default');
+assert.equal(soft.tier, 'allow', 'git push should be allowed by default');
+
+const prCreate = detectExternalAction('gh pr create --title test --body test', defaultPolicy);
+assert.equal(prCreate.tier, 'allow', 'gh pr create should be allowed by default');
 
 const hard = detectExternalAction('gh release create v1.0.0', defaultPolicy);
 assert.equal(hard.tier, 'hard', 'release create should be hard-tier by default');

--- a/scripts/test-security.js
+++ b/scripts/test-security.js
@@ -92,6 +92,21 @@ function main() {
     assert(result.status === 2, `Expected exit code 2 (block), got ${result.status}`);
   });
 
+  test('protect-files allows absolute read outside project for non-env files', () => {
+    const input = JSON.stringify({
+      tool_name: 'Read',
+      tool_input: { file_path: path.join(os.tmpdir(), `citadel-reference-${process.pid}.md`) }
+    });
+
+    const result = spawnSync(process.execPath, [PROTECT_FILES_HOOK], {
+      input,
+      encoding: 'utf8',
+      cwd: PLUGIN_ROOT,
+    });
+
+    assert(result.status === 0, `Expected exit code 0 (allow), got ${result.status}: ${result.stdout}`);
+  });
+
   test('protect-files allows legitimate project-relative path', () => {
     const input = JSON.stringify({
       tool_name: 'Edit',
@@ -221,7 +236,7 @@ function main() {
     assert(result.stderr.includes('protected branch'), 'Expected protected branch message');
   });
 
-  test('external-action-gate triggers first-encounter for soft actions', () => {
+  test('external-action-gate allows reversible delivery actions by default', () => {
     const input = JSON.stringify({
       tool_name: 'Bash',
       tool_input: { command: 'git push origin feat/test' }
@@ -234,12 +249,7 @@ function main() {
       env: { ...process.env, CLAUDE_PROJECT_DIR: os.tmpdir() },
     });
 
-    // With no harness.json in tmpdir, this should be a first-encounter block
-    assert(result.status === 2, `Expected exit code 2 (block), got ${result.status}`);
-    assert(
-      result.stderr.includes('First external action') || result.stderr.includes('first-encounter'),
-      'Expected first-encounter message'
-    );
+    assert(result.status === 0, `Expected exit code 0 (allow), got ${result.status}: ${result.stderr}`);
   });
 
   test('external-action-gate allows non-external commands', () => {

--- a/scripts/verify-hooks.js
+++ b/scripts/verify-hooks.js
@@ -296,6 +296,15 @@ test('protect-files: allows Read on non-env file (exit 0)', () => {
   if (r.exitCode !== 0) return `expected exit 0, got ${r.exitCode}`;
 });
 
+test('protect-files: allows Read outside project root for non-env files (exit 0)', () => {
+  const payload = {
+    tool_name: 'Read',
+    tool_input: { file_path: path.join(os.tmpdir(), `citadel-external-${process.pid}.md`) },
+  };
+  const r = fireHook('protect-files.js', payload, rDir);
+  if (r.exitCode !== 0) return `expected exit 0, got ${r.exitCode}: ${r.stdout}`;
+});
+
 // ── governance.js ──
 
 test('governance: writes audit.jsonl entry on Edit', () => {
@@ -543,6 +552,28 @@ test('permission-request: auto-approves citadel script (stdout has allow decisio
   const payload = {
     tool_name: 'Bash',
     tool_input: { command: 'node .citadel/scripts/telemetry-log.cjs --event test' },
+  };
+  const r = fireHook('permission-request.js', payload, rDir);
+  if (r.exitCode !== 0) return `exit ${r.exitCode}`;
+  if (!r.stdout.includes('"behavior":"allow"') && !r.stdout.includes('"behavior": "allow"'))
+    return 'expected auto-approve decision in stdout';
+});
+
+test('permission-request: auto-approves known verification commands', () => {
+  const payload = {
+    tool_name: 'Bash',
+    tool_input: { command: 'npm run test' },
+  };
+  const r = fireHook('permission-request.js', payload, rDir);
+  if (r.exitCode !== 0) return `exit ${r.exitCode}`;
+  if (!r.stdout.includes('"behavior":"allow"') && !r.stdout.includes('"behavior": "allow"'))
+    return 'expected auto-approve decision in stdout';
+});
+
+test('permission-request: auto-approves generated codex artifact writes', () => {
+  const payload = {
+    tool_name: 'Write',
+    tool_input: { file_path: path.join(rDir, '.codex', 'config.toml') },
   };
   const r = fireHook('permission-request.js', payload, rDir);
   if (r.exitCode !== 0) return `exit ${r.exitCode}`;
@@ -807,7 +838,7 @@ test('protect-files: warns (not blocks) on out-of-scope edit', () => {
   fs.rmSync(path.join(campaignsDir, 'test-scope.md'));
 });
 
-test('protect-files: hard-blocks on Restricted Files edit', () => {
+test('protect-files: warns on Restricted Files edit by default', () => {
   const campaignsDir = path.join(rDir, '.planning', 'campaigns');
   fs.writeFileSync(path.join(campaignsDir, 'test-restricted.md'), [
     '# Campaign: Test Restricted',
@@ -825,8 +856,37 @@ test('protect-files: hard-blocks on Restricted Files edit', () => {
     tool_input: { file_path: path.join(rDir, '.env.production') },
   };
   const r = fireHook('protect-files.js', payload, rDir);
-  if (r.exitCode !== 2) return `expected exit 2 (block), got ${r.exitCode}`;
+  if (r.exitCode !== 0) return `expected exit 0 (advisory), got ${r.exitCode}`;
+  if (!r.stdout.includes('RESTRICTED')) return 'expected restricted warning in stdout';
   fs.rmSync(path.join(campaignsDir, 'test-restricted.md'));
+});
+
+test('protect-files: hard-blocks on Restricted Files edit when strict policy is enabled', () => {
+  const campaignsDir = path.join(rDir, '.planning', 'campaigns');
+  const harnessPath = path.join(rDir, '.claude', 'harness.json');
+  fs.mkdirSync(path.dirname(harnessPath), { recursive: true });
+  const hadHarness = fs.existsSync(harnessPath);
+  const originalHarness = hadHarness ? fs.readFileSync(harnessPath, 'utf8') : null;
+  fs.writeFileSync(harnessPath, JSON.stringify({
+    policy: { campaignRestrictions: { blockRestrictedFiles: true } },
+  }, null, 2));
+  fs.writeFileSync(path.join(campaignsDir, 'test-restricted.md'), [
+    '# Campaign: Test Restricted',
+    'Status: active',
+    '',
+    '## Restricted Files',
+    '- .env.production',
+  ].join('\n'));
+
+  const payload = {
+    tool_name: 'Edit',
+    tool_input: { file_path: path.join(rDir, '.env.production') },
+  };
+  const r = fireHook('protect-files.js', payload, rDir);
+  if (hadHarness) fs.writeFileSync(harnessPath, originalHarness);
+  else fs.rmSync(harnessPath, { force: true });
+  fs.rmSync(path.join(campaignsDir, 'test-restricted.md'));
+  if (r.exitCode !== 2) return `expected exit 2 (block), got ${r.exitCode}`;
 });
 
 // ── Audit integrity (harness-health-util) ──


### PR DESCRIPTION
## Summary
- allow external non-env reads while keeping .env read protection
- allow reversible delivery actions by default while keeping destructive GitHub actions blocked
- make campaign restricted files and organization locks advisory unless strict enforcement is explicitly configured
- make post-edit typecheck advisory by default and broaden safe permission auto-approvals for verification/generated harness artifacts

## Verification
- node scripts/test-all.js