### PR TITLE
Fix the short-screen journey cue overlap

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1396,6 +1396,7 @@
       .search-wrap { padding-top: 16px; }
       .generators { margin-top: 16px; margin-bottom: 14px; }
       .gen-btn { padding-top: 12px; padding-bottom: 12px; }
+      .scroll-cue { bottom: 2px; }
     }
   </style>
 </head>


### PR DESCRIPTION
Live visual QA at 1280 by 720 showed the new `See the work survive a session` cue touching the routing cards. This moves the cue to the available bottom gutter only on desktop viewports 820px tall or shorter.

Verification:

- live screenshot identified the exact overlap
- `node scripts/test-citadel-site-story.js` passes 28/28
- `git diff --check` passes
- one CSS declaration, scoped to the existing short-screen media query