### PR TITLE
Fix Stop hook delivery envelope

### DIFF
--- a/hooks_src/quality-gate.js
+++ b/hooks_src/quality-gate.js
@@ -176,10 +176,18 @@ function run() {
 
     if (CITADEL_UI) {
       hookOutput('quality-gate', 'warned', msg, { violations });
+    } else if (config.qualityRules?.blocking) {
+      // Documented Stop-hook blocking path: the model must address the violations
+      // before it may stop. Loop-safe via the stop_hook_active guard above.
+      process.stdout.write(JSON.stringify({ decision: 'block', reason: msg }));
     } else {
-      // Inject violations directly into Claude's context window via additionalContext.
-      // This makes quality signals visible to Claude without relying on stderr display.
-      process.stdout.write(JSON.stringify({ additionalContext: msg }));
+      // Inject violations into the model's context without blocking. For Stop hooks
+      // the documented envelope is hookSpecificOutput.additionalContext — a bare
+      // top-level `additionalContext` key is not part of the hook output schema and
+      // is silently ignored, as is plain (non-JSON) stdout with exit 0.
+      process.stdout.write(JSON.stringify({
+        hookSpecificOutput: { hookEventName: 'Stop', additionalContext: msg },
+      }));
     }
   }
 


### PR DESCRIPTION
## What changed
- emit the documented Stop-hook blocking response when quality rules are blocking
- wrap advisory context in the documented hook-specific output envelope

## Why
The previous top-level additionalContext field was silently ignored, so quality violations could be lost at Stop time.

## Validation
- node scripts/test-all.js
- node scripts/verify-hooks.js (88 passed)
- node scripts/integration-test.js (20 passed)