### PR TITLE
feat(mcp): codebase-memory — optional read-only orientation MCP over core/map

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -14,6 +14,21 @@
         "required": false,
         "instructions": "Use citadel_status to orient on campaign, fleet, telemetry, and artifact state before invoking Citadel workflows."
       }
+    },
+    "codebase-memory": {
+      "command": "node",
+      "args": [
+        "mcp-servers/codebase-memory/index.js"
+      ],
+      "env": {
+        "CITADEL_MCP_SERVER": "codebase-memory"
+      },
+      "_codex": {
+        "startup_timeout_sec": 15,
+        "tool_timeout_sec": 60,
+        "required": false,
+        "instructions": "Call get_architecture to orient on a cold/large repo, then who_imports, dependencies_of, trace_path, and impact_of_change for structural questions instead of grepping. Read-only; complements (never replaces) CLAUDE.md/AGENTS.md doctrine."
+      }
     }
   }
 }

--- a/mcp-servers/codebase-memory/README.md
+++ b/mcp-servers/codebase-memory/README.md
@@ -1,0 +1,72 @@
+# codebase-memory MCP server
+
+An **optional, read-only, repo-agnostic** orientation layer for agents working a
+cold or large repository. It lets an agent answer structural questions — *who
+imports this, what does it depend on, what breaks if I change it* — by querying a
+graph instead of grepping and reading file after file into context.
+
+It is **not** a replacement for `CLAUDE.md` / `AGENTS.md` / capability manifests
+(those are human-authored doctrine). This is mechanical structure. The two are
+complementary; never auto-write a manifest from this index.
+
+## How it works
+
+It reuses Citadel's existing `core/map` index generator (tree-walked
+exports/imports/symbols/roles + a resolved forward dependency graph, cached at
+`.planning/map/index.json`) and adds the query surface `core/map` doesn't expose:
+reverse edges, path tracing, and change-impact. Pure Node, **no dependencies**,
+MCP `2024-11-05` JSON-RPC over stdio. The index is local and derived; nothing
+leaves the machine.
+
+The tool's value is highest on repos with little documentation — it does not
+displace the docs-first orientation Citadel already encourages, it backstops it.
+
+## Tools
+
+| tool | returns |
+|------|---------|
+| `get_architecture` | language/role stats, top fan-in files, routes, verification commands — start here on a cold repo |
+| `search_symbols` | ranked file pointers for symbol/export/route terms (where is X) |
+| `who_imports` | reverse lookup — which files import a given file |
+| `dependencies_of` | forward — which internal files a given file imports |
+| `trace_path` | shortest dependency path between two files (BFS) |
+| `impact_of_change` | changed files vs a git base → direct importers, fan-in risk-ranked |
+| `index_status` | index location, file count, staleness (added/removed/changed) |
+| `reindex` | force a rebuild after a large pull/branch switch |
+
+## Accuracy model
+
+- **Import/dependency graph is accurate** for relative/internal imports
+  (`who_imports`, `dependencies_of`, `trace_path`).
+- It is **file-granular**, inheriting `core/map`'s regex extraction — it answers
+  "which *file* imports this file", not "which *function* calls this function".
+  `impact_of_change` dependents are direct (1-hop) importers.
+- `search_symbols` is a ranked heuristic over extracted symbols, not a type-aware
+  index. Treat results as leads.
+
+## Enable it
+
+Already registered in this repo's `.mcp.json`. For another project, add:
+
+```json
+{
+  "mcpServers": {
+    "codebase-memory": {
+      "command": "node",
+      "args": ["mcp-servers/codebase-memory/index.js"],
+      "env": { "CITADEL_PROJECT_ROOT": "." }
+    }
+  }
+}
+```
+
+`CITADEL_PROJECT_ROOT` defaults to the process working directory.
+
+## Verify
+
+```bash
+node mcp-servers/codebase-memory/smoke-test.js
+```
+
+Drives a full JSON-RPC handshake + tool calls against this repo and asserts the
+responses.

--- a/mcp-servers/codebase-memory/index.js
+++ b/mcp-servers/codebase-memory/index.js
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+
+'use strict';
+
+/**
+ * codebase-memory MCP server.
+ *
+ * An optional, read-only, repo-agnostic orientation layer. It reuses Citadel's
+ * existing `core/map` index generator (tree-walked exports/imports/symbols/roles
+ * + a forward dependency graph) and adds the query surface core/map doesn't
+ * expose: reverse edges (who-imports / dependents), path tracing, and git-diff
+ * change-impact with fan-in risk. The point is to let an agent answer structural
+ * questions on a cold repo without grepping and reading file chains.
+ *
+ * Pure Node, no dependencies, MCP 2024-11-05 JSON-RPC over stdio — same shape as
+ * mcp-servers/citadel-state. The index is a derived artifact at
+ * .planning/map/index.json; nothing leaves the machine.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const map = require('../../core/map');
+
+const PROJECT_ROOT = path.resolve(process.env.CITADEL_PROJECT_ROOT || process.cwd());
+const OUTPUT_PATH = map.defaultOutputPath(PROJECT_ROOT);
+
+// Fan-in thresholds + the file roles whose changes ripple widely. Named so the
+// risk policy is data, not magic numbers. Roles come from core/map's inferRole.
+const HIGH_FANIN = 10;
+const MED_FANIN = 3;
+const RIPPLE_ROLES = new Set(['types', 'kernel', 'store', 'config']);
+
+const toPosix = (p) => String(p || '').replace(/\\/g, '/');
+
+// ---- index lifecycle -------------------------------------------------------
+
+function ensureIndex(forceRebuild = false) {
+  if (!forceRebuild && fs.existsSync(OUTPUT_PATH)) {
+    try {
+      return map.loadMapIndex(OUTPUT_PATH);
+    } catch (_) {
+      /* corrupt cache — fall through to regenerate */
+    }
+  }
+  const index = map.generateMapIndex(PROJECT_ROOT);
+  try {
+    map.writeMapIndex(index, OUTPUT_PATH);
+  } catch (_) {
+    /* read-only fs is fine; the in-memory index still answers queries */
+  }
+  return index;
+}
+
+function reverseGraph(index) {
+  const reverse = {};
+  for (const [file, deps] of Object.entries(index.graph || {})) {
+    for (const dep of deps) {
+      (reverse[dep] = reverse[dep] || []).push(file);
+    }
+  }
+  for (const key of Object.keys(reverse)) reverse[key].sort();
+  return reverse;
+}
+
+function resolveFile(index, arg) {
+  const want = toPosix(arg);
+  if (index.files && index.files[want]) return want;
+  // tolerate a partial/suffix path the agent typed by hand
+  const matches = Object.keys(index.files || {}).filter((f) => f === want || f.endsWith('/' + want) || f.endsWith(want));
+  return matches.length === 1 ? matches[0] : matches.length ? matches : null;
+}
+
+function riskFor(fanIn, role) {
+  if (fanIn >= HIGH_FANIN) return 'high';
+  if (RIPPLE_ROLES.has(role) && fanIn >= MED_FANIN) return 'high';
+  if (fanIn >= MED_FANIN) return 'medium';
+  return 'low';
+}
+
+// ---- tool implementations --------------------------------------------------
+
+function getArchitecture() {
+  const index = ensureIndex();
+  const reverse = reverseGraph(index);
+  const topDependedOn = Object.entries(reverse)
+    .map(([file, importers]) => ({ file, fanIn: importers.length, role: index.files[file] ? index.files[file].role : null }))
+    .sort((a, b) => b.fanIn - a.fanIn)
+    .slice(0, 15);
+  return {
+    stats: map.mapStats(index),
+    generatedAt: index.generatedAt || index.generated,
+    topDependedOn,
+    routes: (index.routes || []).slice(0, 40),
+    verificationCommands: index.verificationCommands || [],
+  };
+}
+
+function searchSymbols(query, limit) {
+  const index = ensureIndex();
+  return map.queryMapIndex(index, query, limit || 20).map((r) => ({
+    file: r.relPath,
+    role: r.role,
+    exports: r.exports,
+    routes: r.routes,
+    lines: r.lines,
+    score: r.score,
+  }));
+}
+
+function whoImports(file) {
+  const index = ensureIndex();
+  const resolved = resolveFile(index, file);
+  if (!resolved) return { file, importers: [], note: 'file not found in index' };
+  if (Array.isArray(resolved)) return { file, ambiguous: resolved };
+  return { file: resolved, importers: reverseGraph(index)[resolved] || [] };
+}
+
+function dependenciesOf(file) {
+  const index = ensureIndex();
+  const resolved = resolveFile(index, file);
+  if (!resolved || Array.isArray(resolved)) return { file, dependencies: [], note: resolved ? 'ambiguous' : 'not found' };
+  return { file: resolved, dependencies: (index.graph && index.graph[resolved]) || [] };
+}
+
+function tracePath(from, to) {
+  const index = ensureIndex();
+  const a = resolveFile(index, from);
+  const b = resolveFile(index, to);
+  if (!a || Array.isArray(a) || !b || Array.isArray(b)) return { path: null, note: 'from/to not uniquely resolved' };
+  const graph = index.graph || {};
+  const queue = [[a]];
+  const seen = new Set([a]);
+  while (queue.length) {
+    const trail = queue.shift();
+    const head = trail[trail.length - 1];
+    if (head === b) return { path: trail };
+    for (const dep of graph[head] || []) {
+      if (seen.has(dep)) continue;
+      seen.add(dep);
+      queue.push(trail.concat(dep));
+    }
+  }
+  return { path: null, note: 'no dependency path' };
+}
+
+function impactOfChange(base) {
+  const index = ensureIndex();
+  let changed;
+  try {
+    const raw = execFileSync('git', ['diff', '--name-only', base || 'HEAD'], { cwd: PROJECT_ROOT, encoding: 'utf8' });
+    changed = raw.split(/\r?\n/).map((s) => toPosix(s.trim())).filter(Boolean);
+  } catch (err) {
+    return { error: `git diff failed (not a repo, or bad base "${base}"): ${err.message}` };
+  }
+  const reverse = reverseGraph(index);
+  const affected = changed
+    .filter((f) => index.files && index.files[f])
+    .map((f) => {
+      const importers = reverse[f] || [];
+      const role = index.files[f].role;
+      return { file: f, role, fanIn: importers.length, dependents: importers, risk: riskFor(importers.length, role) };
+    });
+  const rank = { high: 0, medium: 1, low: 2 };
+  affected.sort((x, y) => rank[x.risk] - rank[y.risk] || y.fanIn - x.fanIn || x.file.localeCompare(y.file));
+  return {
+    base: base || 'HEAD',
+    changedFiles: changed.length,
+    indexedChangedFiles: affected.length,
+    note: 'File-level impact (core/map is file-granular). Dependents are direct (1-hop) importers.',
+    affected,
+  };
+}
+
+function indexStatus() {
+  const exists = fs.existsSync(OUTPUT_PATH);
+  const index = ensureIndex();
+  const staleness = map.detectMapStaleness(PROJECT_ROOT, index);
+  return {
+    indexPath: toPosix(path.relative(PROJECT_ROOT, OUTPUT_PATH)),
+    existedOnDisk: exists,
+    fileCount: index.fileCount,
+    generatedAt: index.generatedAt || index.generated,
+    stale: staleness.stale,
+    added: staleness.added.length,
+    removed: staleness.removed.length,
+    changed: staleness.changed.length,
+  };
+}
+
+function reindex() {
+  const index = ensureIndex(true);
+  return { reindexed: true, fileCount: index.fileCount, generatedAt: index.generatedAt || index.generated };
+}
+
+// ---- MCP wiring ------------------------------------------------------------
+
+const TOOL_DEFS = [
+  {
+    name: 'get_architecture',
+    description: 'High-level codebase orientation: language/role stats, the most depended-on files (top fan-in), routes, and verification commands. Start here on a cold repo.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'search_symbols',
+    description: 'Find files by symbol/export/route/path terms (where is X defined or handled). Returns ranked file pointers, not file contents.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'Space-separated terms, e.g. "auth login route".' },
+        limit: { type: 'number', description: 'Max files to return (default 20).' },
+      },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'who_imports',
+    description: 'Reverse dependency lookup: which files import the given file. The structural question grep is worst at.',
+    inputSchema: {
+      type: 'object',
+      properties: { file: { type: 'string', description: 'Repo-relative file path.' } },
+      required: ['file'],
+    },
+  },
+  {
+    name: 'dependencies_of',
+    description: 'Forward dependencies: which internal files the given file imports.',
+    inputSchema: {
+      type: 'object',
+      properties: { file: { type: 'string', description: 'Repo-relative file path.' } },
+      required: ['file'],
+    },
+  },
+  {
+    name: 'trace_path',
+    description: 'Shortest dependency path between two files (BFS over the import graph).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        from: { type: 'string', description: 'Start file (repo-relative).' },
+        to: { type: 'string', description: 'Target file (repo-relative).' },
+      },
+      required: ['from', 'to'],
+    },
+  },
+  {
+    name: 'impact_of_change',
+    description: 'Blast radius of the working diff: maps changed files (vs a git base ref) to their direct importers and ranks each by fan-in risk. Run before a commit/PR.',
+    inputSchema: {
+      type: 'object',
+      properties: { base: { type: 'string', description: 'Git base ref to diff against (default HEAD).' } },
+    },
+  },
+  {
+    name: 'index_status',
+    description: 'Report the codebase index location, file count, and whether it is stale (files added/removed/changed since it was built).',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'reindex',
+    description: 'Force a rebuild of the codebase index. Run after a large pull or branch switch.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+];
+
+const HANDLERS = {
+  get_architecture: () => getArchitecture(),
+  search_symbols: (a) => searchSymbols(a.query, a.limit),
+  who_imports: (a) => whoImports(a.file),
+  dependencies_of: (a) => dependenciesOf(a.file),
+  trace_path: (a) => tracePath(a.from, a.to),
+  impact_of_change: (a) => impactOfChange(a.base),
+  index_status: () => indexStatus(),
+  reindex: () => reindex(),
+};
+
+function respond(id, result) {
+  process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id, result }) + '\n');
+}
+
+function respondError(id, code, message) {
+  process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id, error: { code, message } }) + '\n');
+}
+
+function handleRequest(req) {
+  const { id, method, params } = req;
+
+  if (method === 'initialize') {
+    respond(id, {
+      protocolVersion: '2024-11-05',
+      capabilities: { tools: {}, resources: {} },
+      serverInfo: { name: 'codebase-memory', version: '1.0.0' },
+      instructions: 'Call get_architecture to orient on a cold repo, then who_imports / dependencies_of / trace_path / impact_of_change for structural questions instead of grepping. Index is read-only and derived; reindex after large pulls.',
+    });
+    return;
+  }
+
+  if (method === 'notifications/initialized') return;
+
+  if (method === 'tools/list') {
+    respond(id, { tools: TOOL_DEFS });
+    return;
+  }
+
+  if (method === 'tools/call') {
+    const { name, arguments: args = {} } = params || {};
+    const handler = HANDLERS[name];
+    if (!handler) {
+      respondError(id, -32601, `Unknown tool: ${name}`);
+      return;
+    }
+    try {
+      respond(id, { content: [{ type: 'text', text: JSON.stringify(handler(args), null, 2) }] });
+    } catch (err) {
+      respond(id, { isError: true, content: [{ type: 'text', text: `Tool ${name} failed: ${err.message}` }] });
+    }
+    return;
+  }
+
+  if (method === 'resources/list') {
+    respond(id, { resources: [{ uri: 'codebase://architecture', name: 'Codebase Architecture', mimeType: 'application/json' }] });
+    return;
+  }
+
+  if (method === 'resources/read' && params && params.uri === 'codebase://architecture') {
+    respond(id, {
+      contents: [{ uri: 'codebase://architecture', mimeType: 'application/json', text: JSON.stringify(getArchitecture(), null, 2) }],
+    });
+    return;
+  }
+
+  if (id !== undefined) respondError(id, -32601, `Unknown method: ${method}`);
+}
+
+let buffer = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => {
+  buffer += chunk;
+  const lines = buffer.split('\n');
+  buffer = lines.pop();
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      handleRequest(JSON.parse(trimmed));
+    } catch (err) {
+      respondError(null, -32700, `Parse error: ${err.message}`);
+    }
+  }
+});
+
+process.stdin.on('end', () => process.exit(0));
+process.on('SIGTERM', () => process.exit(0));
+process.on('SIGINT', () => process.exit(0));

--- a/mcp-servers/codebase-memory/smoke-test.js
+++ b/mcp-servers/codebase-memory/smoke-test.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+'use strict';
+
+/**
+ * JSON-RPC smoke test for the codebase-memory MCP server. Spawns the server,
+ * drives a realistic handshake + tool calls against this repo, and asserts the
+ * responses. Pure Node, no dependencies. Exit 0 = pass, 1 = fail.
+ *
+ *   node mcp-servers/codebase-memory/smoke-test.js
+ */
+
+const { spawn } = require('child_process');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const SERVER = path.join(__dirname, 'index.js');
+
+const REQUESTS = [
+  { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} },
+  { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} },
+  { jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'get_architecture', arguments: {} } },
+  { jsonrpc: '2.0', id: 4, method: 'tools/call', params: { name: 'who_imports', arguments: { file: 'core/map/index.js' } } },
+  { jsonrpc: '2.0', id: 5, method: 'tools/call', params: { name: 'index_status', arguments: {} } },
+];
+
+function parseResult(resp) {
+  return JSON.parse(resp.result.content[0].text);
+}
+
+const checks = {
+  1: (r) => r.result.serverInfo.name === 'codebase-memory' || 'bad serverInfo',
+  2: (r) => (Array.isArray(r.result.tools) && r.result.tools.length === 8) || `expected 8 tools, got ${r.result.tools && r.result.tools.length}`,
+  3: (r) => (parseResult(r).stats && typeof parseResult(r).stats.files === 'number') || 'no stats.files',
+  4: (r) => (Array.isArray(parseResult(r).importers)) || 'importers not an array',
+  5: (r) => (typeof parseResult(r).fileCount === 'number') || 'no fileCount',
+};
+
+function run() {
+  const child = spawn('node', [SERVER], { cwd: REPO_ROOT, stdio: ['pipe', 'pipe', 'inherit'] });
+  let buffer = '';
+  const responses = {};
+
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (chunk) => {
+    buffer += chunk;
+    const lines = buffer.split('\n');
+    buffer = lines.pop();
+    for (const line of lines) {
+      const t = line.trim();
+      if (!t) continue;
+      const msg = JSON.parse(t);
+      if (msg.id !== undefined) responses[msg.id] = msg;
+    }
+    if (Object.keys(responses).length === REQUESTS.length) finish();
+  });
+
+  let finished = false;
+  function finish() {
+    if (finished) return;
+    finished = true;
+    let failures = 0;
+    for (const [id, check] of Object.entries(checks)) {
+      const resp = responses[id];
+      if (!resp) {
+        console.error(`FAIL id=${id}: no response`);
+        failures++;
+        continue;
+      }
+      const verdict = check(resp);
+      if (verdict === true) {
+        console.log(`ok   id=${id} ${REQUESTS[id - 1].method}${REQUESTS[id - 1].params.name ? ' ' + REQUESTS[id - 1].params.name : ''}`);
+      } else {
+        console.error(`FAIL id=${id}: ${verdict}`);
+        failures++;
+      }
+    }
+    child.kill();
+    if (failures) {
+      console.error(`\n${failures} check(s) failed.`);
+      process.exit(1);
+    }
+    console.log('\nAll codebase-memory smoke checks passed.');
+    process.exit(0);
+  }
+
+  child.on('error', (err) => {
+    console.error('Failed to spawn server:', err.message);
+    process.exit(1);
+  });
+
+  for (const req of REQUESTS) child.stdin.write(JSON.stringify(req) + '\n');
+  setTimeout(() => {
+    console.error('Timed out waiting for responses.');
+    child.kill();
+    process.exit(1);
+  }, 30000);
+}
+
+run();


### PR DESCRIPTION
## What

A new **optional, read-only, repo-agnostic** MCP server at `mcp-servers/codebase-memory/`. It gives an agent a queryable view of a codebase's structure — *who imports this, what does it depend on, what is the blast radius of my diff* — so it can orient on a cold or large repo without grepping and reading file chains into context.

## Why this belongs in Citadel

Citadel's pitch is "drop the harness on any repo and agents orient fast." Fast **structural** orientation on a cold/undocumented repo is exactly where a dependency graph pays off. Citadel already builds that graph — `core/map` tree-walks exports/imports/symbols/roles and resolves a forward dependency graph into `.planning/map/index.json` — but nothing exposes it to an agent over MCP, and it has no reverse/impact queries. **This is the missing seam, not a new indexer.**

It sits alongside `citadel-state` (Citadel state) and `context-compress` (output compression) as the structure-orientation MCP.

## Design

- **Reuses `core/map` wholesale** via `require('../../core/map')` — `generateMapIndex` / `loadMapIndex` / `queryMapIndex` / `mapStats` / `detectMapStaleness`. No duplicate indexer.
- Adds the query layer core/map lacks: reverse graph + path tracing + change-impact.
- **Pure Node, zero dependencies**, MCP `2024-11-05` JSON-RPC over stdio — identical scaffold to `citadel-state`.
- Read-only and derived; nothing leaves the machine.

### Tools
`get_architecture` · `search_symbols` · `who_imports` · `dependencies_of` · `trace_path` · `impact_of_change` (git-diff → direct importers, fan-in risk-ranked) · `index_status` · `reindex`

## Boundaries (deliberate)

- **Complements, never replaces** `CLAUDE.md` / `AGENTS.md` / capability manifests. Those are human-authored doctrine; this is mechanical structure. The server never writes a manifest.
- **File-granular**, inheriting core/map's regex extraction — "which *file* imports this file", not "which *function* calls this function". Stated honestly in the README and tool descriptions.
- Optional: registered with `required: false`; the harness works without it.

## Verification

- `node mcp-servers/codebase-memory/smoke-test.js` — full JSON-RPC handshake + `tools/list` (8) + `get_architecture` / `who_imports` / `index_status` calls, all asserted. **Passes.**
- Real queries on this repo: `who_imports core/map/index.js` returns its true importers; `get_architecture` surfaces real top fan-in.
- **Full `npm test` suite passes** (all suites green), including `compat-05-mcp-translation` which translates the updated `.mcp.json` to Codex config.
- `.mcp.json` diff is the single additive server block; no other files touched.

## Notes

Companion to a Tailored Realms PR that adds a TS-native, symbol-granular version of the same idea for that specific (heavily-documented, TS) codebase. The split is intentional: TR gets a compiler-API symbol index; Citadel ships this repo-agnostic file-level orientation layer for its broad, often-undocumented consumer repos — where the value is highest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
