### PR TITLE
Keep animated site proof values truthful

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3105,17 +3105,9 @@
     // ─── Stats count-up on first screen-2 visit ────────────────────────────
     function animateStats() {
       const rows = document.querySelectorAll('.stat-num');
-      const targets = [33, 4, 14, 0]; // 0 = ~0 (special case)
+      const targets = [49, 4, 29, 2];
       rows.forEach((el, i) => {
         const target = targets[i];
-        if (target === 0) {
-          el.style.opacity = '0';
-          setTimeout(() => {
-            el.style.transition = 'opacity 0.6s';
-            el.style.opacity = '1';
-          }, i * 160 + 200);
-          return;
-        }
         el.textContent = '0';
         const delay = i * 160;
         const duration = 900;

--- a/scripts/test-citadel-site-story.js
+++ b/scripts/test-citadel-site-story.js
@@ -32,6 +32,7 @@ const checks = [
   ['public story copy contains no em dash', !html.slice(html.indexOf('<section class="story-section"'), html.indexOf('<!-- Vertical tier cascade -->')).includes('—')]
   ,['public proof and install copy contains no em dash', !html.slice(html.indexOf('<section class="proof-section"'), html.indexOf('<!-- Final CTA')).includes('—')]
   ,['site remains under declared 250KB source budget', Buffer.byteLength(html, 'utf8') < 250 * 1024]
+  ,['animated stats preserve the published values', html.includes('const targets = [49, 4, 29, 2]') && !html.includes('const targets = [33, 4, 14, 0]')]
 ];
 
 for (const [name, pass] of checks) {


### PR DESCRIPTION
## What changed

- updates the visible count-up animation to preserve the published `49 / 4 / 29 / 2` values
- removes the stale special case that restored the old `~0 config` claim
- adds a product-story contract assertion for the animation targets

## Why

Live Pages verification after PR #186 showed that the HTML contained the correct values, but the first visit animation replaced them with stale values. The displayed proof must remain identical to its source.

## Verification

- `node scripts/test-citadel-site-story.js` passes 24/24
- `node scripts/test-routing-sync.js` passes
- headless Chrome completed the actual animation and returned `["49","4","29","2"]`