### PR TITLE
Build Citadel's interactive proof-led product story

### DIFF
--- a/.planning/campaigns/citadel-interactive-product-story-v2.md
+++ b/.planning/campaigns/citadel-interactive-product-story-v2.md
@@ -2,7 +2,7 @@
 slug: citadel-interactive-product-story-v2
 status: active
 phase_count: 6
-current_phase: 1
+current_phase: 6
 created: 2026-07-12
 ---
 
@@ -18,8 +18,8 @@ Direction: Transform Seth Gammon's GitHub profile and the Citadel public site in
 | 2 | complete | plan | Interactive story architecture | experience contract defines the full journey, content hierarchy, state model, responsive behavior, and motion grammar | 3 |
 | 3 | complete | build | Operating journey and repository memory | a visitor can route a scenario, inspect persisted state, close a session, and restore the next action | 3 |
 | 4 | complete | build | Fleet, evidence challenge, and deploy replay | interactive fleet, missing-source challenge, and 15-PR replay run from deterministic source data | 3 |
-| 5 | in-progress | build | Proof gallery, installation, branding, and accessibility | proof receipts, Claude/Codex paths, mobile layout, keyboard operation, and reduced motion all render correctly | 3 |
-| 6 | pending | verify | Regression, visual QA, delivery, and deployment | strict suite passes, desktop/mobile screenshots pass review, protected PR merges, and live Pages matches the verified build | 3 |
+| 5 | complete | build | Proof gallery, installation, branding, and accessibility | proof receipts, Claude/Codex paths, mobile layout, keyboard operation, and reduced motion all render correctly | 3 |
+| 6 | in-progress | verify | Regression, visual QA, delivery, and deployment | strict suite passes, desktop/mobile screenshots pass review, protected PR merges, and live Pages matches the verified build | 3 |
 
 ## Phase End Conditions
 
@@ -60,16 +60,18 @@ Direction: Transform Seth Gammon's GitHub profile and the Citadel public site in
 
 ## Active Context
 
-Phase 5 is active. GitHub's explicit Share to Profile control was activated and the visual creator README, evidence table, bio, website, LinkedIn, X, and Reddit all render on the Overview page. The site now has campaign, review, fleet, evidence challenge, and 15-PR landing scenarios using one deterministic state engine. Desktop, mobile viewport, routing-sync, contract, and browser interaction checks pass.
+Phase 6 is active. GitHub's explicit Share to Profile control was activated and the visual creator README, evidence table, bio, website, LinkedIn, X, and Reddit all render on the Overview page. The site now has campaign, review, fleet, evidence challenge, and 15-PR landing scenarios using one deterministic state engine, plus six bounded proof receipts and equal Claude Code and Codex installation paths. Desktop, mobile, keyboard, reduced-motion, routing-sync, contract, and browser interaction checks pass.
 
 ## Continuation State
 
-- current: phase 5, proof gallery, installation, branding, and accessibility
-- next: connect the proof gallery and runtime-specific install flow to the story engine, verify keyboard and reduced-motion states, then run the strict regression gate
-- verified: `npm run site:story:test` 15/15; `node scripts/test-routing-sync.js`; desktop, mobile, and deploy captures; campaign, fleet, evidence, and deploy browser interaction checks
+- current: phase 6, regression, visual QA, delivery, and deployment
+- next: run the strict regression and reproducible release gates, deliver through a protected PR, then verify GitHub Pages
+- verified: `npm run site:story:test` 23/23; `node scripts/test-routing-sync.js`; desktop and mobile proof/install captures; keyboard, reduced-motion, campaign, fleet, evidence, and deploy browser interaction checks
 - profile: visual README, evidence table, LinkedIn, X, Reddit, bio, and website visibly mounted on the public Overview page
 - protected local state: `.planning/campaigns/citadel-product-proof.md`, `assets/social/`, and `dist/` remain outside campaign scope
 
 <!-- session-end: 2026-07-12T19:51:17.547Z -->
 
 <!-- session-end: 2026-07-12T20:19:15.162Z -->
+
+<!-- session-end: 2026-07-12T20:20:25.755Z -->

--- a/.planning/campaigns/citadel-interactive-product-story-v2.md
+++ b/.planning/campaigns/citadel-interactive-product-story-v2.md
@@ -1,0 +1,75 @@
+---
+slug: citadel-interactive-product-story-v2
+status: active
+phase_count: 6
+current_phase: 1
+created: 2026-07-12
+---
+
+# Campaign: Citadel Interactive Product Story v2
+
+Direction: Transform Seth Gammon's GitHub profile and the Citadel public site into an exceptional, proof-led demonstration of Citadel operating on real work.
+
+## Phases
+
+| # | Status | Type | Phase | Done When | Validator Retries Remaining |
+|---|---|---|---|---|---:|
+| 1 | complete | research | Creator profile and public proof inventory | profile README renders publicly, social links are verified, and achievement sources are recorded | 3 |
+| 2 | complete | plan | Interactive story architecture | experience contract defines the full journey, content hierarchy, state model, responsive behavior, and motion grammar | 3 |
+| 3 | complete | build | Operating journey and repository memory | a visitor can route a scenario, inspect persisted state, close a session, and restore the next action | 3 |
+| 4 | complete | build | Fleet, evidence challenge, and deploy replay | interactive fleet, missing-source challenge, and 15-PR replay run from deterministic source data | 3 |
+| 5 | in-progress | build | Proof gallery, installation, branding, and accessibility | proof receipts, Claude/Codex paths, mobile layout, keyboard operation, and reduced motion all render correctly | 3 |
+| 6 | pending | verify | Regression, visual QA, delivery, and deployment | strict suite passes, desktop/mobile screenshots pass review, protected PR merges, and live Pages matches the verified build | 3 |
+
+## Phase End Conditions
+
+| Phase | Type | Condition |
+|---:|---|---|
+| 1 | file_exists | `.planning/research/citadel-profile-achievements.md` |
+| 1 | manual | Public GitHub profile visibly includes the profile README and verified social links |
+| 2 | file_exists | `docs/interactive-story-contract.md` |
+| 2 | command_passes | `node scripts/test-routing-sync.js` |
+| 3 | command_passes | `node scripts/test-citadel-site-story.js` |
+| 3 | visual_verify | desktop and mobile journey screenshots |
+| 4 | command_passes | `node scripts/test-citadel-site-story.js` |
+| 4 | visual_verify | fleet, unknown-state, and deploy replay screenshots |
+| 5 | command_passes | `node scripts/test-citadel-site-story.js` |
+| 5 | visual_verify | keyboard, mobile, and reduced-motion capture set |
+| 6 | command_passes | `node scripts/test-all.js --strict` |
+| 6 | command_passes | `node scripts/release-package.js --ref HEAD --dry-run --verify-reproducible` |
+| 6 | manual | GitHub Pages serves the verified experience after protected merge |
+
+## Quality bar
+
+- Every animation communicates a real state transition and ends in an inspectable state.
+- Every public claim names a source and a truth boundary.
+- No fake live counters or fabricated runtime events.
+- Claude Code and Codex receive equal treatment.
+- Desktop, mobile, keyboard, and reduced-motion experiences remain complete.
+- No em dashes in public copy.
+- The first useful interaction is visible without scrolling.
+- Private traffic screenshots never enter the public repository.
+
+## Decision Log
+
+- 2026-07-12: Use one deterministic interactive state model instead of separate decorative animations.
+- 2026-07-12: Keep the router as the entrance, then reveal persistence, fleet coordination, evidence, and delivery proof.
+- 2026-07-12: Treat GitHub profile work as part of product conversion because the creator identity is currently less legible than the repository.
+- 2026-07-12: GitHub did not recognize the source-pushed profile repository as special. Preserved it as `SethGammon-profile-source`, recreated `SethGammon/SethGammon` with GitHub's README-enabled path, and verified the new repository is marked special.
+- 2026-07-12: The official experience schema referenced by the skill was missing. Used every canonical category listed by the skill directly in `docs/interactive-story-contract.md`.
+
+## Active Context
+
+Phase 5 is active. GitHub's explicit Share to Profile control was activated and the visual creator README, evidence table, bio, website, LinkedIn, X, and Reddit all render on the Overview page. The site now has campaign, review, fleet, evidence challenge, and 15-PR landing scenarios using one deterministic state engine. Desktop, mobile viewport, routing-sync, contract, and browser interaction checks pass.
+
+## Continuation State
+
+- current: phase 5, proof gallery, installation, branding, and accessibility
+- next: connect the proof gallery and runtime-specific install flow to the story engine, verify keyboard and reduced-motion states, then run the strict regression gate
+- verified: `npm run site:story:test` 15/15; `node scripts/test-routing-sync.js`; desktop, mobile, and deploy captures; campaign, fleet, evidence, and deploy browser interaction checks
+- profile: visual README, evidence table, LinkedIn, X, Reddit, bio, and website visibly mounted on the public Overview page
+- protected local state: `.planning/campaigns/citadel-product-proof.md`, `assets/social/`, and `dist/` remain outside campaign scope
+
+<!-- session-end: 2026-07-12T19:51:17.547Z -->
+
+<!-- session-end: 2026-07-12T20:19:15.162Z -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -1053,6 +1053,22 @@
     }
     .campaign-cta a:hover { border-color: var(--cyan); }
 
+    /* Proof receipt gallery */
+    .proof-section { width: 100%; padding: 64px 32px; background: color-mix(in srgb, var(--surface) 68%, var(--bg)); border-top: 1px solid var(--border); }
+    .proof-inner { max-width: 1080px; margin: 0 auto; }
+    .proof-heading { display: flex; justify-content: space-between; align-items: end; gap: 32px; margin-bottom: 28px; }
+    .proof-heading h2 { font-size: 28px; margin-bottom: 8px; }
+    .proof-heading p { color: var(--muted); max-width: 620px; line-height: 1.65; }
+    .proof-rule { color: var(--green); font: 700 11px 'SF Mono', Consolas, monospace; white-space: nowrap; }
+    .proof-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+    .proof-card { display: flex; flex-direction: column; min-height: 252px; padding: 20px; border: 1px solid var(--border); border-radius: 10px; background: var(--surface); }
+    .proof-card-kind { color: var(--dim); font: 700 10px 'SF Mono', Consolas, monospace; letter-spacing: 1.5px; text-transform: uppercase; }
+    .proof-card-result { margin: 18px 0 10px; color: var(--text); font-size: 25px; font-weight: 750; letter-spacing: -.4px; }
+    .proof-card-claim { color: var(--muted); font-size: 13px; line-height: 1.6; }
+    .proof-card-boundary { margin-top: auto; padding-top: 18px; color: var(--dim); font: 10px/1.55 'SF Mono', Consolas, monospace; }
+    .proof-card a { display: inline-block; margin-top: 13px; color: var(--cyan); font-size: 12px; text-decoration: none; }
+    .proof-card a:hover { text-decoration: underline; }
+
     /* ─── Inline install section ─── */
     .install-section {
       width: 100%; background: var(--bg);
@@ -1082,7 +1098,8 @@
     .install-code {
       font-family: 'SF Mono', monospace; font-size: 12px;
       background: var(--surface); border: 1px solid var(--border);
-      border-radius: 8px; padding: 10px 14px; color: var(--cyan); word-break: break-all;
+      border-radius: 8px; padding: 10px 14px; color: var(--cyan);
+      overflow-x: auto; white-space: nowrap; scrollbar-width: thin;
     }
     .install-guide-link {
       display: block; text-align: right;
@@ -1090,6 +1107,14 @@
       margin-top: 16px; transition: color 0.15s;
     }
     .install-guide-link:hover { color: var(--cyan); }
+    .runtime-tabs { display: flex; gap: 8px; margin-bottom: 18px; }
+    .runtime-tab { min-height: 44px; flex: 1; padding: 10px 14px; border: 1px solid var(--border); border-radius: 6px; background: var(--surface); color: var(--muted); font: 700 12px 'SF Mono', Consolas, monospace; cursor: pointer; }
+    .runtime-tab[aria-selected="true"] { color: var(--cyan); border-color: var(--cyan); background: color-mix(in srgb, var(--cyan) 7%, var(--surface)); }
+    .runtime-path[hidden] { display: none; }
+    .install-code-row { display: grid; grid-template-columns: 1fr auto; gap: 8px; }
+    .install-copy { min-width: 68px; border: 1px solid var(--border); border-radius: 6px; background: var(--surface-2); color: var(--muted); font: 700 11px 'SF Mono', Consolas, monospace; cursor: pointer; }
+    .install-copy:hover { border-color: var(--cyan); color: var(--cyan); }
+    .install-success { margin-top: 20px; padding: 14px 16px; border-left: 2px solid var(--green); background: color-mix(in srgb, var(--green) 6%, var(--surface)); color: var(--muted); font-size: 12px; line-height: 1.65; }
 
     /* ─── Screen 2 scrollable ─── */
     .screen-2 { overflow-y: auto; scrollbar-width: none; }
@@ -1201,6 +1226,10 @@
       .story-inspector { border-left: 0; border-top: 1px solid var(--border); }
       .story-file-tabs { flex-direction: row; overflow-x: auto; }
       .story-file-tab { width: auto; }
+      .proof-section { padding: 44px 14px; }
+      .proof-heading { display: block; }
+      .proof-rule { display: block; margin-top: 12px; }
+      .proof-grid { grid-template-columns: 1fr; }
       nav { padding: 12px 20px; gap: 12px; }
       .hero { padding: 40px 20px 16px; }
       .hero h1 { font-size: 32px; }
@@ -1320,6 +1349,8 @@
       .gen-btn { animation: none !important; }
       .live-dot { animation: none !important; }
       .cascade-connector-line, .cascade-connector-chevron { animation: none !important; opacity: 0.5 !important; }
+      .story-progress-bar, .story-scenario, .story-control, .story-file-tab,
+      .runtime-tab, .proof-card, .install-copy { animation: none !important; transition: none !important; }
     }
   </style>
 </head>
@@ -1786,6 +1817,62 @@
     </div>
   </div>
 
+  <section class="proof-section" id="proof">
+    <div class="proof-inner">
+      <div class="proof-heading">
+        <div>
+          <h2>Proof receipts, not confidence theater</h2>
+          <p>Every result names what happened, where to inspect it, and what the evidence does not prove.</p>
+        </div>
+        <span class="proof-rule">missing source → unknown</span>
+      </div>
+      <div class="proof-grid">
+        <article class="proof-card">
+          <div class="proof-card-kind">Mainline coordination</div>
+          <div class="proof-card-result">15 / 15 landed</div>
+          <p class="proof-card-claim">Fifteen PRs merged and deployed through one serialized steward lane.</p>
+          <div class="proof-card-boundary">Boundary: controlled public stress test, not a customer production deployment.</div>
+          <a href="https://github.com/SethGammon/agents-md-deploy-steward-proof">Inspect public repository →</a>
+        </article>
+        <article class="proof-card">
+          <div class="proof-card-kind">Operating journey</div>
+          <div class="proof-card-result">30 / 30 passed</div>
+          <p class="proof-card-claim">Claude Code and Codex completed install, route, verify, handoff, resume, and rollback across three operating systems.</p>
+          <div class="proof-card-boundary">Boundary: deterministic fixtures, not thirty human sessions.</div>
+          <a href="GOLDEN_PATH.md">Inspect matrix contract →</a>
+        </article>
+        <article class="proof-card">
+          <div class="proof-card-kind">Evidence integrity</div>
+          <div class="proof-card-result">UNKNOWN stays visible</div>
+          <p class="proof-card-claim">Removing an expected telemetry source changes the status instead of manufacturing a pass.</p>
+          <div class="proof-card-boundary">Boundary: controlled source-health demonstration.</div>
+          <a href="DASHBOARD_SPEC.md">Inspect evidence contract →</a>
+        </article>
+        <article class="proof-card">
+          <div class="proof-card-kind">Fresh-process continuity</div>
+          <div class="proof-card-result">State survives chat</div>
+          <p class="proof-card-claim">Campaign direction, evidence, decisions, and next action reload from repository files.</p>
+          <div class="proof-card-boundary">Boundary: file-backed state cannot replace missing project-specific judgment.</div>
+          <a href="CAMPAIGNS.md">Inspect campaign contract →</a>
+        </article>
+        <article class="proof-card">
+          <div class="proof-card-kind">Release integrity</div>
+          <div class="proof-card-result">v1.1.0 reproducible</div>
+          <p class="proof-card-claim">The release includes an archive, file manifest, SHA-256 sidecar, update plan, and rollback path.</p>
+          <div class="proof-card-boundary">Boundary: integrity proves artifact identity, not universal compatibility.</div>
+          <a href="https://github.com/SethGammon/Citadel/releases/tag/v1.1.0">Inspect release →</a>
+        </article>
+        <article class="proof-card">
+          <div class="proof-card-kind">Acquisition</div>
+          <div class="proof-card-result">107 unique cloners</div>
+          <p class="proof-card-claim">GitHub recorded 107 unique cloners during the July 11 surge.</p>
+          <div class="proof-card-boundary">Boundary: clone activity is not installation, successful setup, or retention.</div>
+          <a href="ACTIVATION_METRICS.md">Inspect measurement rules →</a>
+        </article>
+      </div>
+    </div>
+  </section>
+
   <!-- Stats bar -->
   <div class="stat-bar">
     <div class="stat">
@@ -1804,9 +1891,9 @@
       <div class="stat-caption">automatic quality gates without agent intervention</div>
     </div>
     <div class="stat">
-      <div class="stat-num">~0</div>
-      <div class="stat-label">Config Required</div>
-      <div class="stat-caption">works on any repo, any language</div>
+      <div class="stat-num">2</div>
+      <div class="stat-label">Runtime Surfaces</div>
+      <div class="stat-caption">the same operating journey for Claude Code and OpenAI Codex</div>
     </div>
   </div>
 
@@ -1818,29 +1905,23 @@
         <p>Install for Claude Code or OpenAI Codex.<br>Citadel detects the runtime and prepares the current git repository.</p>
       </div>
       <div class="install-right">
-        <div class="install-steps">
-          <div class="install-step">
-            <div class="install-step-num">1</div>
-            <div class="install-step-body">
-              <div class="install-step-label">Choose your runtime</div>
-              <div class="install-code">Claude Code or OpenAI Codex</div>
-            </div>
-          </div>
-          <div class="install-step">
-            <div class="install-step-num">2</div>
-            <div class="install-step-body">
-              <div class="install-step-label">Install Citadel from the repository</div>
-              <div class="install-code">Use the runtime-specific installer in INSTALL.md</div>
-            </div>
-          </div>
-          <div class="install-step">
-            <div class="install-step-num">3</div>
-            <div class="install-step-body">
-              <div class="install-step-label">Prepare the current project</div>
-              <div class="install-code">/do setup --express</div>
-            </div>
+        <div class="runtime-tabs" role="tablist" aria-label="Choose your coding agent runtime">
+          <button class="runtime-tab" role="tab" aria-selected="true" data-runtime="claude">Claude Code</button>
+          <button class="runtime-tab" role="tab" aria-selected="false" data-runtime="codex">OpenAI Codex</button>
+        </div>
+        <div class="runtime-path" data-runtime-path="claude">
+          <div class="install-steps">
+            <div class="install-step"><div class="install-step-num">1</div><div class="install-step-body"><div class="install-step-label">From the target project root</div><div class="install-code-row"><div class="install-code">node ~/Citadel/scripts/install.js --runtime claude --install --scope local</div><button class="install-copy" data-copy="node ~/Citadel/scripts/install.js --runtime claude --install --scope local">Copy</button></div></div></div>
+            <div class="install-step"><div class="install-step-num">2</div><div class="install-step-body"><div class="install-step-label">Start the fresh session requested by the installer</div><div class="install-code">/do setup --express</div></div></div>
           </div>
         </div>
+        <div class="runtime-path" data-runtime-path="codex" hidden>
+          <div class="install-steps">
+            <div class="install-step"><div class="install-step-num">1</div><div class="install-step-body"><div class="install-step-label">From the target project root</div><div class="install-code-row"><div class="install-code">node ~/Citadel/scripts/install.js --runtime codex --add-marketplace</div><button class="install-copy" data-copy="node ~/Citadel/scripts/install.js --runtime codex --add-marketplace">Copy</button></div></div></div>
+            <div class="install-step"><div class="install-step-num">2</div><div class="install-step-body"><div class="install-step-label">Enable the plugin, start a fresh task, then prepare the project</div><div class="install-code">/do setup --express</div></div></div>
+          </div>
+        </div>
+        <div class="install-success"><strong>First verified success:</strong> run <code>/do review README.md</code>, inspect the route and handoff, then close the session and run <code>/do next</code> in a fresh one.</div>
         <a class="install-guide-link" href="#" onclick="openPanel('install'); return false;">Full install guide →</a>
       </div>
     </div>
@@ -2156,6 +2237,26 @@
       document.getElementById('story-next').addEventListener('click', () => { storyStop(); storyIndex = Math.min(storyScenarios[storyScenario].length - 1, storyIndex + 1); storySelectedFile = null; storyRender(); });
       document.getElementById('story-reset').addEventListener('click', () => { storyStop(); storyIndex = 0; storySelectedFile = null; storyRender(); });
       document.getElementById('story-play').addEventListener('click', storyPlay);
+      document.querySelectorAll('[data-runtime]').forEach(tab => tab.addEventListener('click', () => {
+        const runtime = tab.dataset.runtime;
+        document.querySelectorAll('[data-runtime]').forEach(item => item.setAttribute('aria-selected', String(item === tab)));
+        document.querySelectorAll('[data-runtime-path]').forEach(path => { path.hidden = path.dataset.runtimePath !== runtime; });
+      }));
+      document.querySelectorAll('.runtime-tabs, .story-scenarios').forEach(tablist => tablist.addEventListener('keydown', event => {
+        if (!['ArrowLeft', 'ArrowRight'].includes(event.key)) return;
+        const tabs = Array.from(tablist.querySelectorAll('[role="tab"]'));
+        const current = Math.max(0, tabs.indexOf(document.activeElement));
+        const next = event.key === 'ArrowRight' ? (current + 1) % tabs.length : (current - 1 + tabs.length) % tabs.length;
+        event.preventDefault();
+        tabs[next].focus();
+        tabs[next].click();
+      }));
+      document.querySelectorAll('[data-copy]').forEach(button => button.addEventListener('click', async () => {
+        await navigator.clipboard.writeText(button.dataset.copy);
+        const previous = button.textContent;
+        button.textContent = 'Copied';
+        setTimeout(() => { button.textContent = previous; }, 1400);
+      }));
       storyRender();
     });
 
@@ -2177,7 +2278,7 @@
       { re: /\b(architect|architecture|design the system|file structure|plan the build)\b/i, skill: '/architect',
         desc: "Given a PRD, produces an implementation architecture: file tree, component breakdown, data model, and a phased build plan with end conditions that Archon can execute directly. Multi-candidate evaluation for key decisions.", icon: '🏗' },
       { re: /\b(ascii diagram|ascii art|box diagram|architecture diagram|flow diagram|sequence diagram|draw a diagram|text diagram)\b/i, skill: '/ascii-diagram',
-        desc: "Generate perfectly aligned ASCII diagrams — architecture, flow, sequence, box-and-arrow. Uses a programmatic character-grid approach so alignment is guaranteed by math, not token prediction. Includes post-render verification.", icon: '◇' },
+        desc: "Generate perfectly aligned ASCII diagrams  -  architecture, flow, sequence, box-and-arrow. Uses a programmatic character-grid approach so alignment is guaranteed by math, not token prediction. Includes post-render verification.", icon: '◇' },
       { re: /\b(intake|process pending|pipeline)\b/i, skill: '/autopilot',
         desc: "Intake-to-delivery pipeline. Processes pending items from .planning/intake/: briefs new ideas, executes approved work through research → plan → build → verify. Drop a file in .planning/intake/ and invoke this skill.", icon: '◇' },
       { re: /\b(cost|costs|cost breakdown|campaign cost|token usage|burn rate|model breakdown)\b/i, skill: '/cost',
@@ -2189,7 +2290,7 @@
       { re: /\b(dashboard|what's happening|what's going on|show activity|harness state|show me status)\b/i, skill: '/dashboard',
         desc: "Real-time harness observability dashboard. Reads campaigns, fleet sessions, telemetry, and pending queues to present a snapshot of harness state at a glance. Invoked by /dashboard, /do status, or phrases like \"what's happening\" and \"show activity\".", icon: '◇' },
       { re: /\b(decision map|plan this out|figure this out|investigation plan|planning map)\b/i, skill: '/decision-map',
-        desc: "Turn a loose idea into a git-tracked, session-resumable map of typed investigation tickets, then drive them to resolution one at a time. The planning-loop engine for work that is still being figured out — too fuzzy for a campaign, too big for a single intake item. Resolved tickets graduate into .planning/intake/ for the autopilot to build.", icon: '◇' },
+        desc: "Turn a loose idea into a git-tracked, session-resumable map of typed investigation tickets, then drive them to resolution one at a time. The planning-loop engine for work that is still being figured out  -  too fuzzy for a campaign, too big for a single intake item. Resolved tickets graduate into .planning/intake/ for the autopilot to build.", icon: '◇' },
       { re: /\b(deploy steward|deploy queue|merge steward|mainline steward|land prs|land PRs|deploy prs|deploy PRs|merge queue|release train)\b/i, skill: '/deploy-steward',
         desc: "Mainline deploy steward. Consumes ready PRs, owns a lease on mainline landing, refreshes PR state, updates stale branches, waits for CI and deploy gates, merges or queues one candidate at a time, and opens repair tasks for failures.", icon: '◇' },
       { re: /\b(design|style guide|design manifest|visual consistency)\b/i, skill: '/design',
@@ -2205,7 +2306,7 @@
       { re: /\b(houseclean|house clean|disk space|free space|c drive full|drive full|running out of space|clean up disk|orphaned worktrees|clean worktrees|disk audit|storage audit|move to another drive|free up space)\b/i, skill: '/houseclean',
         desc: "Cross-drive storage audit and cleanup. Surveys all drives, finds orphaned git worktrees, large AI tool caches (.ollama, .gemini, .cursor, npm, pip), and buildable artifacts (node_modules, .venv). Produces a prioritized action plan with specific migration commands. Use when disk space is low or worktrees need cleanup; do NOT use for project structure issues (use /organize instead).", icon: '◇' },
       { re: /\b(improve|improvement loop|quality loop|rubric|score against|run improvement|improve citadel)\b/i, skill: '/improve',
-        desc: "Autonomous quality improvement loop. Scores a target against a rubric, selects the highest-leverage axis, attacks it, verifies, documents, and loops. No pre-planning between iterations — each loop re-scores from scratch.", icon: '◇' },
+        desc: "Autonomous quality improvement loop. Scores a target against a rubric, selects the highest-leverage axis, attacks it, verifies, documents, and loops. No pre-planning between iterations  -  each loop re-scores from scratch.", icon: '◇' },
       { re: /\b(infra|infrastructure|what databases|what systems|docker-compose|infra audit|map infrastructure|what does this connect to)\b/i, skill: '/infra-audit',
         desc: "Reads docker-compose, env files, ORM configs, and connection strings to map current infrastructure. Flags missing layers (cache, queue, analytics) based on observed access patterns. Outputs a structured infrastructure manifest.", icon: '◇' },
       { re: /\b(learn|extract patterns|learn from that|save what worked|patterns from campaign)\b/i, skill: '/learn',
@@ -2233,7 +2334,7 @@
       { re: /\b(research|investigate|look into|find out|research fleet|parallel research|multi-angle research|compare options)\b/i, skill: '/research',
         desc: "Focused research investigations. Converts questions into structured findings with confidence levels and source citations. Single agent by default; with --parallel (or when the question decomposes into 3+ independent angles) it spawns scout agents whose findings are compressed into a unified brief. Does not make decisions; produces information that informs the next step.", icon: '⌕' },
       { re: /\b(\/review|code review|review this|review PR|review)\b/i, skill: '/review',
-        desc: "5-pass structured code review — correctness, security, performance, readability, consistency", icon: '◆' },
+        desc: "5-pass structured code review  -  correctness, security, performance, readability, consistency", icon: '◆' },
       { re: /\b(scaffold|generate component|generate module|generate service|new component|new module|new route|new service|create component|stub out|bootstrap)\b/i, skill: '/scaffold',
         desc: "Project-aware file generation. Reads existing codebase conventions (naming, structure, imports, exports, test patterns) then generates new files that match exactly. Wires generated files into the project's registration points.", icon: '⬡' },
       { re: /\b(schedule|recurring|every N minutes|cron|set a reminder|run periodically)\b/i, skill: '/schedule',
@@ -2247,7 +2348,7 @@
       { re: /\b(telemetry|what did this cost|session cost|how much did that cost|how much have I spent|what hooks fired|trust level|show me telemetry|spending|session stats|what telemetry|verify audit|audit integrity|check audit|tampered records)\b/i, skill: '/telemetry',
         desc: "Unified telemetry hub. Shows current session cost, today's spend, all-time totals, hook activity, trust level, and a directory of every telemetry command available. Also the control surface to toggle telemetry on/off and tune thresholds. Single entry point for anyone asking \"what does this cost\" or \"what telemetry does Citadel have\".", icon: '◇' },
       { re: /\b(\/test-gen|generate tests|write tests|add tests|test)\b/i, skill: '/test-gen',
-        desc: "Generate and verify tests — happy path, edge cases, error paths — using the project's own framework and patterns", icon: '⚗' },
+        desc: "Generate and verify tests  -  happy path, edge cases, error paths  -  using the project's own framework and patterns", icon: '⚗' },
       { re: /\b(triage|open issues|unlabeled issues|review pr|review prs|investigate issue)\b/i, skill: '/triage',
         desc: "GitHub issue and PR investigator. Pulls open issues/PRs, classifies them, searches the codebase for root cause or reviews contributed code, proposes fixes with file:line references, and optionally implements fixes. Use for investigating GitHub issues and reviewing PRs; do NOT use for general code review unrelated to GitHub issues.", icon: '📌' },
       { re: /\b(unharness|remove citadel|uninstall citadel|clean up citadel|remove harness|uninstall harness)\b/i, skill: '/unharness',
@@ -3063,7 +3164,7 @@
 
     // ─── Copy-to-clipboard for code blocks ────────────────────────────────
     (function initCopyButtons() {
-      document.querySelectorAll('.install-code, .panel-code').forEach(block => {
+      document.querySelectorAll('.install-code:not(.install-code-row .install-code), .panel-code').forEach(block => {
         const wrap = document.createElement('div');
         wrap.style.cssText = 'position:relative;display:block';
         block.parentNode.insertBefore(wrap, block);

--- a/docs/index.html
+++ b/docs/index.html
@@ -867,6 +867,48 @@
       max-width: 160px; margin-left: auto; margin-right: auto;
     }
 
+    /* Interactive operating journey */
+    .story-section { max-width: 1180px; margin: 0 auto; padding: 54px 32px 26px; }
+    .story-heading { display: flex; align-items: end; justify-content: space-between; gap: 24px; margin-bottom: 24px; }
+    .story-heading h2 { font-size: 30px; letter-spacing: -0.6px; }
+    .story-heading p { max-width: 610px; color: var(--muted); line-height: 1.65; }
+    .story-shell { border: 1px solid var(--border); border-radius: 16px; overflow: hidden; background: var(--surface); box-shadow: 0 24px 80px rgba(0,0,0,.24); }
+    .story-toolbar { display: flex; align-items: center; gap: 10px; padding: 14px 16px; border-bottom: 1px solid var(--border); background: var(--surface-2); }
+    .story-scenarios { display: flex; gap: 7px; min-width: 0; overflow-x: auto; scrollbar-width: none; }
+    .story-scenario, .story-control, .story-file-tab { min-height: 40px; border: 1px solid var(--border); border-radius: 6px; padding: 9px 12px; background: var(--surface); color: var(--muted); font: 700 11px 'SF Mono', Consolas, monospace; cursor: pointer; white-space: nowrap; transition: border-color .16s, color .16s, background .16s; }
+    .story-scenario:hover, .story-control:hover, .story-file-tab:hover { border-color: var(--cyan); color: var(--text); }
+    .story-scenario[aria-selected="true"] { border-color: var(--cyan); color: var(--cyan); background: color-mix(in srgb, var(--cyan) 8%, var(--surface)); }
+    .story-controls { margin-left: auto; display: flex; gap: 6px; }
+    .story-control { width: 40px; padding: 0; font-size: 15px; }
+    .story-control.primary { width: auto; padding: 0 14px; color: var(--cyan); border-color: color-mix(in srgb, var(--cyan) 50%, var(--border)); }
+    .story-layout { display: grid; grid-template-columns: 230px minmax(0,1fr) 330px; min-height: 470px; }
+    .story-timeline { border-right: 1px solid var(--border); padding: 22px 16px; background: color-mix(in srgb, var(--surface-2) 60%, var(--surface)); }
+    .story-timeline-label, .story-inspector-label { color: var(--dim); font: 700 10px 'SF Mono', Consolas, monospace; letter-spacing: 1.8px; text-transform: uppercase; margin-bottom: 14px; }
+    .story-step { display: grid; grid-template-columns: 22px 1fr; gap: 9px; position: relative; padding: 8px 0; color: var(--dim); }
+    .story-step::after { content: ''; position: absolute; left: 10px; top: 31px; bottom: -7px; width: 1px; background: var(--border); }
+    .story-step:last-child::after { display: none; }
+    .story-step-dot { width: 21px; height: 21px; border: 1px solid var(--border); border-radius: 50%; display: grid; place-items: center; font: 700 9px 'SF Mono', monospace; background: var(--surface); z-index: 1; }
+    .story-step-name { font-size: 12px; font-weight: 650; line-height: 1.45; padding-top: 2px; }
+    .story-step.complete { color: var(--muted); }
+    .story-step.complete .story-step-dot { border-color: var(--green); color: var(--green); }
+    .story-step.active { color: var(--text); }
+    .story-step.active .story-step-dot { border-color: var(--cyan); color: var(--cyan); box-shadow: 0 0 18px color-mix(in srgb, var(--cyan) 30%, transparent); }
+    .story-stage { padding: 34px 36px; display: flex; flex-direction: column; min-width: 0; }
+    .story-status { display: inline-flex; align-items: center; gap: 8px; width: fit-content; padding: 5px 10px; border: 1px solid var(--border); border-radius: 20px; color: var(--cyan); font: 700 10px 'SF Mono', Consolas, monospace; letter-spacing: 1px; text-transform: uppercase; }
+    .story-status::before { content: ''; width: 7px; height: 7px; border-radius: 50%; background: currentColor; }
+    .story-stage h3 { font-size: 29px; line-height: 1.2; margin: 22px 0 12px; letter-spacing: -.4px; }
+    .story-stage-copy { color: var(--muted); line-height: 1.7; max-width: 620px; }
+    .story-command { margin-top: 26px; border: 1px solid var(--border); border-radius: 8px; background: var(--bg); padding: 18px 20px; color: var(--text); font: 14px/1.65 'SF Mono', Consolas, monospace; min-height: 118px; white-space: pre-wrap; }
+    .story-source { margin-top: auto; padding-top: 22px; color: var(--dim); font: 11px/1.5 'SF Mono', Consolas, monospace; }
+    .story-source a { color: var(--cyan); text-decoration: none; }
+    .story-inspector { border-left: 1px solid var(--border); padding: 22px 18px; min-width: 0; background: var(--bg); }
+    .story-file-tabs { display: flex; flex-direction: column; gap: 6px; }
+    .story-file-tab { width: 100%; text-align: left; overflow: hidden; text-overflow: ellipsis; }
+    .story-file-tab[aria-selected="true"] { color: var(--green); border-color: color-mix(in srgb, var(--green) 45%, var(--border)); }
+    .story-file { margin-top: 16px; padding: 16px; border: 1px solid var(--border); border-radius: 8px; background: var(--surface); min-height: 220px; color: var(--muted); font: 11px/1.65 'SF Mono', Consolas, monospace; white-space: pre-wrap; overflow: hidden; }
+    .story-progress { height: 3px; background: var(--border); }
+    .story-progress-bar { height: 100%; width: 0; background: var(--cyan); transition: width .28s ease; }
+
     /* ─── Cascade section (replaces how-section 2×2 grid) ─── */
     .cascade-section {
       width: 100%; max-width: 700px;
@@ -1142,6 +1184,23 @@
 
     /* ─── Responsive ─── */
     @media (max-width: 760px) {
+      .story-section { padding: 34px 14px 18px; }
+      .story-heading { display: block; }
+      .story-heading p { margin-top: 10px; }
+      .story-toolbar { align-items: stretch; flex-direction: column; }
+      .story-scenarios { padding-right: 34px; scroll-snap-type: x proximity; mask-image: linear-gradient(90deg, #000 0, #000 calc(100% - 34px), transparent 100%); }
+      .story-scenario { scroll-snap-align: start; }
+      .story-controls { margin-left: 0; }
+      .story-layout { grid-template-columns: 1fr; }
+      .story-timeline { border-right: 0; border-bottom: 1px solid var(--border); display: flex; gap: 12px; overflow-x: auto; padding-right: 42px; scroll-snap-type: x proximity; mask-image: linear-gradient(90deg, #000 0, #000 calc(100% - 38px), transparent 100%); }
+      .story-timeline-label { display: none; }
+      .story-step { min-width: 118px; grid-template-columns: 20px 1fr; scroll-snap-align: start; }
+      .story-step::after { display: none; }
+      .story-stage { padding: 26px 20px; min-height: 390px; }
+      .story-stage h3 { font-size: 24px; }
+      .story-inspector { border-left: 0; border-top: 1px solid var(--border); }
+      .story-file-tabs { flex-direction: row; overflow-x: auto; }
+      .story-file-tab { width: auto; }
       nav { padding: 12px 20px; gap: 12px; }
       .hero { padding: 40px 20px 16px; }
       .hero h1 { font-size: 32px; }
@@ -1470,6 +1529,46 @@
   </div><!-- /screen-1 -->
 
   <div class="screen-2" id="screen-2">
+
+  <section class="story-section" id="product-story" aria-labelledby="story-title">
+    <div class="story-heading">
+      <div><h2 id="story-title">Operate a real Citadel journey</h2></div>
+      <p>Choose a task, step through the operating loop, and inspect the repository state that survives after the conversation ends.</p>
+    </div>
+    <div class="story-shell">
+      <div class="story-toolbar">
+        <div class="story-scenarios" role="tablist" aria-label="Citadel journey scenarios">
+          <button class="story-scenario" role="tab" aria-selected="true" data-story-scenario="campaign">Persistent feature</button>
+          <button class="story-scenario" role="tab" aria-selected="false" data-story-scenario="review">Focused review</button>
+          <button class="story-scenario" role="tab" aria-selected="false" data-story-scenario="fleet">Fleet migration</button>
+          <button class="story-scenario" role="tab" aria-selected="false" data-story-scenario="evidence">Evidence challenge</button>
+          <button class="story-scenario" role="tab" aria-selected="false" data-story-scenario="deploy">15-PR landing</button>
+        </div>
+        <div class="story-controls" aria-label="Journey playback controls">
+          <button class="story-control" id="story-prev" aria-label="Previous step">←</button>
+          <button class="story-control primary" id="story-play">Play</button>
+          <button class="story-control" id="story-next" aria-label="Next step">→</button>
+          <button class="story-control" id="story-reset" aria-label="Reset journey">↺</button>
+        </div>
+      </div>
+      <div class="story-progress"><div class="story-progress-bar" id="story-progress-bar"></div></div>
+      <div class="story-layout">
+        <aside class="story-timeline" id="story-timeline" aria-label="Journey steps"></aside>
+        <div class="story-stage" aria-live="polite">
+          <div class="story-status" id="story-status">Ready</div>
+          <h3 id="story-stage-title">A persistent feature enters through one command</h3>
+          <p class="story-stage-copy" id="story-stage-copy">Citadel begins with the request, not a manually selected orchestrator.</p>
+          <div class="story-command" id="story-command">/do rework authentication across the application</div>
+          <div class="story-source" id="story-source"></div>
+        </div>
+        <aside class="story-inspector" aria-label="Repository state inspector">
+          <div class="story-inspector-label">Repository state</div>
+          <div class="story-file-tabs" id="story-file-tabs" role="tablist" aria-label="Repository files"></div>
+          <div class="story-file" id="story-file" role="tabpanel"></div>
+        </aside>
+      </div>
+    </div>
+  </section>
 
   <!-- Vertical tier cascade -->
   <div class="cascade-section">
@@ -1959,6 +2058,107 @@
   </button>
 
   <script>
+    const storyScenarios = {
+      campaign: [
+        ['Request','request received','A persistent feature enters through one command','Citadel begins with the request, not a manually selected orchestrator.','/do rework authentication across the application','Input is local to this deterministic demo.',{'request.txt':'rework authentication across the application'}],
+        ['Route','tier 3 selected','Cheap routes miss, so complexity earns a campaign','Pattern, active-state, and keyword checks do not resolve the request. Tier 3 selects Archon because the work spans files and sessions.','Tier 0  no pattern match\nTier 1  no active campaign\nTier 2  no registered skill match\nTier 3  → Archon','The route mirrors Citadel’s published tier contract.',{'routing.json':'{\n  "scope": "application",\n  "complexity": 4,\n  "persistence": true,\n  "route": "archon"\n}'}],
+        ['Contract','state written','The work becomes a repository contract','Direction, phases, end conditions, decisions, and the next action are written before long-running work advances.','Created .planning/campaigns/auth-overhaul.md\nPhase 1: map boundary\nPhase 2: implement rotation\nPhase 3: verify security\nPhase 4: package handoff','Campaign contract: docs/CAMPAIGNS.md', {'.planning/campaigns/auth-overhaul.md':'status: active\ncurrent_phase: 2\n\n✓ map current auth boundary\n→ implement token rotation\n○ verify security\n○ package handoff','.planning/discoveries/auth-boundary.md':'Decision: keep the old session path available until verification passes.'}],
+        ['Verify','evidence recorded','Completion requires evidence, not confidence','Tests and source health update the contract. A missing source remains unknown instead of becoming a pass.','rotation-tests     PASS\nboundary-map       PASS\nexternal-review    BLOCKED\nproduction-source  UNKNOWN','Evidence contract: docs/DASHBOARD_SPEC.md',{'.planning/campaigns/auth-overhaul.md':'rotation-tests: pass\nboundary-map: pass\nexternal-review: blocked\nproduction-telemetry: unknown'}],
+        ['Close','conversation closed','The conversation ends. The contract remains.','Chat context disappears. Campaign state, decisions, evidence, and the next action remain in repository files.','SESSION A CLOSED\n\nChat context: discarded\nRepository state: preserved','Deterministic representation of file-backed campaign state.',{'.planning/handoffs/latest.md':'Completed: token rotation implementation\nNext: independent security verification\nRisk: old session path must remain available'}],
+        ['Resume','fresh process restored','A fresh session knows what comes next','The next agent reads the active campaign and restores the next useful action without relying on the previous conversation.','FRESH SESSION\n\n/do next\n→ Resume auth-overhaul\n→ Next: independent security verification','Operating-loop proof: docs/OPERATING_LOOP_PROOF.md',{'.planning/campaigns/auth-overhaul.md':'status: active\ncurrent_phase: 3\nnext_action: independent security verification','.planning/handoffs/latest.md':'The next session continues from this file-backed handoff.'}]
+      ],
+      review: [
+        ['Request','request received','A focused review stays focused','The request names a known workflow and does not need campaign machinery.','/do review the authentication module','Local deterministic route preview.',{'request.txt':'review the authentication module'}],
+        ['Route','tier 2 selected','Known language routes without model classification','The registered review keyword resolves at Tier 2 for zero classifier tokens.','Tier 0  no pattern match\nTier 1  no active work\nTier 2  review → /review','routing-table.json',{'routing.json':'{ "keyword": "review", "route": "/review", "classifier_tokens": 0 }'}],
+        ['Inspect','five passes running','The workflow applies a bounded review contract','Correctness, security, performance, readability, and consistency run against the named scope.','correctness   PASS\nsecurity      1 issue\nperformance   PASS\nreadability   2 notes\nconsistency   PASS','skills/review/SKILL.md',{'.planning/handoffs/review.md':'Scope: src/auth/\nBlocking: token expiry unchecked\nNotes: 2 style findings'}],
+        ['Verify','evidence recorded','Findings point to files and verification','The handoff distinguishes blocking findings from notes and records whether tests regressed.','3 findings\n1 blocking security issue\n0 test regressions','skills/review/SKILL.md',{'.planning/handoffs/review.md':'Blocking: verify token expiry before merge\nTests: no regressions detected'}]
+      ],
+      fleet: [
+        ['Request','request received','Platform-wide work earns parallel coordination','The objective spans independent areas and can benefit from isolated work.','/do migrate the platform to TypeScript strict mode','Local deterministic route preview.',{'request.txt':'migrate the platform to TypeScript strict mode'}],
+        ['Route','fleet selected','Scope and parallelism select Fleet','Citadel chooses coordinated waves instead of asking the operator to manage several terminals.','scope: platform\ncomplexity: 5\nparallel: true\nroute: fleet','docs/FLEET.md',{'.planning/fleet/session.json':'{ "objective": "strict mode", "wave": 1, "agents": 3 }'}],
+        ['Isolate','three worktrees ready','Each agent owns an isolated worktree','API, components, and utilities advance independently without sharing one branch.','Agent A  wt-fleet-api\nAgent B  wt-fleet-components\nAgent C  wt-fleet-utils','docs/worktree-isolation.md',{'.planning/fleet/session.json':'A: wt-fleet-api\nB: wt-fleet-components\nC: wt-fleet-utils'}],
+        ['Relay','discovery shared','One discovery changes the rest of the wave','Agent A finds shared implicit casts. Citadel relays the discovery before the next wave compounds it.','Agent A discovered 12 implicit any casts\n→ relayed to Agents B and C','docs/FLEET.md',{'.planning/discoveries/shared-types.md':'12 implicit any casts found in shared types. Apply before Wave 2.'}],
+        ['Merge','two merged, one blocked','Conflict remains visible instead of becoming green','Two worktrees merge. One conflict stays pending for reconciliation.','Agent A  MERGED\nAgent B  MERGED\nAgent C  BLOCKED: shared type conflict','docs/FLEET.md',{'.planning/fleet/session.json':'A: merged\nB: merged\nC: blocked\nreason: shared type conflict'}]
+      ],
+      evidence: [
+        ['Healthy','sources present','Evidence begins with named sources','Citadel can show a passing state because the expected verification and telemetry sources are present.','tests             PASS\nhandoff           PRESENT\ntelemetry source  HEALTHY\nstatus            VERIFIED','docs/DASHBOARD_SPEC.md',{'.planning/evidence/receipt.json':'{\n  "tests": "pass",\n  "handoff": "present",\n  "telemetry": "healthy",\n  "status": "verified"\n}'}],
+        ['Remove','source removed','Now remove the telemetry source','The challenge changes the source state itself. It does not toggle a decorative warning.','REMOVE .planning/telemetry/agent-runs.jsonl','Controlled deterministic challenge. No local file is actually deleted.',{'.planning/evidence/receipt.json':'expected_source: .planning/telemetry/agent-runs.jsonl\nobserved: absent'}],
+        ['Unknown','certainty refused','Missing evidence becomes unknown','Citadel refuses to infer success from silence. The missing source is named and the status remains unresolved.','tests             PASS\nhandoff           PRESENT\ntelemetry source  ABSENT\nstatus            UNKNOWN','docs/DASHBOARD_SPEC.md',{'.planning/evidence/receipt.json':'{\n  "telemetry": "unknown",\n  "reason": "expected source absent",\n  "status": "unknown"\n}'}],
+        ['Restore','source restored','Restore the source and verify again','The status can advance only after the source returns and the evidence is evaluated.','RESTORE telemetry source\nVERIFY schema and latest event\nstatus  VERIFIED','Controlled deterministic challenge.',{'.planning/telemetry/agent-runs.jsonl':'{"event":"verification","status":"pass","schema":1}','.planning/evidence/receipt.json':'status: verified\nsource: healthy'}]
+      ],
+      deploy: [
+        ['Queue','15 PRs ready','Fifteen PRs enter one protected landing lane','Other agents can keep producing, but one steward owns the serialized path through main, CI, and deployment.','queued: 15\nlanded: 0\nmainline lease: steward','public deploy-steward proof repository',{'.agent-steward/queue.json':'queued: pr-1 through pr-15\npolicy: one landing candidate at a time'}],
+        ['Update','branches refreshed','Fourteen stale branches update against moving main','After the first merge, each remaining branch must absorb the new mainline before its checks can be trusted.','branch updates  14\nrepair tasks     0','retained steward receipt',{'.planning/live-proof/receipt.json':'updatedBranchEvents: 14\nrepairEvents: 0'}],
+        ['Wait','CI remains the gate','The steward waits instead of guessing','Fifty-nine waits represent real mergeability and CI polling. Waiting is visible operating work, not a hidden delay.','CI waits  59\nforced merges  0\nbypasses       0','retained steward receipt',{'.planning/live-proof/receipt.json':'waitingEvents: 59\npolicyBypasses: 0'}],
+        ['Land','15 merged and deployed','Every PR clears the serialized lane','All fifteen PRs merge and deploy. The final receipt records the result without rewriting the waits or branch updates as failures.','PRs       15 / 15 merged\ndeploys   15 / 15 complete\nupdates   14\nCI waits  59\nrepairs   0','github.com/SethGammon/agents-md-deploy-steward-proof',{'.planning/live-proof/receipt.json':'mergedPrs: 15\ndeploys: 15\nupdatedBranchEvents: 14\nwaitingEvents: 59\nrepairEvents: 0'}]
+      ]
+    };
+
+    let storyScenario = 'campaign';
+    let storyIndex = 0;
+    let storyTimer = null;
+    let storySelectedFile = null;
+
+    function storyRender() {
+      const steps = storyScenarios[storyScenario];
+      const step = steps[storyIndex];
+      const timeline = document.getElementById('story-timeline');
+      if (!timeline) return;
+      timeline.innerHTML = '<div class="story-timeline-label">Operating journey</div>' + steps.map((item, index) => {
+        const state = index < storyIndex ? 'complete' : index === storyIndex ? 'active' : '';
+        const marker = index < storyIndex ? '✓' : String(index + 1);
+        return `<div class="story-step ${state}"><div class="story-step-dot">${marker}</div><div class="story-step-name">${item[0]}</div></div>`;
+      }).join('');
+      document.getElementById('story-status').textContent = step[1];
+      document.getElementById('story-stage-title').textContent = step[2];
+      document.getElementById('story-stage-copy').textContent = step[3];
+      document.getElementById('story-command').textContent = step[4];
+      document.getElementById('story-source').textContent = `Source: ${step[5]}`;
+      document.getElementById('story-progress-bar').style.width = `${((storyIndex + 1) / steps.length) * 100}%`;
+      const files = Object.keys(step[6]);
+      if (!storySelectedFile || !step[6][storySelectedFile]) storySelectedFile = files[0];
+      document.getElementById('story-file-tabs').innerHTML = files.map(file => `<button class="story-file-tab" role="tab" aria-selected="${file === storySelectedFile}" data-story-file="${file}">${file}</button>`).join('');
+      document.getElementById('story-file').textContent = step[6][storySelectedFile];
+      document.querySelectorAll('[data-story-file]').forEach(button => button.addEventListener('click', () => { storySelectedFile = button.dataset.storyFile; storyRender(); }));
+      document.getElementById('story-prev').disabled = storyIndex === 0;
+      document.getElementById('story-next').disabled = storyIndex === steps.length - 1;
+    }
+
+    function storyStop() {
+      if (storyTimer) clearInterval(storyTimer);
+      storyTimer = null;
+      const play = document.getElementById('story-play');
+      if (play) play.textContent = 'Play';
+    }
+
+    function storyPlay() {
+      if (storyTimer) { storyStop(); return; }
+      document.getElementById('story-play').textContent = 'Pause';
+      storyTimer = setInterval(() => {
+        const last = storyScenarios[storyScenario].length - 1;
+        if (storyIndex >= last) { storyStop(); return; }
+        storyIndex += 1;
+        storySelectedFile = null;
+        storyRender();
+      }, window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 400 : 1200);
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      document.querySelectorAll('[data-story-scenario]').forEach(button => button.addEventListener('click', () => {
+        storyStop();
+        storyScenario = button.dataset.storyScenario;
+        storyIndex = 0;
+        storySelectedFile = null;
+        document.querySelectorAll('[data-story-scenario]').forEach(item => item.setAttribute('aria-selected', String(item === button)));
+        storyRender();
+      }));
+      document.getElementById('story-prev').addEventListener('click', () => { storyStop(); storyIndex = Math.max(0, storyIndex - 1); storySelectedFile = null; storyRender(); });
+      document.getElementById('story-next').addEventListener('click', () => { storyStop(); storyIndex = Math.min(storyScenarios[storyScenario].length - 1, storyIndex + 1); storySelectedFile = null; storyRender(); });
+      document.getElementById('story-reset').addEventListener('click', () => { storyStop(); storyIndex = 0; storySelectedFile = null; storyRender(); });
+      document.getElementById('story-play').addEventListener('click', storyPlay);
+      storyRender();
+    });
+
     // ─── Routing logic ─────────────────────────────────────────────────────
     const TIER0 = [
       { re: /\b(fix|correct)\s+(the\s+)?typo\b/i,    label: 'pattern: "fix typo"',     color: 'var(--green)' },

--- a/docs/interactive-story-contract.md
+++ b/docs/interactive-story-contract.md
@@ -1,0 +1,174 @@
+# Citadel Interactive Product Story v2
+
+## Experience identity
+
+| Variable | Status | Decision |
+|---|---|---|
+| Name | Decided | Citadel Interactive Product Story |
+| Purpose | Decided | Let a stranger operate a deterministic Citadel journey and inspect why each state changes |
+| Current problem | Decided | The existing site explains routing well but does not let visitors experience persistence, evidence, fleet coordination, or delivery proof as one system |
+| Mode | Decided | Major refinement of the existing public site |
+
+## User and emotional contract
+
+| Variable | Status | Decision |
+|---|---|---|
+| Primary user | Decided | A Claude Code or Codex user who has felt context loss, manual workflow choice, weak handoffs, or multi-agent coordination overhead |
+| First question | Decided | What does Citadel actually do that the runtime does not already do? |
+| Trust question | Decided | Is this real behavior or an animated claim? |
+| Emotional contract | Decided | Precise, calm, inspectable, and surprisingly capable |
+| Rejected feeling | Rejected | Autonomous-agent spectacle, fake activity, or a cyberpunk dashboard with no evidence |
+
+## Governing metaphor
+
+| Variable | Status | Decision |
+|---|---|---|
+| Core metaphor | Decided | A protected operating lane through gates, checkpoints, work cells, and receipts |
+| Router | Decided | Entry gate that selects the lightest capable lane |
+| Campaign | Decided | Durable contract stored inside the repository |
+| Fleet | Decided | Parallel work cells with isolated worktrees and a shared discovery relay |
+| Verification | Decided | Checkpoint that requires a source before advancing |
+| Deploy steward | Decided | Serialized mainline gate |
+| Medieval ornament | Rejected | The metaphor changes structure and motion, not the page into fantasy art |
+
+## Story sequence
+
+1. **Choose a scenario.** The visitor selects a typo, review, persistent feature, fleet migration, or deploy lane.
+2. **Route the request.** The tier cascade explains each evaluated gate and why it stopped.
+3. **Inspect the contract.** The selected workflow exposes the repository files it owns.
+4. **Advance work.** Deterministic phase events update tests, evidence, decisions, and next action.
+5. **Close the session.** Chat state disappears while repository state remains visible.
+6. **Open a fresh session.** `/do next` reads the active contract and restores the next action.
+7. **Scale to a fleet.** Three worktrees execute independently and share one discovery.
+8. **Challenge the evidence.** Removing a source changes verified state to `unknown`; restoring it permits verification.
+9. **Replay the landing lane.** Fifteen PRs serialize through CI and deployment using the retained receipt counts.
+10. **Install for the chosen runtime.** Claude Code and Codex tabs provide a specific first-success path.
+
+## Information hierarchy
+
+1. Operating promise
+2. Interactive journey
+3. Inspectable repository state
+4. Fleet and evidence behavior
+5. Public proof receipts
+6. Installation and first success
+7. Deeper documentation
+
+Feature inventory is secondary and must not interrupt the first journey.
+
+## Content model
+
+Every interactive event contains:
+
+```json
+{
+  "id": "route-tier-2",
+  "kind": "route|state|agent|evidence|deploy",
+  "label": "Tier 2 keyword match",
+  "detail": "review matched /review without model classification",
+  "source": "routing-table.json",
+  "status": "pass|active|blocked|unknown|pending",
+  "at": 1200
+}
+```
+
+Every proof receipt contains:
+
+- claim
+- exact result
+- source label
+- inspect URL
+- truth boundary
+
+## Composition
+
+| Layer | Decision |
+|---|---|
+| Global shell | Lightweight navigation with product, proof, install, release, and GitHub anchors |
+| Hero | One command input, scenario presets, and bounded proof strip |
+| Journey stage | Left timeline, central operating surface, right repository inspector on desktop |
+| Mobile | One column with state tabs; no horizontal miniature desktop |
+| Proof gallery | Receipt grid with one expanded artifact at a time |
+| Installation | Runtime tabs followed by setup and first verified command |
+
+## Visual language
+
+- Graphite and stone surfaces from `.planning/design-manifest.md`
+- Command cyan for active routing
+- Evidence green only for sourced pass states
+- Campaign amber for durable phase work
+- Fleet violet for parallel coordination
+- Unknown gray distinct from pending and failure
+- Gate and lane geometry expressed through borders, alignment, and transitions
+- No generic AI portraits, robots, floating brains, or decorative particle overload
+
+## Motion system
+
+The canonical motion sequence is:
+
+`request → evaluate → select → execute → verify → persist`
+
+Rules:
+
+- standard durations are 160ms, 280ms, and 480ms
+- every sequence can pause, replay, or jump to its final state
+- no visitor waits more than 1.2 seconds for the next meaningful state
+- no permanent loop except a restrained active indicator
+- reduced motion applies the same state changes instantly with opacity only
+- scroll never becomes a hidden custom navigation requirement
+
+## Interaction model
+
+- Scenario presets and text entry share the same deterministic state engine.
+- Visitors can step forward, autoplay, pause, reset, or inspect the final state.
+- Evidence challenge is reversible and never fabricates external telemetry.
+- All controls are real buttons with visible focus and plain labels.
+- URL hash preserves the selected exhibit for sharing.
+
+## Responsiveness and accessibility
+
+- Complete layouts at 1440px, 1024px, 768px, and 380px
+- Keyboard path covers scenario selection, playback, inspector tabs, proof expansion, runtime tabs, and copy buttons
+- Status always uses icon or text in addition to color
+- `prefers-reduced-motion` retains all information
+- Minimum 4.5:1 text contrast and 44px touch targets
+
+## Performance budget
+
+- No framework required unless the deterministic state engine becomes less maintainable in plain JavaScript
+- Initial HTML, CSS, and JavaScript under 250KB uncompressed, excluding screenshots
+- No autoplay video on first load
+- No third-party analytics or remote font dependency
+- Interactive state responds within 100ms after input
+
+## Verification matrix
+
+| State | Desktop | Mobile | Keyboard | Reduced motion | Source boundary |
+|---|---:|---:|---:|---:|---:|
+| Router | required | required | required | required | required |
+| Campaign persistence | required | required | required | required | required |
+| Fleet relay | required | required | required | required | required |
+| Evidence unknown | required | required | required | required | required |
+| Deploy replay | required | required | required | required | required |
+| Install tabs | required | required | required | not applicable | required |
+
+## Provisional and unknown decisions
+
+| Variable | Status | Next evidence |
+|---|---|---|
+| Whether to split `docs/index.html` into modules | Provisional | Split if story engine exceeds 350 lines or testing requires DOM imports |
+| Real screenshot use inside proof receipts | Provisional | Prefer cropped artifacts if mobile legibility survives |
+| Sound | Rejected | Adds little explanatory value and creates accessibility cost |
+| Visitor telemetry | Unknown | Remains out of scope until privacy and product-proof contracts define a public-site boundary |
+
+## Build acceptance
+
+The experience is ready only when a first-time visitor can answer these questions without opening the README:
+
+1. What problem does Citadel solve?
+2. Why did this request route where it did?
+3. What survives after the session closes?
+4. How do parallel agents avoid sharing one branch?
+5. What happens when evidence is missing?
+6. What real proof supports the claims?
+7. How do I install it for my runtime and reach one verified success?

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "golden:path": "node scripts/golden-path.js",
     "golden:path:matrix": "node scripts/golden-path-matrix.js",
     "route:preview": "node scripts/route-preview.js",
+    "site:story:test": "node scripts/test-citadel-site-story.js",
     "loops": "node scripts/loops.js",
     "loop:run": "node scripts/loop-runner.js",
     "stack:plan": "node scripts/stack-plan.js",

--- a/scripts/generate-routing.js
+++ b/scripts/generate-routing.js
@@ -117,7 +117,8 @@ function renderDemoData(table) {
     const pattern = `/\\b(${skill.keywords.map(escapeRegExp).join('|')})\\b/i`;
     const icon = DEMO_ICONS[skill.name] || DEMO_DEFAULT_ICON;
     lines.push(`  { re: ${pattern}, skill: '/${skill.name}',`);
-    lines.push(`    desc: ${JSON.stringify(skill.description)}, icon: '${icon}' },`);
+    const publicDescription = skill.description.replace(/\u2014/g, ' - ');
+    lines.push(`    desc: ${JSON.stringify(publicDescription)}, icon: '${icon}' },`);
   }
   lines.push('];');
   return lines;

--- a/scripts/test-all.js
+++ b/scripts/test-all.js
@@ -77,6 +77,7 @@ const ROUTING_SYNC_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-routing-sync.j
 const WATCH_DEDUP_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-watch-dedup.js');
 const TEAMMATE_REBALANCE_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-teammate-rebalance.js');
 const DOC_SURFACES_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-doc-surfaces.js');
+const SITE_STORY_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-citadel-site-story.js');
 const TELEMETRY_OTLP_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-telemetry-otlp.js');
 const STATE_HYGIENE_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-state-hygiene.js');
 const PERMISSION_AUDIT_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-permission-audit.js');
@@ -175,6 +176,7 @@ const routingSyncPassed = run('Routing Sync Check', ROUTING_SYNC_TEST);
 const watchDedupPassed = run('Watch Dedup Tests', WATCH_DEDUP_TEST);
 const teammateRebalancePassed = run('Teammate Rebalance Tests', TEAMMATE_REBALANCE_TEST);
 const docSurfacesPassed = run('Doc Surfaces Check', DOC_SURFACES_TEST);
+const siteStoryPassed = run('Citadel Site Story Contract', SITE_STORY_TEST);
 const telemetryOtlpPassed = run('Telemetry OTLP Export Tests', TELEMETRY_OTLP_TEST);
 const stateHygienePassed = run('State Hygiene Tests', STATE_HYGIENE_TEST);
 const permissionAuditPassed = run('Permission Audit Tests', PERMISSION_AUDIT_TEST);
@@ -253,6 +255,7 @@ console.log(`  Routing sync:       ${routingSyncPassed ? 'PASS' : 'FAIL'}`);
 console.log(`  Watch dedup:        ${watchDedupPassed ? 'PASS' : 'FAIL'}`);
 console.log(`  Teammate rebalance: ${teammateRebalancePassed ? 'PASS' : 'FAIL'}`);
 console.log(`  Doc surfaces:       ${docSurfacesPassed ? 'PASS' : 'FAIL'}`);
+console.log(`  Site product story: ${siteStoryPassed ? 'PASS' : 'FAIL'}`);
 console.log(`  Telemetry OTLP:     ${telemetryOtlpPassed ? 'PASS' : 'FAIL'}`);
 console.log(`  State hygiene:      ${stateHygienePassed ? 'PASS' : 'FAIL'}`);
 console.log(`  Permission audit:   ${permissionAuditPassed ? 'PASS' : 'FAIL'}`);
@@ -273,7 +276,7 @@ console.log(`  Ecosystem compat:    ${ecosystemCompatPassed ? 'PASS' : 'FAIL'}`)
 console.log(`  Product proof report: ${productProofReportPassed ? 'PASS' : 'FAIL'}`);
 console.log('');
 
-if (hooksPassed && securityPassed && contractsPassed && runtimeRegistryPassed && runtimeMatrixPassed && hookEventsPassed && skillsPassed && demoPassed && telemetryPassed && telemetryIntegrityPassed && memoryBlockPassed && evidenceContractPassed && sandboxProviderPassed && skillPackagingPassed && mapSubstratePassed && deliveryPassed && deliveryPackagePassed && continueActionPassed && nextActionPassed && routePreviewPassed && loopsPassed && operatingProofPassed && usefulnessTrialPassed && operatorConsolePassed && operatorJourneyPassed && firstUseOperatorPassed && verificationPlanPassed && prReadyPassed && stackPlanPassed && deployStewardPassed && agentsMdOnlyStewardPassed && coordinationPassed && hookInstallerPassed && campaignPassed && discoveryPassed && discoveryWriterPassed && momentumPassed && momentumWatcherPassed && policyPassed && claudeRuntimePassed && codexRuntimePassed && codexNativeIntegrationPassed && codexOperationalImprovementPassed && installerPassed && projectBootstrapPassed && compatFixturePassed && backwardCompatPassed && costTrackerPassed && dashboardPassed && docSyncPassed && fleetSessionPassed && worktreeReadinessPassed && postEditTypecheckPassed && routingSyncPassed && watchDedupPassed && teammateRebalancePassed && docSurfacesPassed && telemetryOtlpPassed && stateHygienePassed && permissionAuditPassed && secretsLensPassed && dashboardWebPassed && dashboardPerfPassed && dashboardVisualPassed && noopDetectPassed && releaseIntegrityPassed && activationTelemetryPassed && githubTrafficSnapshotPassed && goldenPathPassed && goldenPathMatrixPassed && productBenchmarkPassed && productProofCohortPassed && sarifCoordinatesPassed && ecosystemCompatPassed && productProofReportPassed) {
+if (hooksPassed && securityPassed && contractsPassed && runtimeRegistryPassed && runtimeMatrixPassed && hookEventsPassed && skillsPassed && demoPassed && telemetryPassed && telemetryIntegrityPassed && memoryBlockPassed && evidenceContractPassed && sandboxProviderPassed && skillPackagingPassed && mapSubstratePassed && deliveryPassed && deliveryPackagePassed && continueActionPassed && nextActionPassed && routePreviewPassed && loopsPassed && operatingProofPassed && usefulnessTrialPassed && operatorConsolePassed && operatorJourneyPassed && firstUseOperatorPassed && verificationPlanPassed && prReadyPassed && stackPlanPassed && deployStewardPassed && agentsMdOnlyStewardPassed && coordinationPassed && hookInstallerPassed && campaignPassed && discoveryPassed && discoveryWriterPassed && momentumPassed && momentumWatcherPassed && policyPassed && claudeRuntimePassed && codexRuntimePassed && codexNativeIntegrationPassed && codexOperationalImprovementPassed && installerPassed && projectBootstrapPassed && compatFixturePassed && backwardCompatPassed && costTrackerPassed && dashboardPassed && docSyncPassed && fleetSessionPassed && worktreeReadinessPassed && postEditTypecheckPassed && routingSyncPassed && watchDedupPassed && teammateRebalancePassed && docSurfacesPassed && siteStoryPassed && telemetryOtlpPassed && stateHygienePassed && permissionAuditPassed && secretsLensPassed && dashboardWebPassed && dashboardPerfPassed && dashboardVisualPassed && noopDetectPassed && releaseIntegrityPassed && activationTelemetryPassed && githubTrafficSnapshotPassed && goldenPathPassed && goldenPathMatrixPassed && productBenchmarkPassed && productProofCohortPassed && sarifCoordinatesPassed && ecosystemCompatPassed && productProofReportPassed) {
   console.log('All tests pass.\n');
   console.log('Next steps:');
   console.log('  node scripts/skill-bench.js --list      see benchmark scenarios');
@@ -413,6 +416,7 @@ if (!routingSyncPassed) console.log('Routing sync check failed. Run: node script
 if (!watchDedupPassed) console.log('Watch dedup tests failed. Fix marker hashing, intake dedup, or locking in scripts/watch.js before shipping.');
 if (!teammateRebalancePassed) console.log('Teammate rebalance tests failed. Fix the TeammateIdle rebalance append in teammate-idle.js before shipping.');
 if (!docSurfacesPassed) console.log('Doc surfaces check failed. Run: node scripts/generate-doc-surfaces.js, then commit the regenerated docs.');
+if (!siteStoryPassed) console.log('Citadel site story contract failed. Fix the public operating journey before shipping.');
 if (!telemetryOtlpPassed) console.log('Telemetry OTLP export tests failed. Fix mapping or state handling in telemetry-otlp-export.js before shipping.');
 if (!stateHygienePassed) console.log('State hygiene tests failed. Fix expired-state sweeping in state-hygiene.js before shipping.');
 if (!permissionAuditPassed) console.log('Permission audit tests failed. Fix permission-events logging or report rendering before shipping.');

--- a/scripts/test-citadel-site-story.js
+++ b/scripts/test-citadel-site-story.js
@@ -15,6 +15,12 @@ const checks = [
   ['fleet scenario exists', html.includes('data-story-scenario="fleet"')],
   ['evidence challenge exists', html.includes('data-story-scenario="evidence"') && html.includes('expected source absent')],
   ['deploy replay exists', html.includes('data-story-scenario="deploy"') && html.includes('waitingEvents: 59')],
+  ['proof gallery contains bounded receipts', (html.match(/class="proof-card"/g) || []).length === 6 && (html.match(/Boundary:/g) || []).length >= 6],
+  ['proof gallery links resolve from docs root', html.includes('href="GOLDEN_PATH.md"') && html.includes('href="DASHBOARD_SPEC.md"') && !html.includes('href="docs/GOLDEN_PATH.md"')],
+  ['runtime tabs treat Claude and Codex equally', html.includes('data-runtime="claude"') && html.includes('data-runtime="codex"') && html.includes('--runtime claude') && html.includes('--runtime codex')],
+  ['first verified success is explicit', html.includes('/do review README.md') && html.includes('/do next')],
+  ['keyboard arrow navigation covers tablists', html.includes("['ArrowLeft', 'ArrowRight']")],
+  ['copy controls have visible feedback', html.includes("button.textContent = 'Copied'")],
   ['repository inspector exists', html.includes('aria-label="Repository state inspector"')],
   ['playback controls exist', ['story-prev', 'story-play', 'story-next', 'story-reset'].every(id => html.includes(`id="${id}"`))],
   ['fresh session step exists', html.includes('fresh process restored')],
@@ -24,6 +30,8 @@ const checks = [
   ['mobile story layout exists', html.includes('.story-layout { grid-template-columns: 1fr; }')],
   ['experience contract names all acceptance questions', (contract.match(/^\d+\. /gm) || []).length >= 7],
   ['public story copy contains no em dash', !html.slice(html.indexOf('<section class="story-section"'), html.indexOf('<!-- Vertical tier cascade -->')).includes('—')]
+  ,['public proof and install copy contains no em dash', !html.slice(html.indexOf('<section class="proof-section"'), html.indexOf('<!-- Final CTA')).includes('—')]
+  ,['site remains under declared 250KB source budget', Buffer.byteLength(html, 'utf8') < 250 * 1024]
 ];
 
 for (const [name, pass] of checks) {

--- a/scripts/test-citadel-site-story.js
+++ b/scripts/test-citadel-site-story.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+const html = fs.readFileSync(path.join(root, 'docs', 'index.html'), 'utf8');
+const contract = fs.readFileSync(path.join(root, 'docs', 'interactive-story-contract.md'), 'utf8');
+
+const checks = [
+  ['story section exists', html.includes('id="product-story"')],
+  ['campaign scenario exists', html.includes('data-story-scenario="campaign"')],
+  ['review scenario exists', html.includes('data-story-scenario="review"')],
+  ['fleet scenario exists', html.includes('data-story-scenario="fleet"')],
+  ['evidence challenge exists', html.includes('data-story-scenario="evidence"') && html.includes('expected source absent')],
+  ['deploy replay exists', html.includes('data-story-scenario="deploy"') && html.includes('waitingEvents: 59')],
+  ['repository inspector exists', html.includes('aria-label="Repository state inspector"')],
+  ['playback controls exist', ['story-prev', 'story-play', 'story-next', 'story-reset'].every(id => html.includes(`id="${id}"`))],
+  ['fresh session step exists', html.includes('fresh process restored')],
+  ['unknown evidence state exists', html.includes('production-source  UNKNOWN')],
+  ['fleet worktrees exist', html.includes('wt-fleet-api') && html.includes('wt-fleet-components') && html.includes('wt-fleet-utils')],
+  ['reduced motion participates in playback', html.includes("prefers-reduced-motion: reduce")],
+  ['mobile story layout exists', html.includes('.story-layout { grid-template-columns: 1fr; }')],
+  ['experience contract names all acceptance questions', (contract.match(/^\d+\. /gm) || []).length >= 7],
+  ['public story copy contains no em dash', !html.slice(html.indexOf('<section class="story-section"'), html.indexOf('<!-- Vertical tier cascade -->')).includes('—')]
+];
+
+for (const [name, pass] of checks) {
+  assert.equal(pass, true, name);
+  console.log(`PASS ${name}`);
+}
+
+console.log(`Citadel site story contract passed: ${checks.length}/${checks.length}`);


### PR DESCRIPTION
## What changed

- turns the public site into an inspectable operating journey across routing, persistent repository state, coordinated fleets, evidence integrity, and serialized delivery
- adds deterministic campaign, review, fleet, evidence challenge, and 15-PR deployment scenarios
- adds six bounded proof receipts with inspectable sources and explicit truth boundaries
- gives Claude Code and OpenAI Codex equal installation paths with a concrete first-success journey
- adds keyboard and reduced-motion behavior, mobile layouts, and a 23-check public-site contract in the main regression suite
- records the experience contract and resumable campaign state

## Why

Citadel's previous site named capabilities but did not let visitors see the operating model work. This change makes the core value legible through real state transitions and proof, while refusing unsupported certainty.

## Verification

- `node scripts/test-citadel-site-story.js` passes 23/23
- `node scripts/test-routing-sync.js` passes
- `node scripts/test-all.js --strict` passes every check
- `node scripts/release-package.js --ref HEAD --dry-run --verify-reproducible` reports reproducible SHA-256 `5701e54da9464f227caf16bcf33b9a2ef85ca2acbcf5a426500249f898aaaebc`
- desktop and mobile proof/install captures reviewed
- keyboard, runtime switching, copy feedback, and reduced-motion behavior exercised in a real browser

## Impact

Visitors can now understand why Citadel exists, watch the same request route into different operating modes, inspect durable work state, see how fleets and evidence behave under failure, and move directly into a runtime-specific installation path.