### PR TITLE
Add honest Citadel choice guide

### DIFF
--- a/.planning/campaigns/completed/improve-citadel-2026-07-13.md
+++ b/.planning/campaigns/completed/improve-citadel-2026-07-13.md
@@ -1,0 +1,35 @@
+---
+version: 1
+id: improve-citadel-2026-07-13
+status: completed
+type: improve
+target: citadel
+total_loops: 1
+completed_loops: 1
+current_level: 1
+estimated_cost_per_loop: 12
+started: 2026-07-13
+completed: 2026-07-13
+rubric_approved: existing approved rubric
+---
+
+# Improve Citadel
+
+## Status
+
+One bounded improvement loop completed.
+
+## Loop History
+
+| Loop | Axis Attacked | Outcome | Score Movement |
+|---:|---|---|---:|
+| 1 | `competitive_feature_coverage` | improved | 3.0 to 8.0 |
+
+## Continuation State
+
+- `next_loop`: none
+- `last_scorecard_log`: `.planning/improvement-logs/citadel/loop-1.md`
+- `last_outcome`: improved
+- `phase_within_loop`: not-started
+- `level_up_triggered`: false
+

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Citadel is the open-source operating layer for Claude Code and OpenAI Codex. It 
 
 If `CLAUDE.md` and `AGENTS.md` tell the runtime **what** your project is, Citadel tells the runtime **how** to operate on it.
 
-[Install](#quick-install) · [See the operating loop](#see-the-operating-loop) · [Inspect the proof](#proof-not-promises) · [How it works](#how-it-works) · [Help test 1.1](https://github.com/SethGammon/Citadel/discussions/182)
+[Install](#quick-install) · [See the operating loop](#see-the-operating-loop) · [Inspect the proof](#proof-not-promises) · [Choose the right tool](docs/CHOOSING_CITADEL.md) · [Help test 1.1](https://github.com/SethGammon/Citadel/discussions/182)
 
 </div>
 
@@ -145,7 +145,7 @@ Four tiers let Citadel scale from a one-line edit to a multi-session campaign. Y
 
 <table>
 <tr>
-<td width="50%"><img src="assets/card-skill.svg" width="100%" alt="Skill: domain expert. Loads focused expertise on demand, zero tokens when not invoked, 46 built-in" /></td>
+<td width="50%"><img src="assets/card-skill.svg" width="100%" alt="Skill: domain expert. Loads focused expertise on demand, zero tokens when not invoked, 49 built-in" /></td>
 <td width="50%"><img src="assets/card-marshal.svg" width="100%" alt="Marshal: single-session commander. Chains skills autonomously and enforces quality gates between steps" /></td>
 </tr>
 <tr>
@@ -227,6 +227,7 @@ The full plan with exit criteria lives in [docs/ROADMAP.md](docs/ROADMAP.md). Th
 - [Citadel 1.1 product-proof scorecard](docs/PRODUCT_PROOF_REPORT.md) - what is locally proven, CI-proven, human-proven, and still blocked
 - [Skill and memory visibility](docs/SKILL_MEMORY_VISIBILITY.md) - inspect available skills and compiled project memory
 - [Public positioning](docs/PUBLIC_POSITIONING.md) - how to describe Citadel without overclaiming
+- [Choosing Citadel](docs/CHOOSING_CITADEL.md) - an honest comparison with Superpowers, CrewAI, LangChain, LangGraph, and Deep Agents
 - [Security model](SECURITY.md) - path traversal, shell injection, and defensive measures
 - [Contributing](CONTRIBUTING.md) - issues, PRs, skills, and docs
 
@@ -247,6 +248,15 @@ If you use Claude Code or Codex on a real repository and keep hitting context lo
 <br>
 
 Those files describe your project. Citadel adds the operating layer around the agent: routing, memory, hooks, telemetry, and parallel coordination.
+
+</details>
+
+<details>
+<summary><strong>How is Citadel different from Superpowers, CrewAI, or LangGraph?</strong></summary>
+
+<br>
+
+Citadel operates Claude Code and Codex inside an existing repository. Superpowers supplies a disciplined development methodology and can run alongside Citadel. CrewAI, LangChain, and LangGraph are for building your own agent applications or runtimes. See [Choosing Citadel](docs/CHOOSING_CITADEL.md) for the honest boundaries and cases where another tool is the better fit.
 
 </details>
 

--- a/assets/card-skill.svg
+++ b/assets/card-skill.svg
@@ -77,5 +77,5 @@
   <text x="149" y="164" class="cs-sans" font-size="13" fill="#c9d1d9">Zero tokens when not invoked</text>
 
   <circle cx="136" cy="186" r="3.5" fill="#00d2ff" opacity="0.85"/>
-  <text x="149" y="190" class="cs-sans" font-size="13" fill="#c9d1d9">46 built-in · write your own</text>
+  <text x="149" y="190" class="cs-sans" font-size="13" fill="#c9d1d9">49 built-in · write your own</text>
 </svg>

--- a/docs/CHOOSING_CITADEL.md
+++ b/docs/CHOOSING_CITADEL.md
@@ -1,0 +1,54 @@
+# Choosing Citadel
+
+Citadel is an operating layer for Claude Code and OpenAI Codex inside an existing software repository. It is not a framework for building a new agent application.
+
+That distinction decides most comparisons.
+
+## Choose by the job
+
+| If you need to... | Start with... | Why |
+|---|---|---|
+| Make Claude Code or Codex remember, route, verify, and resume work in a repository | **Citadel** | It adds repo-local campaigns, `/do` routing, lifecycle hooks, evidence, cost telemetry, and isolated worktrees without replacing the coding agent. |
+| Enforce a disciplined brainstorm, plan, TDD, review, and delivery method | **Superpowers** | It is a software-development methodology expressed as composable agent skills. It can be used alongside Citadel. |
+| Build a custom Python multi-agent application or business automation | **CrewAI** | It provides agents, crews, flows, tools, memory, knowledge, processes, connectors, and deployment surfaces for applications you are creating. |
+| Build a custom agent loop with model and tool integrations | **LangChain** | It provides application-level abstractions for models, tools, middleware, and agent loops. |
+| Build a durable, stateful agent runtime with explicit graph control | **LangGraph** | It provides low-level orchestration, persistence, streaming, human oversight, and production runtime infrastructure. |
+| Build a custom harness on top of LangGraph | **Deep Agents** | It adds planning, filesystems, context management, and subagents as an SDK for agents you are building. |
+
+## Where Citadel is different
+
+Citadel starts after you have chosen Claude Code or Codex.
+
+You keep the runtime and your repository. Citadel adds the operating contract around them:
+
+- one natural-language entry point through `/do`
+- project state that survives a context reset or fresh session
+- hooks that protect files, verify work, and record evidence
+- campaigns and handoffs written into the repository
+- coordinated agents working in isolated git worktrees
+- local telemetry for cost, routing, and activation
+
+The repository remains the source of truth. There is no hosted control plane required for the core workflow.
+
+## Where other tools are better
+
+Choose CrewAI, LangChain, or LangGraph when you need to ship an agent as part of your own product, define its runtime in application code, connect it to business systems, or operate it as a production service.
+
+Choose Superpowers when your main problem is development discipline and you want an opinionated workflow centered on design, planning, TDD, review, and finishing branches. Citadel and Superpowers are complementary: one supplies operating infrastructure, the other supplies methodology.
+
+Citadel also does not replace code review, sandbox an untrusted host, or prove that an agent's output is correct. It makes the work more persistent, inspectable, and enforceable.
+
+## A practical rule
+
+If you are **building an agent**, begin with a framework or runtime.
+
+If you are **operating a coding agent on a repository**, try Citadel.
+
+## Official sources
+
+- [CrewAI documentation](https://docs.crewai.com/index)
+- [LangChain frameworks, runtimes, and harnesses](https://docs.langchain.com/oss/python/concepts/products)
+- [LangGraph overview](https://docs.langchain.com/oss/python/langgraph/overview)
+- [Superpowers README](https://github.com/obra/superpowers)
+- [Citadel security boundaries](../SECURITY.md)
+


### PR DESCRIPTION
## What changed

- add a source-backed guide for choosing between Citadel, Superpowers, CrewAI, LangChain, LangGraph, and Deep Agents
- link the guide from the README entry row, Learn More section, and FAQ
- correct the stale public skill count from 46 to 49 in the orchestration card
- record the completed Citadel improvement loop

## Why

GitHub traffic shows the repository Overview is the primary evaluation surface. The improvement rubric scored competitive choice coverage at 3/10 because visitors could understand Citadel but could not tell when an adjacent tool was the better fit.

The new guide compares categories and jobs instead of manufacturing checkbox parity. It explicitly names where other tools are better.

## Impact

New visitors can now decide whether they need a coding-agent operating layer, a development methodology, an agent framework, or a durable runtime. The newcomer evaluator score moved from 3/10 to 8/10 and the choice test passed.

## Verification

- `node scripts/test-all.js` completed with every product assertion passing; the Codex runtime fixture was rerun outside the sandbox after its only `EPERM` setup failure
- `node scripts/test-codex-runtime.js` passed
- doc synchronization passed
- demo routing passed 45/45
- site story contract passed 24/24
- skill lint passed 627/627
- targeted public-copy check passed with no em dash and no stale 46-skill count