### PR TITLE
Fix research fleet telemetry contract

### DIFF
--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -212,10 +212,13 @@ Source: {scout report path}
 {What couldn't be resolved — needs human judgment}
 ```
 
-Also log to `.planning/telemetry/agent-runs.jsonl`:
-```json
-{"event":"research-fleet-complete","slug":"{slug}","scouts":0,"waves":0,"timestamp":"ISO"}
+Log the completed wave through Citadel's project-local telemetry helper:
+```bash
+node .citadel/scripts/telemetry-log.cjs --event wave-complete --agent research-fleet --session fleet-{slug} --status success
 ```
+If the helper is unavailable, skip telemetry without blocking the research result.
+Keep the scout count and total wave count authoritative in `REPORT.md` and the
+parallel-mode HANDOFF rather than duplicating them in telemetry metadata.
 
 ### Safety Rules (Parallel Mode)
 


### PR DESCRIPTION
## Summary

- replace the unsupported `research-fleet-complete` event with canonical `wave-complete`
- route logging through the installed project-local telemetry helper
- keep scout and wave counts authoritative in `REPORT.md` and the HANDOFF

## Root cause

The research skill had drifted from `core/telemetry/schema.js`, so its documented completion event was rejected by the live telemetry boundary.

## Evidence

- unsupported event reference: 1 to 0
- research skill lint: 25 checks passed
- research benchmarks: 5 scenarios passed
- fresh installed target: 1 telemetry record verified, 0 invalid, 0 tampered
- full repository suite on current `main`: all checks passed
- diff hygiene: clean

## Scope

One skill file. No telemetry schema, runtime, hook, dependency, or infrastructure changes.