### PR TITLE
Refine the mobile routing rail

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -317,8 +317,14 @@
     }
     .gen-btn:hover .gen-again { opacity: 0.65; }
     @media (max-width: 760px) {
-      .generators { flex-wrap: wrap; }
-      .gen-btn { flex: calc(50% - 6px); min-width: 0; }
+      .generators {
+        flex-wrap: nowrap; overflow-x: auto; max-height: 138px;
+        margin-top: 16px; margin-bottom: 20px; padding-bottom: 4px;
+        scroll-snap-type: x proximity;
+      }
+      .gen-btn { flex: 0 0 150px; min-width: 150px; padding: 12px 14px; scroll-snap-align: start; }
+      .gen-icon { margin-bottom: 6px; }
+      .gen-again { display: none; }
     }
 
     /* ─── Result panel  -  folds out downward from search bar ─── */
@@ -1385,6 +1391,8 @@
       .hero-outcome { grid-template-columns: 1fr; gap: 4px; padding: 8px 5px; text-align: center; font-size: 10px; }
       .hero-outcome + .hero-outcome { border-left: 1px solid var(--border); border-top: 0; }
       .scroll-cue-label { font-size: 10px; }
+      .scroll-cue { bottom: 2px; }
+      .scroll-cue svg:last-child { display: none; }
     }
 
     @media (max-height: 820px) and (min-width: 761px) {

--- a/scripts/test-citadel-site-story.js
+++ b/scripts/test-citadel-site-story.js
@@ -31,6 +31,7 @@ const checks = [
   ['fleet worktrees exist', html.includes('wt-fleet-api') && html.includes('wt-fleet-components') && html.includes('wt-fleet-utils')],
   ['reduced motion participates in playback', html.includes("prefers-reduced-motion: reduce")],
   ['mobile story layout exists', html.includes('.story-layout { grid-template-columns: 1fr; }')],
+  ['mobile router choices use a horizontal rail', html.includes('scroll-snap-type: x proximity') && html.includes('.gen-btn { flex: 0 0 150px;')],
   ['experience contract names all acceptance questions', (contract.match(/^\d+\. /gm) || []).length >= 7],
   ['public story copy contains no em dash', !html.slice(html.indexOf('<section class="story-section"'), html.indexOf('<!-- Vertical tier cascade -->')).includes('—')]
   ,['fallback documentation links are real', html.includes('href="CAMPAIGNS.md"') && html.includes('href="CLAUDE_INSTALLATION_GUIDE.md"')]


### PR DESCRIPTION
Live responsive QA at 390 by 844 showed the four router cards wrapping into two rows and colliding with the journey transition cue.

This change:

- keeps all four routing choices
- presents them as a compact horizontal, snap-aligned rail on mobile
- removes the duplicate cue chevron on mobile
- preserves the labeled transition and primary chevron

Verification:

- public story contract passes 30/30
- `git diff --check` passes
- change is limited to mobile CSS and one regression assertion