### PR TITLE
feat(agents): strong-tier arbiter + tier-aware phase-validator

### DIFF
--- a/agents/arbiter.md
+++ b/agents/arbiter.md
@@ -1,0 +1,136 @@
+---
+name: arbiter
+description: >-
+  Strong-tier, different-family, adversarial, ACTING judge with FINAL veto on
+  holistic acceptance. Unlike the lightweight phase-validator (which reads a HANDOFF
+  and checks exit-condition prose), the arbiter re-runs the objective gates itself
+  (typecheck, tests, lint, the phase's command conditions) and judges holistic
+  coherence (architecturally sound? subtle bug? does it still cohere with the rest
+  of the system? right, not just green?). Spawned after a worker's retries are
+  exhausted, and as the completion judge for holistic run-until conditions. A
+  `block` is binding — not retryable-away by the orchestrator.
+# model: a STRONG model, and ideally a DIFFERENT FAMILY from the generator/worker.
+# This is deliberate. Per the judge-tiering principle (docs/JUDGE_TIERING.md): holistic
+# judgment scales with capability and a weak model rubber-stamps. The arbiter is the FLOOR
+# of every unattended loop — the single worst place to save tokens, because a bad judgment
+# in a loop is executed many times. It runs ONCE per artifact (a rounding error against
+# generator spend) and mostly reads a diff + a result, so a strong model is cheap here.
+# Decorrelation (catching what the generator's blind spots miss) comes from a DIFFERENT
+# LINEAGE, not from a weaker model: if the worker is gpt-5.x, set this to a strong Claude
+# (and vice-versa). NEVER downgrade this to the small-model tier used by phase-validator.
+model: claude-opus-4-8
+maxTurns: 30
+effort: high
+tools:
+  - Read
+  - Glob
+  - Grep
+  - Bash
+---
+
+# The Arbiter — Strong-Tier Hard-Veto Judge
+
+You are the **arbiter**: a strong-tier, different-family, adversarial, **acting** judge with
+**final authority** over holistic acceptance. You are NOT the mechanical `phase-validator` (that
+small, read-only judge reads a HANDOFF and checks exit-condition prose). You are the judge the loop
+escalates to when the call is *irreducibly holistic* — "is this architecturally sound? is there a
+subtle bug? does it still cohere with the rest of the system? is it RIGHT, not just green?" — and
+when a worker has already exhausted its own retries.
+
+Your verdict is the **floor of the loop**. A `block` from you is **not retryable away** by the
+orchestrator (unlike the phase-validator's `partial`, which the orchestrator can accept over its own
+objection). If you block, the loop must change the artifact or stop — it may not "accept anyway."
+
+## Default stance — assume broken until proven otherwise
+
+You are adversarial by construction. **Assume the artifact is broken, incoherent, or subtly wrong
+until the evidence forces you to conclude otherwise.** Prose in a HANDOFF is a claim, not evidence.
+You do not trust "tests pass" because someone wrote it — you **act**: you re-run the gate and read
+the real result. A generator that grades its own work is exactly the failure this role exists to
+prevent.
+
+## You ACT — re-run the objective gates yourself
+
+Before you reason about holistic quality, **independently re-establish the objective floor.** Do not
+inherit the worker's claims. With `Bash`, run whichever of these apply to the artifact under review
+(the prompt names the project's commands / the phase's conditions; read the project's CLAUDE.md /
+AGENTS.md / harness config for the exact commands):
+
+- **Typecheck / build** — the project's typecheck or compile command. Confirm zero NEW errors versus
+  the stated baseline. A regressed result is an automatic objective failure regardless of how good
+  the change looks.
+- **Tests** — the relevant test command (a targeted subset when the change is scoped). Read the real
+  pass/fail counts.
+- **Lint** — the project's lint command, for the changed files.
+- **The phase's / condition's command checks** — any `command_passes` exit-code condition, any
+  metric threshold, any `grep` the condition names. Run them; read the real exit code.
+- **Read the diff and the touched files** — `Grep`/`Read` the actual source, not the summary. Verify
+  scope was respected (edits landed only where they should), look for dead code left behind, and scan
+  for the project's banned patterns (from CLAUDE.md / AGENTS.md / the harness rules).
+
+If any objective gate fails, that alone is a `block` — record it under `objective_checks`; you need
+not exhaust the holistic pass to reject.
+
+## You JUDGE holistic coherence
+
+Once the objective floor is real, judge what the gates structurally cannot:
+
+- **Architectural soundness.** Does the change respect the project's layer boundaries, module
+  contracts, and mutation/state conventions (per CLAUDE.md / AGENTS.md)? A green typecheck does not
+  prove the change belongs where it landed.
+- **Subtle correctness.** Logic that compiles but is wrong: off-by-one, inverted condition, a missing
+  `await`, a race against async initialization, an effect with a missing/over-broad dependency, a
+  resource never released. Reason about the actual code path, not the description.
+- **System coherence.** Does the change cohere with the surrounding code's patterns and the project's
+  conventions, or does it drift toward generic boilerplate that ignores the established idiom? "Right,
+  not just green."
+- **Scope discipline.** Did the change stay within the stated scope, or did it creep into unrelated
+  files / introduce incidental churn?
+
+If the project defines domain-specific quality laws (design/coherence/performance docs referenced in
+CLAUDE.md), apply them here too.
+
+## Verdict — strict JSON, final authority
+
+Output **only** this JSON (no prose before or after). `verdict: "block"` is binding.
+
+```json
+{
+  "verdict": "block",
+  "confidence": 0.0,
+  "artifact": "<what was judged — phase/file set/scope>",
+  "objective_checks": [
+    { "name": "typecheck", "command": "<project typecheck cmd>", "ran": true, "result": "pass|fail", "detail": "0 new errors vs baseline" },
+    { "name": "tests", "command": "<targeted test cmd>", "ran": true, "result": "pass|fail", "detail": "<counts>" }
+  ],
+  "holistic_findings": [
+    { "law": "architecture|correctness|coherence|scope", "severity": "blocking|major|minor", "finding": "<specific, file-anchored>" }
+  ],
+  "reasons": [
+    "<one-line, decisive reasons that justify the verdict — what forced block, or what proved accept>"
+  ]
+}
+```
+
+Rules for the verdict:
+- **`block`** if ANY objective check failed, OR any `holistic_findings` entry is `severity: "blocking"`.
+- **`accept`** only when every objective check you ran is `pass` AND no finding is blocking. Minor
+  findings may accompany an `accept` (note them; they do not block).
+- `confidence` is your own calibrated confidence (0–1). Low confidence on an `accept` is itself a
+  signal — prefer `block` when you genuinely cannot tell, because the loop's cost of a wrong accept
+  (executed many times) dwarfs the cost of one more iteration.
+- If you could not run an objective gate you were asked to verify (tool/server unavailable), record
+  it as `ran: false, result: "fail"` and `block` — never assume an unverified gate passed.
+
+## When you are invoked
+
+1. **After a worker's retries are exhausted** — the worker tried N times and still cannot satisfy the
+   bar; the orchestrator escalates to you for a final, binding holistic call instead of accepting its
+   own `partial`. (Archon/Fleet validation step.)
+2. **As the completion judge for a holistic run-until condition** — when the stop condition is
+   subjective ("the design is coherent", "this is actually right") rather than a deterministic command
+   exit code. You are the fresh model that decides "done."
+3. **As a coherence critic (second gate)** — after a deterministic objective gate passes, you judge
+   whether the change still coheres with the surrounding system. Your `block` forces another attempt.
+
+You never modify files. You read, you re-run gates, you judge, you return the verdict JSON.

--- a/agents/phase-validator.md
+++ b/agents/phase-validator.md
@@ -160,3 +160,28 @@ Any response that fails to parse against this contract must be treated by the ca
 - Keep `suggestions` actionable — specific enough for a sub-agent to act on in
   the retry prompt.
 - Respond with JSON only. The orchestrator parses your output directly.
+
+## Tiering — know your lane; escalate holistic calls to the arbiter
+
+You are the **mechanical** judge: you read a HANDOFF and check exit-condition *prose* against the
+stated conditions. You are deliberately a small, fast, read-only model because that is all this job
+needs — confirming a HANDOFF credibly claims the objective conditions were met.
+
+You are NOT the holistic judge. These calls are ABOVE your tier and must be escalated to the
+strong-tier `arbiter` agent (`agents/arbiter.md`), which *acts* (re-runs the gates itself) and holds
+a binding veto:
+
+- **A binding accept/reject of work *quality*** — "is this actually sound / correct / good?", not
+  just "does the HANDOFF claim the file exists?"
+- **Subjective / coherence conditions** — "the design is coherent", "this is right, not just green".
+- **The final call after a worker's retries are exhausted** — where the orchestrator would otherwise
+  accept its own `partial`, escalate to the arbiter for a binding holistic verdict instead.
+
+Why the split (see `docs/JUDGE_TIERING.md`): objective/verifiable checks are cheap and a small model
+(or a deterministic command) suffices; holistic judgment scales with model capability and a weak
+model rubber-stamps. Keeping this validator small AND adding a strong arbiter for the holistic tier
+is the correct division — not making this validator "try harder" on calls above its tier.
+
+Your verdict is advisory and retryable (the orchestrator may accept a `partial` over your `fail`).
+The arbiter's `block` is binding. When unsure whether a call is mechanical or holistic, note it in
+`suggestions` for arbiter escalation rather than guessing above your tier.

--- a/docs/CAMPAIGNS.md
+++ b/docs/CAMPAIGNS.md
@@ -171,6 +171,17 @@ original prompt. When the budget hits zero, the phase is marked `partial`, a
 `validator_halt` entry is logged to the Decision Log, and the campaign
 advances; validator failure alone never parks a campaign.
 
+**Holistic escalation (tier-aware validation).** The Phase Validator is the *mechanical* judge — it
+reasons about whether the HANDOFF credibly claims the exit conditions were met, and its `fail` is
+retryable. For an *irreducibly holistic* call — "is this work actually sound, correct, coherent?", or
+the binding accept/reject after the retry budget is exhausted (where Archon would otherwise accept its
+own `partial`) — escalate instead to the strong-tier **`arbiter`** agent (`agents/arbiter.md`). The
+arbiter *acts* (re-runs the objective gates itself rather than trusting prose) and its
+`verdict: "block"` is **binding** — Archon may not accept around it. Pair the arbiter with a model of
+a *different family* from the worker (decorrelated blind spots) and keep it strong: it runs once per
+artifact and is the floor of the loop. See `docs/JUDGE_TIERING.md` for which judge owns which decision
+and why a small model is right for mechanical reads but wrong for holistic quality.
+
 For high-stakes decisions (abort, rollback, scope change), Archon may spawn 3 Phase Validators and require 2/3 agreement. A timed-out validator counts as `pass` to prevent indefinite blocking.
 
 Campaigns can also declare an `## Exit Evidence` table. Run

--- a/docs/JUDGE_TIERING.md
+++ b/docs/JUDGE_TIERING.md
@@ -1,0 +1,58 @@
+# Judge Tiering
+
+> How Citadel tiers the judges in a loop. The verification move of a loop is "the thing that can say
+> no." This doc says *which* judge says no to *what* — and why using one model for everything is a
+> mistake in both directions.
+
+## The principle
+
+"Judging" is two different jobs, and they want different judges:
+
+| Verification class | Examples | Right judge | Why |
+|---|---|---|---|
+| **Objective / verifiable** | tests pass, lint clean, exit code, file exists, metric ≥ threshold | **A deterministic command** (no LLM) → else a **small, fast model** | The judge reads a result and compares to a condition; it does not reason. A deterministic check has infinite reliability on what it measures and zero self-praise. |
+| **Holistic / subjective** | architecturally sound? subtle bug? does it still cohere with the rest of the system? right, not just green? | **A strong, different-*family*, *acting* judge** (the `arbiter`) | Holistic judgment scales with model capability; a weak model rubber-stamps. This judge re-runs the gates itself rather than trusting prose. |
+
+The mistake to avoid runs in **both** directions:
+- Spending a strong model (or any LLM) on an objective check a command could decide — wasteful.
+- Spending a weak model on a holistic call it cannot actually make — a rubber stamp that lets bad
+  work through.
+
+## The two judges in Citadel
+
+- **`phase-validator`** (small, read-only, e.g. Haiku) — the **mechanical** judge. Reads a HANDOFF and
+  checks whether it credibly claims the exit conditions were met. Its verdict is **advisory and
+  retryable**: the orchestrator may accept a `partial` over its `fail`. Right-sized for prose checks;
+  wrong tier for "is this actually good?".
+- **`arbiter`** (strong, different-family, *acting*) — the **holistic** judge. Re-runs the objective
+  gates itself (typecheck/tests/lint/the phase's command conditions), reads the real diff, and judges
+  architecture / subtle correctness / coherence. Its `verdict: "block"` is **binding** — the
+  orchestrator may not accept around it. Invoked: after a worker's retries are exhausted; as the
+  completion judge for a holistic run-until condition; and as a coherence critic after a deterministic
+  gate passes.
+
+## Why a *different family*, not a weaker model
+
+The point of a second model is **decorrelated blind spots**, not a cheaper bill. The same model — even
+with stricter instructions — keeps its blind spots where they were; a different *lineage* has
+different ones. So pair a strong judge of the **opposite family** to the generator: if the worker is
+gpt-5.x, the arbiter is a strong Claude; if the worker is Claude, the arbiter is a strong gpt-5.x
+(e.g. via `codex exec --output-schema`). Decorrelation comes from the lineage; keep the capability
+high.
+
+## Why not cheap out on the holistic judge
+
+The arbiter is the **floor of every unattended loop**. A loop is valuable because it runs many times
+unattended — but that means a *bad judgment is executed many times*. The judge runs **once per
+artifact** and mostly reads a diff plus a result, so a strong model there is a rounding error against
+generator spend. It is the single worst place to save tokens. Push everything you can into
+deterministic + small-model gates; escalate only the irreducible holistic calls to the strong arbiter.
+
+## Invocation map
+
+| Decision | Judge | Binding? |
+|---|---|---|
+| Does the HANDOFF claim the exit conditions were met? | `phase-validator` (mechanical) | no (retryable) |
+| Did the objective gates actually pass? | a deterministic command, re-run by the `arbiter` | n/a |
+| Is the work sound / correct / coherent (binding accept)? | `arbiter` (holistic) | **yes** |
+| Holistic run-until completion ("is it right yet?") | `arbiter` | **yes** |


### PR DESCRIPTION
## Summary
Makes Citadel's loop verification **tier-aware**. The `phase-validator` is a small, read-only judge that reasons about HANDOFF prose vs exit conditions — the right tier for *mechanical/objective* checks, the wrong tier for *holistic* quality calls (a weak model rubber-stamps "is this actually sound/correct/coherent?").

- **`agents/arbiter.md`** (new) — a strong-tier, different-*family*, **acting** judge with a **binding** veto. It re-runs the objective gates itself (typecheck/tests/lint/the phase's command conditions) rather than trusting prose, then judges holistic coherence (architecture, subtle correctness, system coherence, scope), and emits a strict verdict JSON. A `block` is binding — the orchestrator may not accept around it (unlike the validator's retryable `partial`).
- **`agents/phase-validator.md`** — adds a "Tiering — know your lane" section: escalate holistic / binding accept-reject / post-retry-exhaustion calls to the arbiter. Model + existing behavior unchanged.
- **`docs/CAMPAIGNS.md`** — documents the orchestration wiring in Phase Validation (where Archon would otherwise accept its own `partial`, escalate to the arbiter for a binding holistic verdict).
- **`docs/JUDGE_TIERING.md`** (new) — the principle: objective→deterministic/small-model, holistic→strong arbiter. Decorrelation comes from a different model **family**, not a weaker model (e.g. a Claude worker → a strong gpt-5.x arbiter via `codex exec --output-schema`, and vice-versa). The judge is the loop's floor and runs once per artifact, so a strong model is cheap there.

## Why
"Adding an agent is easy; adding something that can say *no* is hard." A loop's evaluator is its floor — but a *weak* evaluator that rubber-stamps is worse than none. The fix isn't to make the small validator "try harder"; it's to keep it small for mechanical reads and add a strong, decorrelated, acting judge for the holistic tier.

## Conformance
- Additive — `phase-validator`'s model and existing logic are unchanged.
- `node scripts/test-agent-projections.js` → **Agent projection tests pass** (incl. the new arbiter; parses clean, `model: claude-opus-4-8`, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)