### PR TITLE
Roadmap rewrite: dashboard-first release tracks plus dashboard spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,13 +196,13 @@ npm test
 
 ## Roadmap
 
-The full milestone plan with exit criteria lives in [docs/ROADMAP.md](docs/ROADMAP.md). Current priorities:
+The full plan with exit criteria lives in [docs/ROADMAP.md](docs/ROADMAP.md). The arc: make the harness visible, prove it with numbers, then make it steerable.
 
-- **Campaign recovery:** better rollback, resume, and repair tools for interrupted long-running work.
-- **Codex parity:** tighter native support for Codex plugin packaging, hooks, MCP wiring, and app verification.
-- **Fleet merge discipline:** clearer merge-review queues, conflict handling, and branch hygiene for parallel agents.
-- **Team workflows:** shared campaign visibility, policy templates, and safer defaults for multi-operator repositories.
-- **Observability:** better local dashboards for hook activity, cost, campaign health, and agent throughput.
+- **See It:** a local dashboard over `.planning/` state: campaigns, fleet, loops, hooks, and dual-mode cost (dollars for API users, plan-window burn for subscribers). Spec in [docs/DASHBOARD_SPEC.md](docs/DASHBOARD_SPEC.md).
+- **Prove It:** a public, reproducible benchmark page: completion rate and cost on long tasks, bare agent vs harnessed.
+- **Drive It:** approvals, steering, and a loop builder in the browser, through the same file contracts the terminal uses.
+- **Harden It:** teams-native fleet GA, sandboxed execution profiles, threat model v2, release integrity.
+- **Multiply It:** team workflows, a community skill and loop registry, and a third runtime adapter.
 
 ## Learn More
 

--- a/docs/DASHBOARD_SPEC.md
+++ b/docs/DASHBOARD_SPEC.md
@@ -1,0 +1,149 @@
+# Citadel Dashboard Specification (R1: v0.1 read-only)
+
+`citadel dashboard` (also `npm run dashboard:web`) serves a local web app that renders the
+project's `.planning/` state and telemetry live. It is the visible form of the harness:
+campaigns, fleet, loops, hooks, costs, and handoffs in one glanceable surface.
+
+This document specifies v0.1 (read-only) and names the contracts that v0.2+ (two-way) will
+build on. Roadmap context lives in [ROADMAP.md](ROADMAP.md) R1 and R3.
+
+## Principles
+
+1. **Files are canonical.** The dashboard is a view over `.planning/` markdown and JSON plus
+   telemetry JSONL. Deleting the dashboard loses nothing. It never holds state the files do
+   not.
+2. **One contract for terminal and browser.** In v0.2, browser actions write intent files
+   into `.planning/` that hooks and agents consume. The dashboard never gets a private API
+   into the runtime; if the terminal cannot do it through files, neither can the browser.
+3. **Honesty over polish.** Unknown state renders as unknown, never green. Every cost figure
+   derived from token math carries an "est." label. Every claim links to its evidence: the
+   diff, the file, the telemetry line.
+4. **Local only.** Binds to `127.0.0.1`. No auth layer in v0.1 because there is no remote
+   access. Adding remote access in any form is out of scope for this spec and gated on the
+   threat model (ROADMAP R4).
+
+## Architecture
+
+```
+.planning/** + telemetry JSONL + OTLP receiver
+        │ (fs.watch, debounced — reuse scripts/local-watch.js pattern)
+        ▼
+scripts/dashboard-server.js     Node, stdlib only, no new runtime deps
+  ├── normalizers (core/…)      parse-campaign, loops, fleet, telemetry readers
+  ├── GET /api/*                normalized JSON snapshots
+  ├── GET /api/events           SSE: push invalidation keys on file change
+  ├── POST /otlp/v1/metrics     OTLP/HTTP receiver (cost mode, see below)
+  └── static /                  single-bundle SPA (no CDN, works offline)
+```
+
+- Server start must not scan the world: index `.planning/` lazily, cache parsed records
+  keyed by mtime, and re-parse only changed files on watch events.
+- The SPA receives SSE invalidation keys (`campaigns`, `loops`, `cost`, ...) and refetches
+  only the affected `/api/*` snapshot. No polling loops.
+- Reuse existing parsers (`core/campaigns/parse-campaign`, evidence contracts, loops
+  registry readers). The dashboard adds normalizers, not new interpretations of state.
+- Port: default `4180`, `--port` to override, fail with a clear message if taken.
+
+## Data contracts (v0.1 endpoints)
+
+All endpoints return `{ generated_at, source_files: [...], data }`. Shapes are versioned
+with a top-level `schema: 1` so v0.2 can evolve without breaking saved clients.
+
+| Endpoint | Source | `data` shape (summary) |
+|---|---|---|
+| `/api/overview` | all below | `{ needs_you: Item[], active: {campaigns, fleet_agents, loops}, cost_today, last_verify }` |
+| `/api/campaigns` | `.planning/campaigns/*.md` | `[{ id, title, status, phase: {n, of, title}, progress, started_at, last_handoff, evidence }]` |
+| `/api/campaigns/:id` | campaign file + handoffs | full phase list, exit conditions, decisions, artifacts |
+| `/api/fleet` | `.planning/fleet/` | `[{ session, agents: [{ name, scope, worktree, status, last_discovery }], wave, merge_queue }]` |
+| `/api/loops` | `.planning/loops/*.json`, `daemon.json` | `[{ id, type, trigger, budget: {kind, total, spent}, verifier, last_run: {at, status}, stop_state }]` |
+| `/api/hooks/feed` | telemetry JSONL | last N hook events: `{ at, event, decision, reason, target }` (blocks first) |
+| `/api/handoffs` | `.planning/handoffs/`, campaign records | timeline of `{ at, campaign, summary, path }` |
+| `/api/cost` | OTLP receiver + transcript fallback | see Cost modes |
+
+`needs_you` is the product. It aggregates anything waiting on a human: campaign phase gates,
+fleet merge reviews, loops in `needs-human-review` or `blocked`, stale approvals. Sorted by
+age. The dashboard's home answers "do I need to do anything?" in one glance.
+
+## Cost modes
+
+Two user populations, two units. Mode is detected per session and shown explicitly.
+
+**API-key mode (unit: estimated USD).**
+- Source of truth: OTLP metrics from the runtime. Setup wires the env vars
+  (`CLAUDE_CODE_ENABLE_TELEMETRY=1`, `OTEL_METRICS_EXPORTER=otlp`,
+  `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`,
+  `OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4180/otlp`) opt-in during `/do setup`.
+- Metrics consumed: `claude_code.cost.usage` (USD), `claude_code.token.usage`, and request
+  events carrying `cost_usd` with `skill.name` / `agent.name` / `mcp_server.name` / model /
+  effort attribution. Attribution powers per-skill and per-campaign-phase cost breakdowns.
+- Every dollar figure renders with "est." and a tooltip: estimates are computed locally
+  from token counts and can differ from the bill; the Console is authoritative.
+- Burn rate and projected cost-to-finish are derived from the active campaign's phase
+  history. Projections are labeled as projections.
+
+**Subscription mode (unit: plan window).**
+- Pro/Max users do not pay per token; dollars are the wrong unit. Render plan-window
+  consumption (session tokens, share of recent usage by skill/agent, activity over 24h/7d)
+  from the same token telemetry, mirroring how `/usage` treats subscribers.
+- Optional delight stat: "this campaign would have cost ~$X at API prices, included in
+  your plan." Same "est." discipline.
+- Window-percentage math is an estimate from local history (other devices not visible);
+  say so in the UI.
+
+**Fallbacks.** No OTLP: parse transcript JSONL usage fields where available. Bedrock,
+Vertex, and Foundry emit no cost metrics: tokens-only with a note. Codex: token usage via
+the Codex adapter; cost treated as API mode when a key is configured. Unknown: render
+"telemetry off" with the one-line instruction to enable it, never zeros.
+
+## Panels (v0.1)
+
+| Panel | Content | Evidence links |
+|---|---|---|
+| Needs You (home) | aggregated interrupts, age-sorted, count in tab title | each item links to its file/diff |
+| Campaigns | cards: phase progress, status, last handoff, evidence freshness | campaign md, handoff md |
+| Fleet | agents, scopes, worktrees, wave status, merge queue preview | worktree paths, discovery log |
+| Loops | contract cards: budget burn-down, verifier history, stop-state badge | loop JSON, review artifact |
+| Cost | mode-appropriate spend, per-skill attribution, burn rate | telemetry lines |
+| Hook feed | recent decisions, blocks first, friendly reason text | rule + target file |
+
+Multi-project switching, fortress view, and any write action are explicitly v0.2+
+(ROADMAP R3). Ship the six panels well.
+
+## Quality bars
+
+**Performance budgets (enforced by a perf check in CI against a generated fixture
+project with 1,000 planning files):**
+- Cold start to first render: < 1 s. Server RSS: < 50 MB. File-change to UI update:
+  < 500 ms. Interaction latency: < 100 ms.
+- No layout-forcing reads in render loops; SSE invalidation, never polling.
+
+**Design language.** Dark-first with a real light mode. The four tier colors are semantic
+everywhere (cyan skill, blue marshal, orange archon, purple fleet); color is never
+decoration. Mono for data, sans for prose, tabular numerals for every figure. Motion only
+narrates state change: 150-250 ms transitions, transforms and opacity only,
+`prefers-reduced-motion` respected, 60 fps or the animation ships disabled.
+
+**Copy voice.** Calm operator. "Archon finished phase 3. Two files need review." Numbers
+over adjectives. Every empty state teaches (shows the command that would populate it);
+every error names the next action.
+
+**Keyboard.** `?` overlay, j/k through the needs-you queue, Enter to open evidence, cmd+K
+switcher reserved for v0.2.
+
+## Verification
+
+- Unit: normalizers against fixture `.planning/` trees (healthy, mid-campaign, corrupted,
+  empty) — corrupted files render as "unreadable: <path>" rows, never crash the panel.
+- Contract: every `/api/*` response validates against its schema; schema files live next
+  to the server and are the v0.2 compatibility baseline.
+- Perf: budget script in CI per the table above.
+- Visual: screenshot pass on the fixture project (the make-frame technique from the README
+  work) checked at desktop and 380 px widths, dark and light.
+- Manual exit check (matches ROADMAP R1): a person who has never seen Citadel opens the
+  dashboard on a live project and explains what is happening within 60 seconds.
+
+## Out of scope for v0.1
+
+Write actions of any kind, remote access, auth, hosted anything, fortress view,
+multi-project aggregation, Repobeats-style public embeds. Each is either R3 work or parked
+per the roadmap.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,163 +1,134 @@
-# Citadel Roadmap: The Path to World Class
+# Citadel Roadmap: Mission Control for Coding Agents
 
-This is the working milestone plan for making Citadel the reference orchestration layer for
-Claude Code and OpenAI Codex. It is sequenced by leverage: each milestone removes a class of
-risk or unlocks a class of capability, and each has binary exit criteria so progress is
-verifiable rather than vibes.
+Citadel's thesis: the agent companies compete on the agent; nobody owns the operations layer
+above the agents. Memory, routing, guardrails, spend, parallel coordination, and visibility
+are naturally runtime-agnostic, and that layer is what Citadel is becoming.
 
-Origin: a full June 2026 audit of the harness (four deep-dive reviews plus an adversarial
-verification pass over every major finding). The audit confirmed strong fundamentals
-(near-total hook event coverage, quota-aware scheduling, tamper-evident telemetry, real tests)
-and identified the gaps this plan closes.
+This plan supersedes the June 2026 milestone ladder (M0-M7). The shipped milestones are
+recorded below; the unshipped ones are absorbed into the release tracks rather than dropped.
+Sequencing principle is unchanged: reliability over novelty, and every phase has binary exit
+criteria.
 
 ## North Star Metrics
-
-These are the numbers that define "world class" for a harness. Every milestone should move at
-least one of them.
 
 | Metric | Definition | Target |
 |---|---|---|
 | Install success rate | Fresh installs that reach a working `/do` without manual repair | > 95% |
 | Time to first routed task | Install start to first successful `/do` dispatch | < 10 minutes |
 | Campaign resume rate | Interrupted campaigns that resume correctly in a fresh session | > 95% |
-| Safety net honesty | Quality gates that report "did not run" instead of silently passing | 100% |
+| Time to comprehension | A stranger opens the dashboard and can say what Citadel is doing | < 60 seconds |
+| Safety net honesty | Gates that report "did not run" instead of silently passing | 100% |
 | Doc drift | Counts, lists, and tables that can disagree with the code | 0 (generated) |
-| Hook overhead p95 | Added latency per tool call from the hook pipeline | < 200 ms |
 
-## M0: Trust the Safety Net (shipped 2026-06-11)
+## Shipped Foundations (June 2026)
 
-The harness's value rests on its gates being real. This milestone makes every shipped gate do
-what it claims, on every platform.
+- **M0 Trust the Safety Net:** honest cross-platform typecheck outcomes, single source of
+  truth for routing, symmetric secrets protection, watch dedup, fleet teams pilot scaffolding.
+- **M1 One Source of Truth:** generated skill/hook counts across README and docs with a CI
+  drift check.
+- **M2 Native Platform Spine (core):** AskUserQuestion at approval gates, structured outputs
+  for judge agents, checkpoint-aware recovery.
+- **M5 Skill Platform Hygiene:** lint-enforced line budgets, benchmark coverage for
+  destructive skills, skill lifecycle policy.
 
-- Cross-platform post-edit typecheck with honest outcomes (pass, errors, unavailable, timeout).
-  No silent passes, ever.
-- Single source of truth for `/do` routing: keywords live in skill frontmatter, every surface
-  (router table, route preview, demo) is generated, and a drift check runs in CI.
-- Symmetric secrets protection: `.env` writes blocked by default across Edit, Write, and Bash;
-  the native Claude Code memory directory is allowlisted; block reasons are visible on stderr.
-- `/watch` intake dedup and cross-process locking implemented as documented.
-- Fleet Teams Mode pilot scaffolding: protocol, rebalance hook, fallback, benchmark scenario.
+## R1: See It (now to ~6 weeks)
 
-**Exit criteria:** `npm test` green on Windows and POSIX including the new regression tests;
-`generate-routing --check` wired into CI; the typecheck regression guard proves an unavailable
-toolchain produces a visible advisory.
+Convert the invisible parts of the harness (memory, gates, telemetry, loops) into the thing
+people screenshot. Full design in [DASHBOARD_SPEC.md](DASHBOARD_SPEC.md).
 
-## M1: One Source of Truth (core shipped 2026-06-11)
+- **Local dashboard v0.1, read-only.** `citadel dashboard` serves a localhost web app over
+  `.planning/` and telemetry: needs-you inbox, campaigns with phase progress, fleet agents
+  and worktrees, hook activity feed, handoff timeline. Live updates via file watching. The
+  files stay canonical; the dashboard is a view, never a second source of truth.
+- **Loops panel.** Every loop contract record rendered as a card: status, budget burn-down,
+  verifier history, stop-state badge, last review artifact. Loops are already first-class in
+  [LOOP_CONTRACT.md](LOOP_CONTRACT.md); this makes them visible.
+- **Dual-mode cost.** API-key users see estimated dollars (always labeled as estimates),
+  burn rate, and projected cost-to-finish. Subscription users see plan-window consumption
+  and per-skill attribution instead of dollars, mirroring how `/usage` treats them. Sourced
+  from a local OTLP receiver (`claude_code.cost.usage`, `claude_code.token.usage`) with
+  transcript parsing as fallback; Codex via adapter.
+- **Campaign recovery hardening** (carried from the old plan; it is load-bearing for the
+  dashboard story): rollback, resume, and repair for interrupted long-running work.
 
-Eliminate every place where documentation can drift from code, by construction rather than
-discipline.
+**Exit criteria:** a stranger installs Citadel, runs `/do` and `citadel dashboard`, and
+understands what it does in under 60 seconds without reading docs; campaign resume rate
+measured above 95% on the regression suite; dashboard cold start under 1 second and live
+update under 500 ms on a real project.
 
-- Skill counts, skill lists, and hook event tables generated from the catalog into README,
-  docs/SKILLS.md, and docs/ARCHITECTURE.md between markers.
-- Fix AGENTS.md runtime paths; make it a thin dispatcher to CLAUDE.md and Codex equivalents.
-- Consolidate INSTALL.md and QUICKSTART.md into one installation guide with per-runtime
-  sections; DEMO.md becomes a short copyable script that links into it.
-- Extend the routing generator pattern to all generated doc surfaces with one `--check`.
+## R2: Prove It (~6 weeks to 3 months)
 
-**Exit criteria:** a doc-drift test fails CI when any generated surface is stale; a new user
-has exactly one obvious document to follow from clone to first `/do`.
+Manufacture the reason to care: honest, reproducible numbers nobody else publishes.
 
-## M2: Native Platform Spine (gates and contracts shipped 2026-06-11; plugin defaultEnabled deferred)
+- **Public benchmark page** built from the usefulness-trial harness: completion rate and
+  cost on long tasks, bare agent vs harnessed, with methodology and scripts public.
+- **The 90-second demo video** (problem, learning, solution) and a Show HN built around the
+  dashboard plus benchmark page.
+- **Contribution pipeline** (absorbed from M7): good-first-skill issues, a submission
+  checklist, CI running full lint and bench on PRs.
 
-Adopt the platform primitives that replace prompt conventions with contracts.
+**Exit criteria:** a benchmark page we would defend in a comment thread, regenerated by
+script; at least one external contributor lands a skill through the pipeline.
 
-- AskUserQuestion at every approval gate: `/improve` rubric approval, Archon phase boundaries,
-  `/do` ambiguous-route confirmation. Multiple choice beats "STOP and wait".
-- Structured outputs for judge agents (policy-enforcer, phase-validator): schema-enforced
-  returns instead of "respond with ONLY this JSON".
-- Native checkpoint and rewind awareness in Archon recovery, alongside the existing git stash
-  checkpoints (stash for cross-session durability, rewind for in-session rollback).
-- /reload-skills in the create-skill and evolve loops; plugin `defaultEnabled` for invasive
-  components such as the Codex integration.
-- Plan-mode-aware campaign design: spec-first flows start read-only.
+## R3: Drive It (~3 to 5 months)
 
-**Exit criteria:** zero prompt-convention JSON parsing in judge agents; approval gates use
-AskUserQuestion; Archon recovery documents both rollback paths; benchmarks cover the gates.
+The dashboard becomes two-way. Browser actions write intent files into `.planning/` that
+hooks and agents consume, the same contract the terminal uses.
 
-## M3: Teams-Native Fleet GA
+- **Approvals in the browser:** phase gates and risky-action requests with full context
+  (diff, risk note, what happens next), keyboard-first.
+- **Steer, pause, and stop** per agent and per campaign, honoring safe boundaries.
+- **Loop Builder:** a guided flow (trigger, scope, budget, verifier, stop conditions) that
+  refuses to create a loop without a working verifier and a budget. `/do create a loop
+  that...` routes here.
+- **Fortress view:** the same state rendered as a keep; campaigns as banners, agents as
+  units, hook blocks as arrows off the walls, spend as treasury. One-click shareable image.
 
-Graduate the M0 pilot into the default coordination model where the runtime supports it.
+**Exit criteria:** an operator runs a full campaign without touching the terminal after
+launch; a loop authored in the builder runs overnight and stops on its declared conditions.
 
-- Run the Teams Mode pilot on a real multi-scope campaign; measure the success criteria
-  (zero lost discoveries against the .planning mirror, reassignment latency on TeammateIdle,
-  merge conflict rate no worse than classic).
-- Native task spine: scopes and phases live as native tasks with dependency links during
-  execution; `.planning/` remains the durable ledger and recovery source.
-- Make teams mode the default on supporting Claude Code versions with automatic classic
-  fallback; publish the pilot report.
-- Slim fleet SKILL.md below 300 lines by moving protocol depth into docs/FLEET.md.
+## R4: Harden It (~5 to 8 months)
 
-**Exit criteria:** pilot report committed with measured numbers; teams default behind version
-detection; fleet SKILL.md under the line budget; campaign resume works mid-teams-session.
+Depth work that makes the two-way surface safe to trust (absorbs M3 and M6).
 
-## M4: Observability That Sells
+- **Teams-native fleet GA:** run the pilot on a real multi-scope campaign, measure discovery
+  loss, reassignment latency, and merge conflict rate; default on supporting runtimes with
+  classic fallback; publish the pilot report.
+- **Security hardening v2:** sandboxed bash profiles for risky phases, threat model refresh
+  covering teams mode and remote triggers, permission audit reports from real session data,
+  secrets-scanning in the quality gate.
+- **Release integrity:** versioned releases with checksums and migration notes.
 
-Turn the telemetry that already exists into something operators and teams can see.
+**Exit criteria:** pilot report committed with measured numbers; THREAT_MODEL.md v2
+reviewed; a permission audit report renders from real session data.
 
-- OTLP exporter that reads the JSONL telemetry and ships standard OpenTelemetry metrics
-  (token spend, hook latency, agent runs, campaign phases). The hash-chained JSONL stays as
-  the tamper-evident system of record.
-- Dashboard upgrade: hook timing percentiles, campaign cost breakdown, gate outcomes,
-  routine quota usage.
-- Session-start health line: hooks installed, gates active, last verification result.
-- State hygiene: expired consent markers and stale locks cleaned automatically.
+## R5: Multiply It (~8 to 12 months)
 
-**Exit criteria:** one command exports to a local OTEL collector demo; dashboard shows hook
-p50/p95; no unbounded state files remain.
+- **Team workflows** (absorbed from M7): multi-operator campaign visibility, policy
+  templates per repository class, managed-settings guidance for organizations.
+- **Skill and loop registry:** community-contributed skills and loop templates with the
+  existing lint and bench suites as the quality bar, discoverable from the project site.
+- **Runtime expansion:** evaluate a third adapter (Gemini CLI or OpenCode) to make
+  runtime-agnostic undeniable. Adapter work must not regress the two supported runtimes.
 
-## M5: Skill Platform Hygiene (shipped 2026-06-11)
+**Exit criteria:** a team of 5+ runs Citadel as shared infrastructure; a skill or loop the
+maintainer did not write reaches meaningful installs through the registry.
 
-Make the skill collection sustainable as it grows.
+## Parked: Relay
 
-- Line budget enforced by skill-lint: no SKILL.md over 300 lines; split fleet, setup,
-  organize, and watch into core protocol plus linked appendices.
-- Merge `/research` and `/research-fleet` behind one flag; resolve the `/organize` versus
-  `/refactor` boundary (narrow organize or fold it in).
-- Benchmark coverage at 100% for every state-changing or destructive skill (houseclean,
-  organize, watch included).
-- Skill lifecycle policy: versioning field, deprecation path, and router regeneration on any
-  add, rename, or removal.
-
-**Exit criteria:** lint enforces the budget; every destructive skill has scenarios; a skill
-rename is a one-command operation that updates every surface.
-
-## M6: Security Hardening v2
-
-Extend the existing strong posture to the new execution models.
-
-- Sandboxed bash profiles for risky campaign phases, loosening prompts for reversible work
-  inside the sandbox.
-- Threat model refresh covering Teams Mode, routines, and remote triggers.
-- Permission audit reports compiled from the PermissionRequest and PermissionDenied hooks.
-- A secrets-scanning pass in the quality gate (pattern-based, stdlib only).
-- Release integrity: versioned releases of the plugin with checksums and migration notes.
-
-**Exit criteria:** THREAT_MODEL.md v2 reviewed; sandbox profile shipped and documented; a
-permission audit report renders from real session data.
-
-## M7: Team and Distribution
-
-Make Citadel adoptable by teams and discoverable by everyone else.
-
-- Multi-operator campaign visibility: shared campaign state conventions for repos with more
-  than one human operator.
-- Policy templates per repository class (library, service, monorepo, app) installable at
-  setup.
-- Managed-settings guidance for organizations (version pinning, marketplace allowlists).
-- Marketplace polish: accurate counts, per-skill context cost disclosure, screenshots, and a
-  60-second demo.
-- Contribution pipeline: good-first-skill issues, a skill submission checklist, and CI that
-  runs the full lint and bench suite on PRs.
-
-**Exit criteria:** at least two external contributors land skills through the pipeline; the
-marketplace listing is accurate by generation, not by hand.
+A hosted sync plane (cross-machine state, mobile status, push approvals) is deliberately
+not scheduled. It only makes sense after the dashboard is excellent and demand is
+demonstrated (waitlist signal, recurring requests). Nothing in R1-R5 may take a dependency
+on a hosted service; the local-first contract is the product.
 
 ## Sequencing Notes
 
-- M0 and M1 are foundation work: do not start M3 or M7 before they land. Shipping growth on
-  top of silent gates or drifting docs compounds the debt.
-- M2 and M4 can run in parallel after M0; they touch disjoint surfaces.
-- M3 depends on M0 (pilot scaffolding) and benefits from M2 (structured outputs for the lead's
-  judge calls).
-- Reliability over novelty, always: a smaller harness that never lies beats a larger one that
-  sometimes does.
+- R1 blocks everything: R2's video and Show HN are built around the dashboard, and R3 is
+  the dashboard's second act. Do not start R3 before R1's exit criteria are measured.
+- R2 can overlap late R1; the benchmark harness already exists.
+- R4's security work should land before R3's two-way surface is promoted as a default
+  workflow; intent files change the threat surface and the threat model must keep up.
+- The project site lives on GitHub Pages for now. A custom domain is a deferred decision
+  and nothing on the site may depend on one.
+- Reliability over novelty, always: a smaller harness that never lies beats a larger one
+  that sometimes does.


### PR DESCRIPTION
## What changed

- docs/ROADMAP.md rewritten around five release tracks: See It (local dashboard over .planning state), Prove It (public reproducible benchmarks), Drive It (two-way operator surface via intent files), Harden It (teams-native fleet GA plus security v2), Multiply It (team workflows, skill and loop registry, third runtime adapter).
- Shipped milestones (M0, M1, M2 core, M5) recorded as foundations; unshipped M3/M4/M6/M7 items absorbed into the tracks rather than dropped. Hosted relay explicitly parked with no scheduled date and a rule that nothing may depend on a hosted service.
- New docs/DASHBOARD_SPEC.md for R1 v0.1: read-only architecture (Node server, SSE invalidation, files canonical), per-source data contracts, the needs-you inbox, dual-mode cost (estimated USD for API-key users, plan-window burn for subscribers, local OTLP receiver consuming claude_code.cost.usage and claude_code.token.usage with transcript and Codex fallbacks), six panels, performance budgets, and the verification plan.
- README roadmap section synced to the new tracks.

## Verification

npm test passes (full suite including doc-surface checks).