### PR TITLE
Measure verified activation from real installs

### DIFF
--- a/core/telemetry/activation.js
+++ b/core/telemetry/activation.js
@@ -187,6 +187,22 @@ function readEvents(root = process.cwd()) {
 
 function increment(map, key) { map[key] = (map[key] || 0) + 1; }
 
+function rate(numerator, denominator) {
+  return denominator === 0 ? null : Number((numerator / denominator).toFixed(4));
+}
+
+function successfulInstallationsByStage(events) {
+  const byStage = Object.fromEntries(STAGES.map((stage) => [stage, new Set()]));
+  for (const event of events) {
+    if (event.status === 'succeeded') byStage[event.stage].add(event.installation_id);
+  }
+  return Object.fromEntries(STAGES.map((stage) => [stage, byStage[stage].size]));
+}
+
+function metric(numerator, denominator) {
+  return { numerator, denominator, rate: rate(numerator, denominator) };
+}
+
 function report(root = process.cwd()) {
   const read = readEvents(root);
   const stages = {}, statuses = {}, failures = {}, sources = {};
@@ -197,11 +213,35 @@ function report(root = process.cwd()) {
     increment(sources, event.acquisition_source);
     if (event.failure_code) increment(failures, event.failure_code);
   }
+  const successful = successfulInstallationsByStage(read.events);
+  const completedInstalls = successful.install_completed;
+  const stageRate = (stage) => ({
+    successful_installations: successful[stage],
+    rate_from_install: rate(successful[stage], completedInstalls),
+  });
   return {
     schema: 1, redacted: true, transmitted: false, total_events: read.events.length,
     unique_installations: installations.size, invalid_events: read.invalid_count,
     migrated_events: read.migrated_count, by_stage: stages, by_status: statuses,
     by_failure_code: failures, by_acquisition_source: sources,
+    activation_funnel: {
+      successful_installs: completedInstalls,
+      setup_completed: stageRate('setup_completed'),
+      route_completed: stageRate('route_completed'),
+      verified_handoff: stageRate('verified_handoff'),
+      resume_completed: stageRate('resume_completed'),
+      return_session: stageRate('return_session'),
+    },
+    decision_metrics: {
+      verified_activation_rate: metric(successful.verified_handoff, completedInstalls),
+      durable_resume_rate: metric(successful.resume_completed, completedInstalls),
+      return_use_rate: metric(successful.return_session, completedInstalls),
+    },
+    guardrails: {
+      failed_events: statuses.failed || 0,
+      failure_event_rate: rate(statuses.failed || 0, read.events.length),
+      invalid_events: read.invalid_count,
+    },
   };
 }
 
@@ -217,5 +257,6 @@ function setOptOut(root = process.cwd(), disabled = true) {
 module.exports = {
   SCHEMA, STAGES, STATUSES, FAILURE_CODES, ACQUISITION_SOURCES, RUNTIMES,
   OS_FAMILIES, EVENT_FIELDS, LEGACY_FIELDS, pathsFor, osFamily, validateEvent,
-  createEvent, record, migrateLegacy, readEvents, report, isEnabled, setOptOut,
+  createEvent, record, migrateLegacy, readEvents, rate,
+  successfulInstallationsByStage, report, isEnabled, setOptOut,
 };

--- a/docs/ACTIVATION_METRICS.md
+++ b/docs/ACTIVATION_METRICS.md
@@ -38,7 +38,11 @@ The schema is versioned and accepts only declared fields. Its stages are:
 7. `return_session`
 
 This preserves the important distinction between an installed harness and one that is actually
-configured and useful. Record a stage explicitly:
+configured and useful. The unified installer records `install_started` and `install_completed`
+automatically for real installations. Dry runs and plugin-only operations do not count as installs.
+The same local opt-out contract applies, and telemetry failure can never fail an installation.
+
+Downstream workflow integrations can record a stage explicitly:
 
 ```sh
 node scripts/activation-telemetry.js record --stage install_completed --status succeeded --runtime codex
@@ -59,6 +63,22 @@ node scripts/activation-telemetry.js report --output .planning/product-proof/act
 ```
 
 No report is uploaded automatically.
+
+### Decision metrics
+
+The redacted report calculates three primary rates against successful installations:
+
+- `verified_activation_rate`: installations that reached a successful verified handoff
+- `durable_resume_rate`: installations that successfully resumed durable work
+- `return_use_rate`: installations that recorded a later return session
+
+Setup and route completion are diagnostic funnel steps. Failed event rate and invalid event count
+are guardrails. Each installation counts at most once per successful stage, so retries cannot
+inflate conversion. A rate is `null` until at least one successful install supplies a denominator.
+
+Only the install boundary is automatic in this release. Setup, route, handoff, resume, and return
+must be recorded by the workflow that can prove each milestone. Missing integration remains missing
+evidence, not a manufactured conversion.
 
 ## GitHub acquisition history
 

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -2,15 +2,35 @@
 
 'use strict';
 
+const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
+const activation = require('../core/telemetry/activation');
 
-function arg(name, fallback = null) {
+const CITADEL_VERSION = require('../package.json').version;
+const HELP = `Usage: node scripts/install.js --runtime <claude|codex> [runtime options]
+
+Unified Citadel installer dispatcher.
+
+Examples:
+  node scripts/install.js --runtime claude --install --scope local
+  node scripts/install.js --runtime codex --add-marketplace
+
+Run the runtime-specific helper for all options:
+  node scripts/claude-install.js --help
+  node scripts/codex-install.js --help
+`;
+
+function arg(argv, name, fallback = null) {
   const prefix = `${name}=`;
-  const inline = process.argv.find((value) => value.startsWith(prefix));
+  const inline = argv.find((value) => value.startsWith(prefix));
   if (inline) return inline.slice(prefix.length);
-  const idx = process.argv.indexOf(name);
-  return idx >= 0 ? process.argv[idx + 1] : fallback;
+  const idx = argv.indexOf(name);
+  return idx >= 0 ? argv[idx + 1] : fallback;
+}
+
+function has(argv, flag) {
+  return argv.includes(flag);
 }
 
 function withoutRuntimeArgs(argv) {
@@ -27,44 +47,98 @@ function withoutRuntimeArgs(argv) {
   return result;
 }
 
-if (process.argv.includes('--help') || process.argv.includes('-h')) {
-  console.log(`Usage: node scripts/install.js --runtime <claude|codex> [runtime options]
-
-Unified Citadel installer dispatcher.
-
-Examples:
-  node scripts/install.js --runtime claude --install --scope local
-  node scripts/install.js --runtime codex --add-marketplace
-
-Run the runtime-specific helper for all options:
-  node scripts/claude-install.js --help
-  node scripts/codex-install.js --help
-`);
-  process.exit(0);
+function normalizeRuntime(runtime) {
+  if (runtime === 'claude' || runtime === 'claude-code') return 'claude-code';
+  if (runtime === 'codex') return 'codex';
+  return 'unknown';
 }
 
-const runtime = String(arg('--runtime', '')).toLowerCase();
-const scriptByRuntime = {
-  claude: 'claude-install.js',
-  'claude-code': 'claude-install.js',
-  codex: 'codex-install.js',
+function targetRoot(argv, cwd = process.cwd()) {
+  return path.resolve(arg(argv, '--project-root', arg(argv, '--target-project', cwd)));
+}
+
+function shouldRecordActivation(argv) {
+  return !has(argv, '--dry-run') && !has(argv, '--plugin-only');
+}
+
+function acquisitionSource(env = process.env) {
+  const value = env.CITADEL_ACQUISITION_SOURCE || 'unknown';
+  return activation.ACQUISITION_SOURCES.includes(value) ? value : 'unknown';
+}
+
+function recordSafely(input, options) {
+  try {
+    if (!fs.existsSync(options.root) || !fs.statSync(options.root).isDirectory()) {
+      return { recorded: false, reason: 'target_missing' };
+    }
+    return activation.record(input, options);
+  } catch {
+    return { recorded: false, reason: 'record_failed' };
+  }
+}
+
+function execute(argv, options = {}) {
+  const cwd = options.cwd || process.cwd();
+  const env = options.env || process.env;
+  const clock = options.clock || (() => new Date());
+  const spawn = options.spawnSync || spawnSync;
+
+  if (has(argv, '--help') || has(argv, '-h')) return { status: 0, help: true };
+
+  const runtimeArg = String(arg(argv, '--runtime', '')).toLowerCase();
+  const scriptByRuntime = {
+    claude: 'claude-install.js',
+    'claude-code': 'claude-install.js',
+    codex: 'codex-install.js',
+  };
+  const scriptName = scriptByRuntime[runtimeArg];
+  if (!scriptName) return { status: 1, error: 'Missing or invalid --runtime. Expected claude or codex.' };
+
+  const root = targetRoot(argv, cwd);
+  const runtime = normalizeRuntime(runtimeArg);
+  const records = [];
+  const recordEnabled = shouldRecordActivation(argv);
+  const startedAt = clock();
+  if (recordEnabled) {
+    records.push(recordSafely({
+      stage: 'install_started', status: 'started', runtime,
+      acquisition_source: acquisitionSource(env),
+    }, { root, env, now: startedAt, version: CITADEL_VERSION }));
+  }
+
+  const scriptPath = path.join(__dirname, scriptName);
+  const result = spawn(process.execPath, [scriptPath, ...withoutRuntimeArgs(argv)], {
+    cwd,
+    stdio: 'inherit',
+    shell: false,
+  });
+  const endedAt = clock();
+  const status = result.error ? 1 : (result.status ?? 1);
+
+  if (recordEnabled) {
+    records.push(recordSafely({
+      stage: 'install_completed',
+      status: status === 0 ? 'succeeded' : 'failed',
+      runtime,
+      duration_ms: Math.max(0, endedAt - startedAt),
+      failure_code: status === 0 ? null : (result.error ? 'dependency_missing' : 'unknown_error'),
+      acquisition_source: acquisitionSource(env),
+    }, { root, env, now: endedAt, version: CITADEL_VERSION }));
+  }
+
+  return { status, error: result.error ? result.error.message : null, records };
+}
+
+function main() {
+  const outcome = execute(process.argv.slice(2));
+  if (outcome.help) process.stdout.write(HELP);
+  if (outcome.error) process.stderr.write(`${outcome.error}\n`);
+  process.exitCode = outcome.status;
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  HELP, arg, withoutRuntimeArgs, normalizeRuntime, targetRoot,
+  shouldRecordActivation, acquisitionSource, recordSafely, execute,
 };
-
-const scriptName = scriptByRuntime[runtime];
-if (!scriptName) {
-  console.error('Missing or invalid --runtime. Expected claude or codex.');
-  process.exit(1);
-}
-
-const scriptPath = path.join(__dirname, scriptName);
-const result = spawnSync(process.execPath, [scriptPath, ...withoutRuntimeArgs(process.argv.slice(2))], {
-  cwd: process.cwd(),
-  stdio: 'inherit',
-  shell: false,
-});
-
-if (result.error) {
-  console.error(result.error.message);
-  process.exit(1);
-}
-process.exit(result.status ?? 1);

--- a/scripts/test-activation-telemetry.js
+++ b/scripts/test-activation-telemetry.js
@@ -142,10 +142,42 @@ test('fixture journey records install through return and reports redacted aggreg
   assert.equal(result.by_stage.return_session, 1);
   assert.equal(result.by_status.started, 1);
   assert.equal(result.by_status.succeeded, 6);
+  assert.equal(result.activation_funnel.successful_installs, 1);
+  assert.equal(result.activation_funnel.setup_completed.rate_from_install, 1);
+  assert.deepEqual(result.decision_metrics.verified_activation_rate, { numerator: 1, denominator: 1, rate: 1 });
+  assert.deepEqual(result.decision_metrics.durable_resume_rate, { numerator: 1, denominator: 1, rate: 1 });
+  assert.deepEqual(result.decision_metrics.return_use_rate, { numerator: 1, denominator: 1, rate: 1 });
+  assert.deepEqual(result.guardrails, { failed_events: 0, failure_event_rate: 0, invalid_events: 0 });
   assert.equal(result.redacted, true);
   assert.equal(result.transmitted, false);
   assert.equal(JSON.stringify(result).includes(localId), false);
   assert.equal(JSON.stringify(result).includes('timestamp'), false);
+});
+
+test('funnel counts installations once and excludes failed milestones', () => {
+  const root = tempRoot();
+  const record = (stage, status = 'succeeded') => activation.record({
+    stage, status, runtime: 'codex',
+    failure_code: status === 'failed' ? 'verification_failed' : null,
+  }, { root });
+  record('install_completed');
+  record('install_completed');
+  record('route_completed');
+  record('verified_handoff', 'failed');
+  const result = activation.report(root);
+  assert.equal(result.activation_funnel.successful_installs, 1);
+  assert.equal(result.activation_funnel.route_completed.rate_from_install, 1);
+  assert.equal(result.decision_metrics.verified_activation_rate.rate, 0);
+  assert.equal(result.guardrails.failed_events, 1);
+  assert.equal(result.guardrails.failure_event_rate, 0.25);
+});
+
+test('rates are null when no successful installation denominator exists', () => {
+  const result = activation.report(tempRoot());
+  assert.equal(result.decision_metrics.verified_activation_rate.rate, null);
+  assert.equal(result.decision_metrics.durable_resume_rate.rate, null);
+  assert.equal(result.decision_metrics.return_use_rate.rate, null);
+  assert.equal(result.guardrails.failure_event_rate, null);
 });
 
 test('reader migrates legacy lines and counts invalid lines without exposing them', () => {

--- a/scripts/test-installers.js
+++ b/scripts/test-installers.js
@@ -7,6 +7,8 @@ const { execFileSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const activation = require('../core/telemetry/activation');
+const installer = require('./install');
 
 const CITADEL_ROOT = path.resolve(__dirname, '..');
 
@@ -92,8 +94,91 @@ function testClaudeMarketplaceManifest() {
   assert(!marketplace.plugins[0].description.includes('â'), 'Claude marketplace description should not contain mojibake');
 }
 
+function testUnifiedDispatcherRecordsSuccessfulInstall() {
+  const tmp = tempProject('citadel-unified-activation-');
+  try {
+    const times = [new Date('2026-07-13T12:00:00.000Z'), new Date('2026-07-13T12:00:00.250Z')];
+    const result = installer.execute(['--runtime', 'codex', '--project-root', tmp], {
+      cwd: CITADEL_ROOT,
+      env: { CITADEL_ACQUISITION_SOURCE: 'github_trending' },
+      clock: () => times.shift(),
+      spawnSync: () => ({ status: 0 }),
+    });
+    assert.equal(result.status, 0);
+    const events = activation.readEvents(tmp).events;
+    assert.equal(events.length, 2);
+    assert.deepEqual(events.map(({ stage, status }) => ({ stage, status })), [
+      { stage: 'install_started', status: 'started' },
+      { stage: 'install_completed', status: 'succeeded' },
+    ]);
+    assert.equal(events[1].duration_ms, 250);
+    assert.equal(events[1].runtime, 'codex');
+    assert.equal(events[1].acquisition_source, 'github_trending');
+    assert.equal(events[1].citadel_version, require('../package.json').version);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+function testUnifiedDispatcherRecordsFailureWithoutChangingExit() {
+  const tmp = tempProject('citadel-unified-failure-');
+  try {
+    const failed = installer.execute(['--runtime=claude', '--project-root', tmp], {
+      cwd: CITADEL_ROOT,
+      clock: () => new Date('2026-07-13T12:00:00.000Z'),
+      spawnSync: () => ({ status: 7 }),
+    });
+    assert.equal(failed.status, 7);
+    let event = activation.readEvents(tmp).events.at(-1);
+    assert.equal(event.status, 'failed');
+    assert.equal(event.failure_code, 'unknown_error');
+    assert.equal(event.runtime, 'claude-code');
+
+    fs.rmSync(activation.pathsFor(tmp).dir, { recursive: true, force: true });
+    const missing = installer.execute(['--runtime=codex', '--project-root', tmp], {
+      cwd: CITADEL_ROOT,
+      clock: () => new Date('2026-07-13T12:00:00.000Z'),
+      spawnSync: () => ({ error: new Error('missing') }),
+    });
+    assert.equal(missing.status, 1);
+    event = activation.readEvents(tmp).events.at(-1);
+    assert.equal(event.failure_code, 'dependency_missing');
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+function testUnifiedDispatcherRespectsNonInstallModesAndOptOut() {
+  for (const flag of ['--dry-run', '--plugin-only']) {
+    const tmp = tempProject('citadel-unified-no-activation-');
+    try {
+      installer.execute(['--runtime=codex', '--project-root', tmp, flag], {
+        cwd: CITADEL_ROOT, spawnSync: () => ({ status: 0 }),
+      });
+      assert.equal(fs.existsSync(activation.pathsFor(tmp).events), false);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  }
+
+  const tmp = tempProject('citadel-unified-opt-out-');
+  try {
+    activation.setOptOut(tmp, true);
+    const result = installer.execute(['--runtime=codex', '--project-root', tmp], {
+      cwd: CITADEL_ROOT, spawnSync: () => ({ status: 0 }),
+    });
+    assert(result.records.every((record) => record.reason === 'opted_out'));
+    assert.equal(fs.existsSync(activation.pathsFor(tmp).events), false);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
 testClaudeDryRun();
 testUnifiedDispatcherDryRun();
 testClaudeMarketplaceManifest();
+testUnifiedDispatcherRecordsSuccessfulInstall();
+testUnifiedDispatcherRecordsFailureWithoutChangingExit();
+testUnifiedDispatcherRespectsNonInstallModesAndOptOut();
 
 console.log('installer tests passed');


### PR DESCRIPTION
## What changed

- record `install_started` and `install_completed` around real unified installer runs
- preserve installer behavior and exit codes even when local telemetry cannot be written
- calculate verified activation, durable resume, and return-use rates from successful installs
- deduplicate successful stages by installation so retries cannot inflate conversion
- document what is automatic today and what still requires workflow integration

## Privacy and truthfulness

Events stay local and off the network. Dry runs and plugin-only operations do not count. Opt-out remains supported. Missing denominators produce `null`, and downstream milestones are not claimed until their proving workflows record them.

## Verification

- `node scripts/test-activation-telemetry.js`: 19 passed
- `node scripts/test-installers.js`: passed
- `git diff --check`: passed
- `node scripts/test-all.js`: reached and passed the relevant installer, activation, docs, site, telemetry, and release checks, then the Windows host reproduced an existing `EPERM` while a legacy Codex fixture test attempted to create `hooks_src/test-fixture-plain-stop.js`
