### PR TITLE
Clear the mobile journey cue

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1391,7 +1391,7 @@
       .hero-outcome { grid-template-columns: 1fr; gap: 4px; padding: 8px 5px; text-align: center; font-size: 10px; }
       .hero-outcome + .hero-outcome { border-left: 1px solid var(--border); border-top: 0; }
       .scroll-cue-label { font-size: 10px; }
-      .scroll-cue { bottom: 2px; }
+      .scroll-cue { bottom: 2px; padding-top: 4px; padding-bottom: 4px; }
       .scroll-cue svg:last-child { display: none; }
     }
 


### PR DESCRIPTION
The published 390 by 844 geometry had a remaining 4px touch between the mobile routing rail and the labeled journey cue. This reduces only the cue's mobile vertical padding from 8px to 4px, creating positive clearance without shrinking cards, text, or controls.

Verification:

- live geometry measured after PR #194
- public story contract passes 30/30
- `git diff --check` passes
- one scoped CSS declaration changed