### PR TITLE
Clear the short-screen journey cue

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1397,6 +1397,7 @@
       .generators { margin-top: 16px; margin-bottom: 14px; }
       .gen-btn { padding-top: 12px; padding-bottom: 12px; }
       .scroll-cue { bottom: 2px; }
+      .scroll-cue svg:last-child { display: none; }
     }
   </style>
 </head>

--- a/scripts/test-citadel-site-story.js
+++ b/scripts/test-citadel-site-story.js
@@ -12,6 +12,7 @@ const checks = [
   ['story section exists', html.includes('id="product-story"')],
   ['hero shows the first-success path', html.includes('Citadel first-success path') && html.includes('/do next')],
   ['screen transition names its value', html.includes('See the work survive a session')],
+  ['short screens remove the duplicate cue chevron', html.includes('.scroll-cue svg:last-child { display: none; }')],
   ['campaign scenario exists', html.includes('data-story-scenario="campaign"')],
   ['review scenario exists', html.includes('data-story-scenario="review"')],
   ['fleet scenario exists', html.includes('data-story-scenario="fleet"')],


### PR DESCRIPTION
The first live QA fix reduced the overlap to 8px at 1280 by 720. This removes only the duplicate decorative chevron on short desktop viewports, leaving the labeled transition and primary chevron intact.

Verification:

- exact live geometry measured after PR #192
- public story contract passes 29/29
- `git diff --check` passes
- two-line change, one CSS rule and one regression assertion