### PR TITLE
Recruit 1.1 testers and fix Windows steward check

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It gives your coding agent durable project memory, `/do` intent routing, safety 
 
 If `CLAUDE.md` and `AGENTS.md` tell the runtime **what** your project is, Citadel tells the runtime **how** to operate on it.
 
-[Install](#quick-install) · [See It Run](#see-it-run) · [How It Works](#how-it-works) · [Why It Exists](#why-citadel-exists) · [Roadmap](#roadmap)
+[Install](#quick-install) · [See It Run](#see-it-run) · [How It Works](#how-it-works) · [Why It Exists](#why-citadel-exists) · [Roadmap](#roadmap) · [Help Test 1.1](https://github.com/SethGammon/Citadel/discussions/182)
 
 </div>
 
@@ -257,6 +257,7 @@ Yes. Hooks and scripts run on Node.js, and the Codex installer includes Windows 
 
 ## Community
 
+- [Help test Citadel 1.1](https://github.com/SethGammon/Citadel/discussions/182) - independent benchmark review, first-time-user trials, and return-use evidence
 - [GitHub Discussions](https://github.com/SethGammon/Citadel/discussions) - questions, use cases, bugs, and workflow requests
 - [X / Twitter](https://x.com/SethGammon) - project updates
 

--- a/scripts/test-agents-md-only-steward.js
+++ b/scripts/test-agents-md-only-steward.js
@@ -24,7 +24,7 @@ function writeJson(filePath, value) {
 }
 
 function extractStewardScript(agentsMd) {
-  const match = agentsMd.match(/<!-- BEGIN_STEWARD_SCRIPT -->\s*```js\n([\s\S]*?)\n```\s*<!-- END_STEWARD_SCRIPT -->/);
+  const match = agentsMd.match(/<!-- BEGIN_STEWARD_SCRIPT -->\s*```js\r?\n([\s\S]*?)\r?\n```\s*<!-- END_STEWARD_SCRIPT -->/);
   assert(match, 'AGENTS.md must contain a BEGIN_STEWARD_SCRIPT JavaScript block');
   return match[1];
 }


### PR DESCRIPTION
## Summary

- add a top-level README link to the independent 1.1 product-proof trial
- surface benchmark, first-time-user, and return-use recruitment in Community
- accept CRLF line endings in the standalone AGENTS.md steward test
- keep the unfinished 1.1 implementation isolated in PR #181

## Root cause

The README-only commit exposed a pre-existing Windows-only failure: the steward test matched LF code fences but rejected CRLF checkouts. Both Windows jobs failed at the same bootstrap assertion while Linux, HOL, and plugin scanning passed.

## Verification

- node scripts/test-agents-md-only-steward.js: 15 merges and 15 deploys pass
- node scripts/test-doc-surfaces.js
- node scripts/test-all.js: all checks pass in 173.5s
- git diff --check

Discussion: #182