### PR TITLE
Capture activation across core workflows

### DIFF
--- a/core/telemetry/activation.js
+++ b/core/telemetry/activation.js
@@ -153,6 +153,29 @@ function record(input, options = {}) {
   return { recorded: true, file, event };
 }
 
+function recordOnce(input, options = {}) {
+  const root = options.root || process.cwd();
+  if (!isEnabled(root, options.env || process.env)) return { recorded: false, reason: 'opted_out' };
+  const now = options.now || new Date();
+  const identity = options.identity || readOrCreateIdentity(root, now);
+  const duplicate = readEvents(root).events.some((event) => (
+    event.installation_id === identity.installation_id
+    && event.stage === input.stage
+    && event.status === input.status
+  ));
+  if (duplicate) return { recorded: false, reason: 'already_recorded' };
+
+  const event = createEvent(input, { ...options, root, now, identity });
+  const minimumDay = options.minimum_day_since_install || 0;
+  if (event.day_since_install < minimumDay) {
+    return { recorded: false, reason: 'too_early', day_since_install: event.day_since_install };
+  }
+  const file = pathsFor(root).events;
+  fs.mkdirSync(pathsFor(root).dir, { recursive: true });
+  fs.appendFileSync(file, JSON.stringify(event) + '\n');
+  return { recorded: true, file, event };
+}
+
 function migrateLegacy(event) {
   assertObject(event, 'legacy event');
   assertFields(event, LEGACY_FIELDS, 'legacy event');
@@ -257,6 +280,6 @@ function setOptOut(root = process.cwd(), disabled = true) {
 module.exports = {
   SCHEMA, STAGES, STATUSES, FAILURE_CODES, ACQUISITION_SOURCES, RUNTIMES,
   OS_FAMILIES, EVENT_FIELDS, LEGACY_FIELDS, pathsFor, osFamily, validateEvent,
-  createEvent, record, migrateLegacy, readEvents, rate,
+  createEvent, record, recordOnce, migrateLegacy, readEvents, rate,
   successfulInstallationsByStage, report, isEnabled, setOptOut,
 };

--- a/docs/ACTIVATION_METRICS.md
+++ b/docs/ACTIVATION_METRICS.md
@@ -76,9 +76,11 @@ Setup and route completion are diagnostic funnel steps. Failed event rate and in
 are guardrails. Each installation counts at most once per successful stage, so retries cannot
 inflate conversion. A rate is `null` until at least one successful install supplies a denominator.
 
-Only the install boundary is automatic in this release. Setup, route, handoff, resume, and return
-must be recorded by the workflow that can prove each milestone. Missing integration remains missing
-evidence, not a manufactured conversion.
+The unified installer records the install boundary. A configured session start records setup once,
+and the first configured session at least one day later records return use once. Standard `/do setup`
+and `/do` workflows record route, verified handoff, and successful resume at their proving seams.
+Each write remains local, optional, deduplicated where hooks may repeat, and non-blocking. Missing
+integration remains missing evidence, not a manufactured conversion.
 
 ## GitHub acquisition history
 

--- a/hooks_src/init-project.js
+++ b/hooks_src/init-project.js
@@ -11,6 +11,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const activation = require('../core/telemetry/activation');
 
 const PLUGIN_ROOT = path.resolve(__dirname, '..');
 const PROJECT_ROOT = process.env.CLAUDE_PROJECT_DIR || process.cwd();
@@ -191,6 +192,10 @@ function main() {
       PLUGIN_ROOT
     );
 
+    // 6b. Record proof-backed activation milestones. This is local-only,
+    // deduplicated, and can never block session initialization.
+    recordActivationMilestones();
+
     // 7. Watchdog — check for stale command results from a previous session
     checkStaleCommandResult();
 
@@ -204,6 +209,27 @@ function main() {
     // Non-fatal — don't block session start
     process.exit(0);
   }
+}
+
+function activationRuntime() {
+  const declared = String(process.env.CITADEL_RUNTIME || '').toLowerCase();
+  if (declared === 'codex') return 'codex';
+  if (declared === 'claude' || declared === 'claude-code') return 'claude-code';
+  return 'unknown';
+}
+
+function recordActivationMilestones() {
+  try {
+    const config = path.join(PROJECT_ROOT, '.claude', 'harness.json');
+    if (!fs.existsSync(config)) return;
+    JSON.parse(fs.readFileSync(config, 'utf8'));
+    const input = { status: 'succeeded', runtime: activationRuntime() };
+    activation.recordOnce({ ...input, stage: 'setup_completed' }, { root: PROJECT_ROOT });
+    activation.recordOnce({ ...input, stage: 'return_session' }, {
+      root: PROJECT_ROOT,
+      minimum_day_since_install: 1,
+    });
+  } catch { /* activation evidence is best-effort and never blocks startup */ }
 }
 
 /**

--- a/scripts/test-activation-telemetry.js
+++ b/scripts/test-activation-telemetry.js
@@ -5,6 +5,7 @@ const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+const { execFileSync } = require('child_process');
 const activation = require('../core/telemetry/activation');
 const cli = require('./activation-telemetry');
 
@@ -178,6 +179,43 @@ test('rates are null when no successful installation denominator exists', () => 
   assert.equal(result.decision_metrics.durable_resume_rate.rate, null);
   assert.equal(result.decision_metrics.return_use_rate.rate, null);
   assert.equal(result.guardrails.failure_event_rate, null);
+});
+
+test('recordOnce deduplicates milestones and enforces return age', () => {
+  const root = tempRoot();
+  const now = new Date('2026-01-03T00:00:00.000Z');
+  const options = { root, identity, version: '1.1.0', os_family: 'linux', now };
+  assert.equal(activation.recordOnce({ stage: 'setup_completed', status: 'succeeded' }, options).recorded, true);
+  assert.equal(activation.recordOnce({ stage: 'setup_completed', status: 'succeeded' }, options).reason, 'already_recorded');
+  const freshIdentity = { ...identity, installation_id: '22222222-2222-4222-8222-222222222222', created_at: now.toISOString() };
+  const early = activation.recordOnce({ stage: 'return_session', status: 'succeeded' }, {
+    ...options, identity: freshIdentity, minimum_day_since_install: 1,
+  });
+  assert.equal(early.reason, 'too_early');
+  assert.equal(activation.readEvents(root).events.length, 1);
+});
+
+test('session start records configured setup and a later return once', () => {
+  const root = tempRoot();
+  fs.mkdirSync(path.join(root, '.claude'), { recursive: true });
+  fs.writeFileSync(path.join(root, '.claude', 'harness.json'), '{}\n');
+  const files = activation.pathsFor(root);
+  fs.mkdirSync(files.dir, { recursive: true });
+  fs.writeFileSync(files.identity, JSON.stringify({
+    schema: 1,
+    installation_id: identity.installation_id,
+    created_at: new Date(Date.now() - 2 * 86400000).toISOString(),
+  }, null, 2) + '\n');
+  const run = () => execFileSync(process.execPath, [path.join(__dirname, '..', 'hooks_src', 'init-project.js')], {
+    cwd: root,
+    env: { ...process.env, CLAUDE_PROJECT_DIR: root, CITADEL_RUNTIME: 'codex' },
+    stdio: 'pipe',
+  });
+  run();
+  run();
+  const events = activation.readEvents(root).events;
+  assert.deepEqual(events.map((event) => event.stage).sort(), ['return_session', 'setup_completed']);
+  assert(events.every((event) => event.runtime === 'codex'));
 });
 
 test('reader migrates legacy lines and counts invalid lines without exposing them', () => {

--- a/skills/do/SKILL.md
+++ b/skills/do/SKILL.md
@@ -275,7 +275,7 @@ When 2+ independent tasks detected (non-overlapping scopes, complexity >= 3, not
    `node .citadel/scripts/telemetry-log.cjs --event agent-complete --agent do-router --session routing --status success --meta '{"tier":N,"target":"[skill]","input_chars":M}'`
 
    Use `.citadel/scripts/telemetry-log.cjs` (the project-local copy). If it doesn't exist, skip logging silently — never block routing on telemetry failure.
-
+   Also run `node .citadel/scripts/activation-telemetry.js record --stage route_completed --status succeeded --runtime {claude-code|codex}` with the current runtime; skip failures silently.
 2. **Announce the routing decision**: "Routing to [target] because [one-sentence reason]"
 3. **Invoke the target** skill or orchestrator
 4. If the target fails or the user says "wrong tool", try the next tier up. If the target is already Tier 3 (marshal fails or user explicitly escalates from a failed marshal attempt): re-route to `/archon` with the original input as context.
@@ -293,14 +293,12 @@ Output a grouped skill list drawn from the system reminder's available skills. G
 - **Routed skill not found**: Report "Skill not found" and fall back to Marshal as the safe default.
 
 ## Contextual Gates
-
 **Disclosure:** "Routing to [skill]. See that skill's contextual gates for reversibility."
 **Reversibility:** depends on routed skill — check the routed skill's reversibility
 **Trust gates:**
 - Any: routing and dispatch; inherits trust gates from the routed skill.
 
 ## Quality Gates
-
 - Tier 0-2 must resolve in under 1 second
 - Tier 3 classification must be transparent (announce reasoning)
 - Never route a trivial task (complexity 1) to Archon or Fleet
@@ -311,6 +309,8 @@ Output a grouped skill list drawn from the system reminder's available skills. G
 
 After routing and execution complete:
 - If the routed skill/orchestrator produces a HANDOFF, relay it to the user
+- If a routed workflow produces a HANDOFF with successful verification evidence, record `--stage verified_handoff --status succeeded` through `.citadel/scripts/activation-telemetry.js`.
+- If Tier 1 successfully resumed an existing campaign or fleet, record `--stage resume_completed --status succeeded` through `.citadel/scripts/activation-telemetry.js`.
 - If the task was trivial (Tier 0), just show the result
 - Do not add overhead to simple tasks
 - Telemetry is fire-and-forget — never surface telemetry errors to the user

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -201,6 +201,16 @@ Print the reference card using the canonical boxed layout at docs/SETUP_REFERENC
 
 ### Step 9: CLOSING LINE (all modes)
 
+Before printing the closing line, record successful setup as local activation evidence:
+
+```bash
+node .citadel/scripts/activation-telemetry.js record --stage setup_completed --status succeeded --runtime {claude-code|codex}
+```
+
+Use the current runtime. This is fire-and-forget. If the delegate is missing or recording fails,
+skip it silently and never fail setup. The next successful session start also records this milestone
+once when it finds a valid `.claude/harness.json`.
+
 ```
 Express:      Done. {N} hooks live, {N} skills registered.
               Type /do [anything] to start.


### PR DESCRIPTION
## What changed

- add a deduplicated local milestone writer
- record successful setup when a valid harness configuration exists
- record the first configured return session after at least one day
- teach `/do` to record route, verified handoff, and successful resume at their proving seams
- keep every activation write optional, local-only, non-blocking, and privacy constrained
- document which production workflow proves each stage

## Verification

- activation telemetry: 21/21 passed
- hook install and synthetic runtime checks: 88/88 passed
- hook pipeline integration: 20/20 passed
- modified skill lint: clean, no warnings, no line-budget overflow
- full suite: every listed subsystem passed except the existing Windows `EPERM` in the Codex runtime fixture before it could create `hooks_src/test-fixture-plain-stop.js`
- `git diff --check`: passed

## Measurement contract

A valid harness configuration proves setup. A configured session at least one day after installation proves return use. Routing, resume, and verified handoff are recorded only by the workflows that can observe their success. Missing evidence remains missing.