### PR TITLE
feat: preserve Citadel memory across disposable clones

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,21 @@ jobs:
           strict: "true"
           working-directory: "."
 
+  repository-memory:
+    name: repository memory on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+      - name: Verify cross-clone identity, SQLite persistence, and safe restore
+        run: node scripts/test-repository-memory.js
+
   test:
     name: node ${{ matrix.node }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -326,6 +326,26 @@ leave plan/apply path. A legacy install without a receipt must first use
 `adopt import plan`; the emergency `unharness --legacy-apply` path is explicitly
 inexact and cannot support an exact-removal claim.
 
+## Optional cross-clone memory
+
+Citadel's core remains repository-local. On Node.js 22.13+, users with disposable
+clones can opt into a user-level SQLite store:
+
+```bash
+citadel memory enable
+citadel memory status
+```
+
+The store is keyed by a SHA-256 digest of the normalized `origin` fetch URL.
+It contains only durable Markdown knowledge and project context, never active
+execution state, telemetry, consent, or runtime configuration. Raw remote URLs
+and clone paths are not stored as identity metadata; allowlisted documents are
+stored verbatim and may themselves mention either. Missing files restore
+automatically in another clone of the enabled repository; different existing
+files remain untouched. See
+[Cross-clone repository memory](docs/REPOSITORY_MEMORY.md) for paths, limits,
+manual sync/restore, disable, and purge.
+
 ## Troubleshooting
 
 **Hook not firing / "command not found" errors:**

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -3,8 +3,8 @@
 Citadel runs entirely on your machine. It does not collect, transmit, or sell
 any data.
 
-- All state lives in your repository under `.planning/` and `.claude/` or
-  `.codex/`. Nothing is sent anywhere by Citadel itself.
+- By default, state lives in your repository under `.planning/` and `.claude/`
+  or `.codex/`. Nothing is sent anywhere by Citadel itself.
 - Telemetry (cost, hook timing, audit records) is written to local JSONL files
   in `.planning/telemetry/`. It never leaves your machine unless you run the
   optional OTLP exporter, which sends metrics only to the endpoint you specify.
@@ -12,6 +12,25 @@ any data.
   your own account and their respective privacy policies. Citadel adds no
   additional services, accounts, or network calls.
 - The interactive demo site is static and sets no cookies.
+
+## Optional cross-clone memory
+
+On Node.js 22.13+, `citadel memory enable` creates a local user-level SQLite
+database so durable lessons can survive deletion of a clone. It is disabled by
+default and never makes a network request.
+
+- Only completed campaigns, postmortems, research, discoveries, backlog
+  Markdown, and `.citadel/project.md` are eligible.
+- Active campaigns, worktree and fleet state, telemetry, consent, runtime
+  configuration, credentials, and hook settings are excluded.
+- The database stores a SHA-256 repository key, relative paths, content, content
+  digests, timestamps, and preserved versions. It does not store the raw remote
+  URL or clone path as identity metadata. Because eligible documents are stored
+  verbatim, their text may itself contain paths, URLs, or other private context.
+- `citadel memory disable` stops sync and restore without deleting history.
+  `citadel memory purge --confirm PURGE` deletes the current repository's rows.
+
+See [Cross-clone repository memory](docs/REPOSITORY_MEMORY.md).
 
 ## Real User Proof v2
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ Citadel does not replace `CLAUDE.md` or `AGENTS.md`. Those files describe the pr
 
 The repository remains the source of truth. Citadel adds an operating layer around the coding agent rather than replacing its runtime.
 
+If you regularly delete clones, opt into [cross-clone repository memory](docs/REPOSITORY_MEMORY.md)
+on Node.js 22.13+ with `citadel memory enable`. Citadel then keeps completed
+campaigns, postmortems, research, discoveries, backlog, and project context in
+a user-level SQLite database and restores missing files in another clone of the
+same remote. Its default path is outside the checkout, and Citadel never commits,
+pushes, or transmits it.
+
 ## Portable operations
 
 Portable operations are optional. They are for work that needs a stable contract, durable recovery, comparable executors, or a verifiable receipt. Ordinary repository work still begins with `/do`.
@@ -177,6 +184,19 @@ Runtime adapters may add Claude Code or Codex configuration files. [Installation
 </details>
 
 ## Common questions
+
+<details>
+<summary><strong>Can I delete a clone without losing Citadel's lessons?</strong></summary>
+
+<br>
+
+Yes, if you enable cross-clone memory first with `citadel memory enable` on
+Node.js 22.13+. It syncs only durable knowledge to a local user-level SQLite store.
+A new clone with the same `origin` restores missing knowledge automatically
+after Citadel is installed. Existing divergent files are never overwritten
+automatically. See [Cross-clone repository memory](docs/REPOSITORY_MEMORY.md).
+
+</details>
 
 <details>
 <summary><strong>Do I need to learn every skill or operation command?</strong></summary>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,6 +29,7 @@ For the detailed trust-boundary map, see [THREAT_MODEL.md](THREAT_MODEL.md).
 - Local use inside a repository you control.
 - Claude Code and OpenAI Codex sessions with normal tool approval boundaries.
 - Project-local state under `.planning/`, `.citadel/`, `.codex/`, `.claude/`, and generated runtime configuration files.
+- Optional user-level cross-clone memory explicitly enabled with `citadel memory enable`.
 - Reviewable pull-request workflows for publishing harness changes.
 
 ### Not supported
@@ -50,6 +51,7 @@ For the detailed trust-boundary map, see [THREAT_MODEL.md](THREAT_MODEL.md).
 | Prompt injection | Repo docs, issues, PRs, web pages, or generated artifacts can contain hostile instructions | Instruction hierarchy, explicit trust boundaries, review before automation |
 | Unattended automation drift | Long-running agents can make broad changes if scope is unclear | Campaign state, handoffs, approval capsules, PR readiness checks |
 | Public artifact leakage | `.planning/` can contain decisions, costs, logs, screenshots, or research | `.gitignore` coverage, private-state guidance, review before sharing |
+| Cross-clone memory disclosure | The optional SQLite store contains durable project notes outside the clone | Disabled by default, repository-key hashing, strict content allowlist, user-only file mode where supported, explicit disable and purge |
 
 ## Defensive hooks and checks
 
@@ -86,6 +88,14 @@ Write boundaries:
 > Do not assume generated Citadel state is safe to publish. It can include repository structure, work plans, local paths, tool outputs, review findings, cost telemetry, screenshots, or links to private work.
 
 Review these paths before committing, sharing logs, recording demos, or opening support issues: `.planning/`, `.citadel/`, `.codex/`, `.claude/`, `.mcp.json`, plus screenshots, browser captures, telemetry logs, research notes, and handoff files.
+
+If cross-clone memory is enabled, also protect the user-level
+`repository-memory.sqlite3` database documented in
+[Cross-clone repository memory](docs/REPOSITORY_MEMORY.md). It is plaintext local
+storage and can contain the full text of completed campaigns, postmortems,
+research, discoveries, backlog items, and project context. Citadel attempts a
+user-only file mode where the operating system supports it; disk encryption and
+account security remain the user's responsibility.
 
 ## Security checklist for harness changes
 

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -1,11 +1,12 @@
 # Threat Model
 
-Version 3.0 (2026-07-13). Version 1 covered the core hook, campaign, and fleet
+Version 4.0 (2026-07-31). Version 1 covered the core hook, campaign, and fleet
 surfaces. Version 2 adds Teams Mode coordination, routine and daemon
 automation, generated routing surfaces, the native memory write allowlist, and
 the accepted residuals from the June 2026 audit. Version 3 adds Operation Fork,
 cross-runtime worktrees, signed comparison evidence, local selection, landing,
-and redacted replay.
+and redacted replay. Version 4 adds the opt-in user-level cross-clone memory
+boundary, content allowlist, restore controls, and retention semantics.
 
 Citadel is an agent orchestration harness for local coding runtimes. It adds
 skills, hooks, scripts, generated configuration, and repo-local state so an AI
@@ -44,6 +45,7 @@ Citadel does not try to:
 | Source files | The agent can modify code, docs, tests, and generated artifacts. |
 | Secrets and credentials | `.env` files, tokens, keys, and private config must not be copied into prompts, logs, or public artifacts. |
 | Repo-local planning state | `.planning/` can contain campaign details, research, screenshots, telemetry, cost data, local paths, and handoffs. |
+| Optional cross-clone memory | A user-level SQLite database can contain durable completed campaigns, research, discoveries, backlog, and project context. |
 | Runtime configuration | `.codex/`, `.claude/`, `.mcp.json`, and generated hook config influence future agent behavior. |
 | Git branches and worktrees | Fleet and PR workflows can create, inspect, and coordinate parallel work. |
 | External services | GitHub, package registries, MCP servers, and browser targets may have side effects or expose data. |
@@ -74,6 +76,14 @@ Citadel writes state under paths such as `.planning/`, `.citadel/`, `.codex/`,
 and `.claude/`. These files are useful for continuity, but they may contain
 private project details. Users should review them before publishing.
 
+When explicitly enabled, cross-clone memory adds one user-level trust boundary:
+`repository-memory.sqlite3`. It stores only allowlisted durable files, uses a
+SHA-256 digest rather than a raw remote URL or clone path as identity metadata,
+and never transmits data. Allowlisted documents are stored verbatim and may
+themselves contain private URLs or local paths. The database is plaintext local
+storage. A process running as the same OS user can read it, and a malicious
+durable Markdown file remains untrusted input when restored into a later clone.
+
 ### Agents and Sub-Agents
 
 Parallel agents, Fleet sessions, and campaign continuations inherit project
@@ -102,6 +112,10 @@ that conflict with user, system, runtime, or repository policy.
 | Fork comparison spoofing | A runtime claims success without equivalent proof | shared contract digests, signed receipts, required evidence coverage, and explicit unknown states |
 | Duplicate landing | Recovery repeats a merge after losing state | persist unknown before the effect, block ambiguous recovery, and require idempotency |
 | Replay leak | A public comparison exposes prompts, source, paths, or credentials | strict output allowlist, digest projection, and secret-like value rejection |
+| Cross-repository memory bleed | One clone receives another repository's private lessons | normalized remote identity hashed with a versioned domain separator; path-scoped fallback does not claim cross-clone portability |
+| Memory restore overwrite | Stored content replaces newer work in a clone | automatic restore writes missing files only; divergent files are reported and require explicit `--force` |
+| Memory path escape | A tampered database row targets a path outside the repository | strict durable-path allowlist, containment check, plain-file and symlink rejection |
+| Memory retention surprise | Disabling the feature is mistaken for deleting stored content | `disable` preserves and stops use; destructive removal is a separate `purge --confirm PURGE` command |
 
 ## Expanded Surfaces (v2)
 

--- a/core/cli/package-cli.js
+++ b/core/cli/package-cli.js
@@ -33,6 +33,7 @@ Commands:
   governance   Record or authorize a fail-honest governance decision
   control-plane Run the Governance Port alpha or its conformance suite
   trial        Operate the local-only Real User Proof v2 instrument
+  memory       Preserve durable Citadel knowledge across disposable clones
   help         Show this help
 
 Run citadel <command> --help for command-specific help.
@@ -59,6 +60,7 @@ citadel adopt plan|apply so every mutation and later leave is receipt-owned.
   governance: 'Usage: citadel governance <evaluate|authorize|check> [options]\n',
   'control-plane': 'Usage: citadel control-plane <stdio|conformance> [options]\n',
   trial: 'Usage: citadel trial <validate|plan|start|record|report|share-preview|purge> [options]\n',
+  memory: 'Usage: citadel memory <status|enable|sync|restore|versions|restore-version|disable|purge> [options]\n',
 });
 
 function has(args, flag) {
@@ -362,6 +364,7 @@ function main(argv = process.argv.slice(2), options = {}) {
   if (command === 'governance') return child('governance-gate.js', args, { ...context, json: has(args, '--json') });
   if (command === 'control-plane') return controlPlane(args, context);
   if (command === 'trial') return child('product-proof-trial.js', args, { ...context, json: true });
+  if (command === 'memory') return child('repository-memory.js', args, { ...context, json: has(args, '--json') });
   const error = new Error(`unknown command: ${command}`);
   error.code = CODE.COMMAND_FAILED;
   error.exitCode = EXIT.USAGE;

--- a/core/memory/repository-store.js
+++ b/core/memory/repository-store.js
@@ -1,0 +1,686 @@
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const SCHEMA_VERSION = 1;
+const MIN_SQLITE_NODE_MAJOR = 22;
+const MIN_SQLITE_NODE_MINOR = 13;
+const MIN_SQLITE_NODE_VERSION = `${MIN_SQLITE_NODE_MAJOR}.${MIN_SQLITE_NODE_MINOR}`;
+const MAX_ENTRY_BYTES = 2 * 1024 * 1024;
+const MAX_SYNC_BYTES = 50 * 1024 * 1024;
+const DURABLE_DIRECTORIES = Object.freeze([
+  '.planning/campaigns/completed',
+  '.planning/postmortems',
+  '.planning/research',
+  '.planning/discoveries',
+  '.planning/intake',
+]);
+const DURABLE_FILES = Object.freeze(['.citadel/project.md']);
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function normalizeSlashes(value) {
+  return String(value || '').replace(/\\/g, '/');
+}
+
+function normalizeRemoteUrl(input) {
+  let value = String(input || '').trim();
+  if (!value) return null;
+
+  const scp = value.match(/^(?:[^@/\s]+@)?([^:/\s]+):(.+)$/);
+  if (!value.includes('://') && scp && !/^[a-zA-Z]:[\\/]/.test(value)) {
+    value = `ssh://${scp[1]}/${scp[2]}`;
+  }
+
+  try {
+    const parsed = new URL(value);
+    const host = parsed.hostname.toLowerCase();
+    const defaultPorts = { 'git:': '9418', 'http:': '80', 'https:': '443', 'ssh:': '22' };
+    const authority = parsed.port && parsed.port !== defaultPorts[parsed.protocol]
+      ? `${host}:${parsed.port}`
+      : host;
+    let pathname = decodeURIComponent(parsed.pathname).replace(/^\/+|\/+$/g, '');
+    pathname = pathname.replace(/\.git$/i, '');
+    if (!host || !pathname) return null;
+    return `${authority}/${pathname}`;
+  } catch {
+    // Relative paths and local filesystem remotes are not stable cross-clone
+    // identities. Fall back to the clone's canonical local path instead.
+    return null;
+  }
+}
+
+function runGit(projectRoot, args, options = {}) {
+  const spawn = options.spawn || spawnSync;
+  const result = spawn('git', ['-C', projectRoot, ...args], {
+    encoding: 'utf8',
+    shell: false,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 5000,
+  });
+  if (result.error || result.status !== 0) return null;
+  return String(result.stdout || '').trim() || null;
+}
+
+function repositoryIdentity(projectRoot, options = {}) {
+  const requestedRoot = path.resolve(projectRoot);
+  const gitRoot = runGit(requestedRoot, ['rev-parse', '--show-toplevel'], options);
+  const root = path.resolve(gitRoot || requestedRoot);
+  const remote = runGit(root, ['remote', 'get-url', 'origin'], options);
+  const normalizedRemote = normalizeRemoteUrl(remote);
+  if (normalizedRemote) {
+    return {
+      repository_id: sha256(`remote:v1:${normalizedRemote}`),
+      identity_kind: 'remote',
+      portable: true,
+      project_root: root,
+    };
+  }
+
+  let canonical = root;
+  try { canonical = fs.realpathSync.native(root); } catch { /* use resolved path */ }
+  if (process.platform === 'win32') canonical = canonical.toLowerCase();
+  return {
+    repository_id: sha256(`local:v1:${normalizeSlashes(canonical)}`),
+    identity_kind: 'local-path',
+    portable: false,
+    project_root: root,
+  };
+}
+
+function defaultDatabasePath(options = {}) {
+  const env = options.env || process.env;
+  if (env.CITADEL_MEMORY_DB) return path.resolve(env.CITADEL_MEMORY_DB);
+  const platform = options.platform || process.platform;
+  const home = options.home || os.homedir();
+  if (platform === 'win32') {
+    const local = env.LOCALAPPDATA || path.join(home, 'AppData', 'Local');
+    return path.join(local, 'Citadel', 'repository-memory.sqlite3');
+  }
+  if (platform === 'darwin') {
+    return path.join(home, 'Library', 'Application Support', 'Citadel', 'repository-memory.sqlite3');
+  }
+  const state = env.XDG_STATE_HOME || path.join(home, '.local', 'state');
+  return path.join(state, 'citadel', 'repository-memory.sqlite3');
+}
+
+function loadBuiltinSqlite() {
+  const original = process.emitWarning;
+  try {
+    // Node 22 emits this warning on every short-lived hook process. The feature
+    // is explicitly opt-in, so suppress only the module's known warning while
+    // preserving every other process warning.
+    process.emitWarning = function filteredWarning(warning, ...args) {
+      const type = typeof args[0] === 'string' ? args[0] : args[0]?.type;
+      if (type === 'ExperimentalWarning' && /SQLite is an experimental feature/i.test(String(warning))) return;
+      return original.call(process, warning, ...args);
+    };
+    return require('node:sqlite');
+  } finally {
+    process.emitWarning = original;
+  }
+}
+
+function sqliteCapability(options = {}) {
+  if (options.DatabaseSync) return { available: true, DatabaseSync: options.DatabaseSync };
+  const [major, minor] = String(options.nodeVersion || process.versions.node).split('.').map(Number);
+  if (!Number.isInteger(major) || !Number.isInteger(minor)
+    || major < MIN_SQLITE_NODE_MAJOR
+    || (major === MIN_SQLITE_NODE_MAJOR && minor < MIN_SQLITE_NODE_MINOR)) {
+    return {
+      available: false,
+      code: 'CITADEL_SQLITE_UNAVAILABLE',
+      reason: `Cross-clone memory requires Node.js ${MIN_SQLITE_NODE_VERSION}+; current runtime is ${options.nodeVersion || process.versions.node}.`,
+    };
+  }
+  try {
+    const { DatabaseSync } = loadBuiltinSqlite();
+    return { available: true, DatabaseSync };
+  } catch (error) {
+    return {
+      available: false,
+      code: 'CITADEL_SQLITE_UNAVAILABLE',
+      reason: `The node:sqlite module is unavailable: ${error.message}`,
+    };
+  }
+}
+
+function schemaSql() {
+  return `
+    PRAGMA foreign_keys = ON;
+    PRAGMA busy_timeout = 5000;
+    CREATE TABLE IF NOT EXISTS repositories (
+      repository_id TEXT PRIMARY KEY,
+      identity_kind TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1 CHECK(enabled IN (0, 1)),
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      last_synced_at TEXT,
+      last_restored_at TEXT
+    );
+    CREATE TABLE IF NOT EXISTS entries (
+      repository_id TEXT NOT NULL,
+      relative_path TEXT NOT NULL,
+      content BLOB NOT NULL,
+      content_sha256 TEXT NOT NULL,
+      bytes INTEGER NOT NULL,
+      captured_at TEXT NOT NULL,
+      PRIMARY KEY (repository_id, relative_path),
+      FOREIGN KEY (repository_id) REFERENCES repositories(repository_id) ON DELETE CASCADE
+    );
+    CREATE TABLE IF NOT EXISTS entry_versions (
+      repository_id TEXT NOT NULL,
+      relative_path TEXT NOT NULL,
+      content_sha256 TEXT NOT NULL,
+      content BLOB NOT NULL,
+      bytes INTEGER NOT NULL,
+      captured_at TEXT NOT NULL,
+      PRIMARY KEY (repository_id, relative_path, content_sha256),
+      FOREIGN KEY (repository_id) REFERENCES repositories(repository_id) ON DELETE CASCADE
+    );
+    PRAGMA user_version = ${SCHEMA_VERSION};
+  `;
+}
+
+function openDatabase(options = {}) {
+  const capability = sqliteCapability(options);
+  if (!capability.available) {
+    const error = new Error(capability.reason);
+    error.code = capability.code;
+    throw error;
+  }
+  const databasePath = options.databasePath || defaultDatabasePath(options);
+  fs.mkdirSync(path.dirname(databasePath), { recursive: true, mode: 0o700 });
+  if (fs.existsSync(databasePath)) {
+    const stat = fs.lstatSync(databasePath);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      const error = new Error(`Repository memory database must be a plain file: ${databasePath}`);
+      error.code = 'CITADEL_MEMORY_DB_UNSAFE';
+      throw error;
+    }
+  } else {
+    // Establish private permissions before SQLite writes schema or content.
+    // `wx` also avoids following a destination created during the check.
+    try {
+      fs.closeSync(fs.openSync(databasePath, 'wx', 0o600));
+    } catch (error) {
+      if (error.code !== 'EEXIST') throw error;
+      const stat = fs.lstatSync(databasePath);
+      if (!stat.isFile() || stat.isSymbolicLink()) {
+        const unsafe = new Error(`Repository memory database must be a plain file: ${databasePath}`);
+        unsafe.code = 'CITADEL_MEMORY_DB_UNSAFE';
+        throw unsafe;
+      }
+    }
+  }
+  try { fs.chmodSync(databasePath, 0o600); } catch { /* Windows and some filesystems ignore POSIX modes */ }
+  const db = new capability.DatabaseSync(databasePath);
+  const observedVersion = Number(db.prepare('PRAGMA user_version').get().user_version || 0);
+  if (observedVersion > SCHEMA_VERSION) {
+    db.close();
+    const error = new Error(`Repository memory schema ${observedVersion} is newer than supported schema ${SCHEMA_VERSION}. Update Citadel before opening it.`);
+    error.code = 'CITADEL_MEMORY_SCHEMA_UNSUPPORTED';
+    throw error;
+  }
+  db.exec(schemaSql());
+  return { db, databasePath };
+}
+
+function normalizedRelative(projectRoot, filePath) {
+  const relative = normalizeSlashes(path.relative(projectRoot, path.resolve(filePath)));
+  if (!relative || relative === '..' || relative.startsWith('../') || path.isAbsolute(relative)) return null;
+  return relative;
+}
+
+function pathContainsSymlink(projectRoot, relativePath) {
+  let cursor = path.resolve(projectRoot);
+  for (const segment of normalizeSlashes(relativePath).split('/')) {
+    if (!segment) continue;
+    cursor = path.join(cursor, segment);
+    if (!fs.existsSync(cursor)) return false;
+    try {
+      if (fs.lstatSync(cursor).isSymbolicLink()) return true;
+    } catch {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isDurablePath(relativePath) {
+  const relative = normalizeSlashes(relativePath).replace(/^\.\//, '');
+  if (!relative || relative === '..' || relative.startsWith('../') || path.isAbsolute(relative)) return false;
+  if (DURABLE_FILES.includes(relative)) return true;
+  if (!relative.endsWith('.md') || /(?:^|\/)\_TEMPLATE\.md$/i.test(relative)) return false;
+  return DURABLE_DIRECTORIES.some((directory) => relative.startsWith(`${directory}/`));
+}
+
+function readDurableFile(projectRoot, relativePath) {
+  if (!isDurablePath(relativePath)) return { skipped: 'not-durable' };
+  const absolute = path.resolve(projectRoot, ...relativePath.split('/'));
+  if (normalizedRelative(projectRoot, absolute) !== relativePath) return { skipped: 'unsafe-path' };
+  if (pathContainsSymlink(projectRoot, relativePath)) return { skipped: 'symlink-path' };
+  let stat;
+  try { stat = fs.lstatSync(absolute); } catch { return { skipped: 'missing' }; }
+  if (!stat.isFile() || stat.isSymbolicLink()) return { skipped: 'not-plain-file' };
+  if (stat.size > MAX_ENTRY_BYTES) return { skipped: 'entry-too-large', bytes: stat.size };
+  const content = fs.readFileSync(absolute);
+  return {
+    relative_path: relativePath,
+    content,
+    content_sha256: sha256(content),
+    bytes: content.length,
+  };
+}
+
+function collectDurableEntries(projectRoot) {
+  const root = path.resolve(projectRoot);
+  const entries = [];
+  const skipped = [];
+  let totalBytes = 0;
+
+  const add = (relative) => {
+    const item = readDurableFile(root, relative);
+    if (item.skipped) {
+      if (!['missing', 'not-durable'].includes(item.skipped)) skipped.push({ path: relative, reason: item.skipped });
+      return;
+    }
+    if (totalBytes + item.bytes > MAX_SYNC_BYTES) {
+      skipped.push({ path: relative, reason: 'sync-limit-exceeded' });
+      return;
+    }
+    totalBytes += item.bytes;
+    entries.push(item);
+  };
+
+  for (const relative of DURABLE_FILES) add(relative);
+  for (const directory of DURABLE_DIRECTORIES) {
+    const absoluteRoot = path.join(root, ...directory.split('/'));
+    if (!fs.existsSync(absoluteRoot)) continue;
+    if (pathContainsSymlink(root, directory)) {
+      skipped.push({ path: directory, reason: 'symlink-path' });
+      continue;
+    }
+    const visit = (absolute) => {
+      for (const entry of fs.readdirSync(absolute, { withFileTypes: true })) {
+        const candidate = path.join(absolute, entry.name);
+        if (entry.isSymbolicLink()) {
+          const relative = normalizedRelative(root, candidate);
+          skipped.push({ path: relative || candidate, reason: 'symlink-path' });
+          continue;
+        }
+        if (entry.isDirectory()) visit(candidate);
+        else if (entry.isFile()) {
+          const relative = normalizedRelative(root, candidate);
+          if (relative && isDurablePath(relative)) add(relative);
+        }
+      }
+    };
+    visit(absoluteRoot);
+  }
+  return { entries: entries.sort((left, right) => left.relative_path.localeCompare(right.relative_path)), skipped, totalBytes };
+}
+
+function withTransaction(db, operation) {
+  db.exec('BEGIN IMMEDIATE');
+  try {
+    const result = operation();
+    db.exec('COMMIT');
+    return result;
+  } catch (error) {
+    try { db.exec('ROLLBACK'); } catch { /* retain original error */ }
+    throw error;
+  }
+}
+
+function registerRepository(db, identity, enabled = true, now = new Date().toISOString()) {
+  db.prepare(`
+    INSERT INTO repositories(repository_id, identity_kind, enabled, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?)
+    ON CONFLICT(repository_id) DO UPDATE SET
+      identity_kind = excluded.identity_kind,
+      enabled = excluded.enabled,
+      updated_at = excluded.updated_at
+  `).run(identity.repository_id, identity.identity_kind, enabled ? 1 : 0, now, now);
+}
+
+function repositoryRow(db, repositoryId) {
+  return db.prepare('SELECT * FROM repositories WHERE repository_id = ?').get(repositoryId) || null;
+}
+
+function syncEntries(db, identity, items, now) {
+  const version = db.prepare(`
+    INSERT OR IGNORE INTO entry_versions
+      (repository_id, relative_path, content_sha256, content, bytes, captured_at)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `);
+  const current = db.prepare(`
+    INSERT INTO entries(repository_id, relative_path, content, content_sha256, bytes, captured_at)
+    VALUES (?, ?, ?, ?, ?, ?)
+    ON CONFLICT(repository_id, relative_path) DO UPDATE SET
+      content = excluded.content,
+      content_sha256 = excluded.content_sha256,
+      bytes = excluded.bytes,
+      captured_at = excluded.captured_at
+  `);
+  let versionsAdded = 0;
+  for (const item of items) {
+    const result = version.run(
+      identity.repository_id, item.relative_path, item.content_sha256,
+      item.content, item.bytes, now,
+    );
+    versionsAdded += Number(result.changes || 0);
+    current.run(
+      identity.repository_id, item.relative_path, item.content,
+      item.content_sha256, item.bytes, now,
+    );
+  }
+  db.prepare(`
+    UPDATE repositories SET updated_at = ?, last_synced_at = ? WHERE repository_id = ?
+  `).run(now, now, identity.repository_id);
+  return versionsAdded;
+}
+
+function enableRepository(projectRoot, options = {}) {
+  const identity = repositoryIdentity(projectRoot, options);
+  const collected = collectDurableEntries(identity.project_root);
+  const opened = openDatabase(options);
+  try {
+    const now = new Date().toISOString();
+    const versionsAdded = withTransaction(opened.db, () => {
+      registerRepository(opened.db, identity, true, now);
+      return syncEntries(opened.db, identity, collected.entries, now);
+    });
+    return {
+      status: 'enabled', database_path: opened.databasePath, ...identity,
+      entries_synced: collected.entries.length, versions_added: versionsAdded,
+      bytes_synced: collected.totalBytes, skipped: collected.skipped,
+    };
+  } finally {
+    opened.db.close();
+  }
+}
+
+function syncRepository(projectRoot, options = {}) {
+  const databasePath = options.databasePath || defaultDatabasePath(options);
+  if (!fs.existsSync(databasePath)) return { status: 'not-configured', database_path: databasePath };
+  const identity = repositoryIdentity(projectRoot, options);
+  const opened = openDatabase({ ...options, databasePath });
+  try {
+    const row = repositoryRow(opened.db, identity.repository_id);
+    if (!row || row.enabled !== 1) return { status: 'disabled', database_path: databasePath, ...identity };
+    let collected;
+    if (options.filePath) {
+      const relative = normalizedRelative(identity.project_root, options.filePath);
+      const item = relative ? readDurableFile(identity.project_root, relative) : { skipped: 'unsafe-path' };
+      collected = item.skipped
+        ? { entries: [], skipped: [{ path: relative || String(options.filePath), reason: item.skipped }], totalBytes: 0 }
+        : { entries: [item], skipped: [], totalBytes: item.bytes };
+    } else {
+      collected = collectDurableEntries(identity.project_root);
+    }
+    const now = new Date().toISOString();
+    const versionsAdded = withTransaction(opened.db, () => syncEntries(opened.db, identity, collected.entries, now));
+    return {
+      status: 'synced', database_path: databasePath, ...identity,
+      entries_synced: collected.entries.length, versions_added: versionsAdded,
+      bytes_synced: collected.totalBytes, skipped: collected.skipped,
+    };
+  } finally {
+    opened.db.close();
+  }
+}
+
+function restoreRepository(projectRoot, options = {}) {
+  const databasePath = options.databasePath || defaultDatabasePath(options);
+  if (!fs.existsSync(databasePath)) return { status: 'not-configured', database_path: databasePath };
+  const identity = repositoryIdentity(projectRoot, options);
+  const opened = openDatabase({ ...options, databasePath });
+  try {
+    const row = repositoryRow(opened.db, identity.repository_id);
+    if (!row || row.enabled !== 1) return { status: 'disabled', database_path: databasePath, ...identity };
+    const rows = opened.db.prepare(`
+      SELECT relative_path, content, content_sha256, bytes, captured_at
+      FROM entries WHERE repository_id = ? ORDER BY relative_path
+    `).all(identity.repository_id);
+    const restored = [];
+    const unchanged = [];
+    const conflicts = [];
+    const skipped = [];
+    for (const entry of rows) {
+      if (!isDurablePath(entry.relative_path)) {
+        skipped.push({ path: entry.relative_path, reason: 'unsafe-or-unsupported-path' });
+        continue;
+      }
+      const destination = path.resolve(identity.project_root, ...entry.relative_path.split('/'));
+      if (normalizedRelative(identity.project_root, destination) !== entry.relative_path) {
+        skipped.push({ path: entry.relative_path, reason: 'unsafe-path' });
+        continue;
+      }
+      if (pathContainsSymlink(identity.project_root, entry.relative_path)) {
+        conflicts.push({ path: entry.relative_path, reason: 'destination-path-contains-symlink' });
+        continue;
+      }
+      const content = Buffer.from(entry.content);
+      if (sha256(content) !== entry.content_sha256 || content.length !== entry.bytes) {
+        skipped.push({ path: entry.relative_path, reason: 'database-content-digest-mismatch' });
+        continue;
+      }
+      if (fs.existsSync(destination)) {
+        const destinationStat = fs.lstatSync(destination);
+        if (!destinationStat.isFile() || destinationStat.isSymbolicLink()) {
+          conflicts.push({ path: entry.relative_path, reason: 'destination-is-not-a-plain-file' });
+          continue;
+        }
+        const existing = fs.readFileSync(destination);
+        const existingDigest = sha256(existing);
+        if (existingDigest === entry.content_sha256) {
+          unchanged.push(entry.relative_path);
+          continue;
+        }
+        if (!options.force) {
+          conflicts.push({ path: entry.relative_path, local_sha256: existingDigest, stored_sha256: entry.content_sha256 });
+          continue;
+        }
+      }
+      fs.mkdirSync(path.dirname(destination), { recursive: true });
+      fs.writeFileSync(destination, content);
+      restored.push(entry.relative_path);
+    }
+    const now = new Date().toISOString();
+    opened.db.prepare(`
+      UPDATE repositories SET updated_at = ?, last_restored_at = ? WHERE repository_id = ?
+    `).run(now, now, identity.repository_id);
+    return {
+      status: conflicts.length ? 'restored-with-conflicts' : 'restored',
+      database_path: databasePath, ...identity, restored, unchanged, conflicts, skipped,
+    };
+  } finally {
+    opened.db.close();
+  }
+}
+
+function listVersions(projectRoot, options = {}) {
+  const databasePath = options.databasePath || defaultDatabasePath(options);
+  if (!fs.existsSync(databasePath)) return { status: 'not-configured', database_path: databasePath, versions: [] };
+  const identity = repositoryIdentity(projectRoot, options);
+  const relativePath = options.relativePath
+    ? normalizeSlashes(options.relativePath).replace(/^\.\//, '')
+    : null;
+  if (relativePath && !isDurablePath(relativePath)) {
+    const error = new Error(`Version path is not eligible durable memory: ${relativePath}`);
+    error.code = 'CITADEL_MEMORY_PATH_UNSUPPORTED';
+    throw error;
+  }
+  const opened = openDatabase({ ...options, databasePath });
+  try {
+    const row = repositoryRow(opened.db, identity.repository_id);
+    if (!row) return { status: 'not-enabled', database_path: databasePath, ...identity, versions: [] };
+    const base = `
+      SELECT v.relative_path, v.content_sha256, v.bytes, v.captured_at,
+        CASE WHEN e.content_sha256 = v.content_sha256 THEN 1 ELSE 0 END AS is_current
+      FROM entry_versions v
+      LEFT JOIN entries e ON e.repository_id = v.repository_id AND e.relative_path = v.relative_path
+      WHERE v.repository_id = ?`;
+    const rows = relativePath
+      ? opened.db.prepare(`${base} AND v.relative_path = ? ORDER BY v.captured_at DESC`).all(identity.repository_id, relativePath)
+      : opened.db.prepare(`${base} ORDER BY v.relative_path, v.captured_at DESC`).all(identity.repository_id);
+    return {
+      status: row.enabled === 1 ? 'enabled' : 'disabled', database_path: databasePath, ...identity,
+      versions: rows.map((entry) => ({ ...entry, bytes: Number(entry.bytes), is_current: entry.is_current === 1 })),
+    };
+  } finally {
+    opened.db.close();
+  }
+}
+
+function restoreVersion(projectRoot, options = {}) {
+  const relativePath = normalizeSlashes(options.relativePath).replace(/^\.\//, '');
+  const contentSha256 = String(options.contentSha256 || '').toLowerCase();
+  if (!isDurablePath(relativePath)) {
+    const error = new Error(`Version path is not eligible durable memory: ${relativePath || '(missing)'}`);
+    error.code = 'CITADEL_MEMORY_PATH_UNSUPPORTED';
+    throw error;
+  }
+  if (!/^[a-f0-9]{64}$/.test(contentSha256)) {
+    const error = new Error('restore-version requires --sha256 with a full stored content digest.');
+    error.code = 'CITADEL_MEMORY_VERSION_REQUIRED';
+    throw error;
+  }
+  const databasePath = options.databasePath || defaultDatabasePath(options);
+  if (!fs.existsSync(databasePath)) return { status: 'not-configured', database_path: databasePath };
+  const identity = repositoryIdentity(projectRoot, options);
+  const opened = openDatabase({ ...options, databasePath });
+  try {
+    const repository = repositoryRow(opened.db, identity.repository_id);
+    if (!repository || repository.enabled !== 1) {
+      return { status: 'disabled', database_path: databasePath, ...identity, relative_path: relativePath };
+    }
+    const entry = opened.db.prepare(`
+      SELECT relative_path, content, content_sha256, bytes, captured_at
+      FROM entry_versions WHERE repository_id = ? AND relative_path = ? AND content_sha256 = ?
+    `).get(identity.repository_id, relativePath, contentSha256);
+    if (!entry) return { status: 'version-not-found', database_path: databasePath, ...identity, relative_path: relativePath };
+    const destination = path.resolve(identity.project_root, ...relativePath.split('/'));
+    if (normalizedRelative(identity.project_root, destination) !== relativePath
+      || pathContainsSymlink(identity.project_root, relativePath)) {
+      return { status: 'conflict', reason: 'unsafe-or-symlink-destination', database_path: databasePath, ...identity, relative_path: relativePath };
+    }
+    const content = Buffer.from(entry.content);
+    if (content.length !== entry.bytes || sha256(content) !== entry.content_sha256) {
+      return { status: 'corrupt-version', database_path: databasePath, ...identity, relative_path: relativePath };
+    }
+    if (fs.existsSync(destination)) {
+      const stat = fs.lstatSync(destination);
+      if (!stat.isFile() || stat.isSymbolicLink()) {
+        return { status: 'conflict', reason: 'destination-is-not-a-plain-file', database_path: databasePath, ...identity, relative_path: relativePath };
+      }
+      const localSha256 = sha256(fs.readFileSync(destination));
+      if (localSha256 !== contentSha256 && !options.force) {
+        return { status: 'conflict', reason: 'different-local-content', local_sha256: localSha256, stored_sha256: contentSha256, database_path: databasePath, ...identity, relative_path: relativePath };
+      }
+    }
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    fs.writeFileSync(destination, content);
+    const now = new Date().toISOString();
+    withTransaction(opened.db, () => {
+      opened.db.prepare(`
+        UPDATE entries SET content = ?, content_sha256 = ?, bytes = ?, captured_at = ?
+        WHERE repository_id = ? AND relative_path = ?
+      `).run(content, contentSha256, content.length, now, identity.repository_id, relativePath);
+      opened.db.prepare('UPDATE repositories SET updated_at = ?, last_restored_at = ? WHERE repository_id = ?')
+        .run(now, now, identity.repository_id);
+    });
+    return { status: 'version-restored', database_path: databasePath, ...identity, relative_path: relativePath, content_sha256: contentSha256 };
+  } finally {
+    opened.db.close();
+  }
+}
+
+function repositoryStatus(projectRoot, options = {}) {
+  const databasePath = options.databasePath || defaultDatabasePath(options);
+  const capability = sqliteCapability(options);
+  if (!capability.available) return { status: 'unavailable', database_path: databasePath, ...capability };
+  const identity = repositoryIdentity(projectRoot, options);
+  if (!fs.existsSync(databasePath)) return { status: 'not-configured', database_path: databasePath, ...identity };
+  const opened = openDatabase({ ...options, databasePath, DatabaseSync: capability.DatabaseSync });
+  try {
+    const row = repositoryRow(opened.db, identity.repository_id);
+    if (!row) return { status: 'not-enabled', database_path: databasePath, ...identity };
+    const entryCount = opened.db.prepare('SELECT COUNT(*) AS count FROM entries WHERE repository_id = ?').get(identity.repository_id).count;
+    const versionCount = opened.db.prepare('SELECT COUNT(*) AS count FROM entry_versions WHERE repository_id = ?').get(identity.repository_id).count;
+    return {
+      status: row.enabled === 1 ? 'enabled' : 'disabled', database_path: databasePath, ...identity,
+      entries: Number(entryCount), versions: Number(versionCount),
+      last_synced_at: row.last_synced_at, last_restored_at: row.last_restored_at,
+    };
+  } finally {
+    opened.db.close();
+  }
+}
+
+function disableRepository(projectRoot, options = {}) {
+  const databasePath = options.databasePath || defaultDatabasePath(options);
+  if (!fs.existsSync(databasePath)) return { status: 'not-configured', database_path: databasePath };
+  const identity = repositoryIdentity(projectRoot, options);
+  const opened = openDatabase({ ...options, databasePath });
+  try {
+    const result = opened.db.prepare(`
+      UPDATE repositories SET enabled = 0, updated_at = ? WHERE repository_id = ?
+    `).run(new Date().toISOString(), identity.repository_id);
+    return { status: Number(result.changes || 0) ? 'disabled' : 'not-enabled', database_path: databasePath, ...identity };
+  } finally {
+    opened.db.close();
+  }
+}
+
+function purgeRepository(projectRoot, options = {}) {
+  if (options.confirm !== 'PURGE') {
+    const error = new Error('Purge requires --confirm PURGE. This deletes every stored version for the current repository.');
+    error.code = 'CITADEL_MEMORY_CONFIRMATION_REQUIRED';
+    throw error;
+  }
+  const databasePath = options.databasePath || defaultDatabasePath(options);
+  if (!fs.existsSync(databasePath)) return { status: 'not-configured', database_path: databasePath };
+  const identity = repositoryIdentity(projectRoot, options);
+  const opened = openDatabase({ ...options, databasePath });
+  try {
+    const result = opened.db.prepare('DELETE FROM repositories WHERE repository_id = ?').run(identity.repository_id);
+    return { status: Number(result.changes || 0) ? 'purged' : 'not-enabled', database_path: databasePath, ...identity };
+  } finally {
+    opened.db.close();
+  }
+}
+
+module.exports = Object.freeze({
+  DURABLE_DIRECTORIES,
+  DURABLE_FILES,
+  MAX_ENTRY_BYTES,
+  MAX_SYNC_BYTES,
+  MIN_SQLITE_NODE_MAJOR,
+  MIN_SQLITE_NODE_MINOR,
+  MIN_SQLITE_NODE_VERSION,
+  SCHEMA_VERSION,
+  collectDurableEntries,
+  defaultDatabasePath,
+  disableRepository,
+  enableRepository,
+  isDurablePath,
+  normalizeRemoteUrl,
+  pathContainsSymlink,
+  purgeRepository,
+  repositoryIdentity,
+  repositoryStatus,
+  restoreRepository,
+  restoreVersion,
+  sha256,
+  sqliteCapability,
+  syncRepository,
+  listVersions,
+});

--- a/core/memory/repository-store.js
+++ b/core/memory/repository-store.js
@@ -68,10 +68,15 @@ function runGit(projectRoot, args, options = {}) {
   return String(result.stdout || '').trim() || null;
 }
 
+function realpathOrResolved(value) {
+  const resolved = path.resolve(value);
+  try { return fs.realpathSync.native(resolved); } catch { return resolved; }
+}
+
 function repositoryIdentity(projectRoot, options = {}) {
   const requestedRoot = path.resolve(projectRoot);
   const gitRoot = runGit(requestedRoot, ['rev-parse', '--show-toplevel'], options);
-  const root = path.resolve(gitRoot || requestedRoot);
+  const root = realpathOrResolved(gitRoot || requestedRoot);
   const remote = runGit(root, ['remote', 'get-url', 'origin'], options);
   const normalizedRemote = normalizeRemoteUrl(remote);
   if (normalizedRemote) {
@@ -84,7 +89,6 @@ function repositoryIdentity(projectRoot, options = {}) {
   }
 
   let canonical = root;
-  try { canonical = fs.realpathSync.native(root); } catch { /* use resolved path */ }
   if (process.platform === 'win32') canonical = canonical.toLowerCase();
   return {
     repository_id: sha256(`local:v1:${normalizeSlashes(canonical)}`),
@@ -233,7 +237,10 @@ function openDatabase(options = {}) {
 }
 
 function normalizedRelative(projectRoot, filePath) {
-  const relative = normalizeSlashes(path.relative(projectRoot, path.resolve(filePath)));
+  const root = realpathOrResolved(projectRoot);
+  const requested = path.resolve(filePath);
+  const candidate = fs.existsSync(requested) ? realpathOrResolved(requested) : requested;
+  const relative = normalizeSlashes(path.relative(root, candidate));
   if (!relative || relative === '..' || relative.startsWith('../') || path.isAbsolute(relative)) return null;
   return relative;
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -56,7 +56,7 @@ Automatic Node.js scripts: <!-- GENERATED: hook-script-count -->35<!-- /GENERATE
 | Safety (PreToolUse) | `protect-files.js`, `external-action-gate.js`, `governance.js` | Block protected edits, gate external actions, audit tool calls |
 | Quality (PostToolUse) | `post-edit.js`, `organize-enforce.js`, `complexity-check.js` | Typecheck, file placement, advisory complexity scores |
 | Wave (PostToolBatch) | `post-tool-batch.js` | Async quality checkpoint after parallel tool waves |
-| Session | `init-project.js`, `session-end.js`, `restore-compact.js` | Scaffold state, flush telemetry, restore after compression |
+| Session | `init-project.js`, `session-end.js`, `restore-compact.js` | Scaffold state, flush telemetry, restore after compression, and sync opted-in cross-clone memory |
 | Fleet | `subagent-start.js`, `subagent-stop.js`, `worktree-setup.js` | Agent identity binding, completion logging, worktree init |
 | Consent | `permission-request.js`, `external-action-gate.js` | Auto-approve safe ops, gate pushes/PRs with user consent |
 | Signals | `instructions-loaded.js`, `file-changed.js`, `config-change.js` | React to CLAUDE.md reloads, file-on-disk changes, settings changes |
@@ -79,7 +79,9 @@ New telemetry and artifact records carry stable lineage fields (`event_id`, `run
 
 ## Campaign Files
 
-The only persistent state. Everything else is amnesiac.
+The default persistent state. An optional user-level SQLite store can preserve a
+strict durable-knowledge subset across disposable clones; active execution state
+remains repository-local. See [Cross-clone repository memory](REPOSITORY_MEMORY.md).
 
 ```markdown
 # Campaign: {name}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -135,6 +135,28 @@ result, and one exact token. `land apply` rechecks all three before a local merg
 pushes, publishes, tags, deploys, or bypasses branch protection. An ambiguous merge effect
 blocks recovery and is not repeated.
 
+## Cross-clone repository memory
+
+On Node.js 22.13+, opt into a user-level SQLite store for completed Citadel
+knowledge that must survive disposable clones:
+
+```sh
+citadel memory enable --project-root .
+citadel memory status --project-root . --json
+citadel memory sync --project-root .
+citadel memory restore --project-root .
+citadel memory versions --project-root . --path .planning/research/topic/REPORT.md
+citadel memory restore-version --project-root . --path .planning/research/topic/REPORT.md --sha256 FULL_DIGEST
+citadel memory disable --project-root .
+citadel memory purge --project-root . --confirm PURGE
+```
+
+The store is disabled by default. It hashes the normalized `origin` fetch URL
+for repository identity, retains content versions, and restores only missing
+files automatically. Existing different content is a conflict and remains
+unchanged unless `restore --force` is invoked manually. No command contacts the
+remote. See [Cross-clone repository memory](REPOSITORY_MEMORY.md).
+
 ## Packs and receipts
 
 `citadel pack` manages the local certified Pack index and lifecycle. `citadel journey` starts or completes a Pack as an Operations Protocol run, and `citadel receipt verify` checks its execution receipt offline. Missing evidence remains `unknown`.

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -12,7 +12,7 @@ You never invoke them manually. They provide automated quality enforcement and t
 | `protect-files.js` | PreToolUse | Block edits to protected files and out-of-scope paths |
 | `external-action-gate.js` | PreToolUse (Bash) | Gate external actions (git push, API calls) |
 | `governance.js` | PreToolUse (Edit/Write/Bash/Agent) | Audit every significant tool call |
-| `post-edit.js` | PostToolUse | Project-scope incremental typecheck + structural/performance/visual lenses |
+| `post-edit.js` | PostToolUse | Project-scope incremental typecheck + structural/performance/visual lenses; sync eligible opted-in memory files |
 | `organize-enforce.js` | PostToolUse (Edit/Write) | Enforce file placement conventions |
 | `circuit-breaker.js` | PostToolUse (Bash) + PostToolUseFailure | Detect failure loops |
 | `cost-tracker.js` | PostToolUse | Real-time session cost monitoring |
@@ -25,13 +25,13 @@ You never invoke them manually. They provide automated quality enforcement and t
 | `init-project.js` | SessionStart + Setup | Scaffold .planning/ state; also runs in --init-only mode |
 | `restore-compact.js` | SessionStart (compact) | Restore context after compression |
 | `intake-scanner.js` | SessionStart | Report pending work items |
-| `session-end.js` | SessionEnd | Flush session telemetry |
+| `session-end.js` | SessionEnd | Flush session telemetry and opted-in durable repository memory |
 | `subagent-start.js` | SubagentStart | Bind fleet agent identity at spawn time |
 | `subagent-stop.js` | SubagentStop | Log agent completion + flag abnormal exits |
 | `teammate-idle.js` | TeammateIdle | Log teammate idle events (multi-instance fleet) |
 | `permission-request.js` | PermissionRequest + PermissionDenied | Auto-approve safe Citadel ops, log all decisions |
 | `instructions-loaded.js` | InstructionsLoaded | Detect CLAUDE.md reloads, queue doc-sync |
-| `file-changed.js` | FileChanged | React to file-on-disk changes; queue doc-sync and skill-lint |
+| `file-changed.js` | FileChanged | React to file-on-disk changes; queue doc-sync and skill-lint; sync eligible opted-in memory files |
 | `cwd-changed.js` | CwdChanged | Log directory changes; flag when moving outside project root |
 | `config-change.js` | ConfigChange | Detect harness.json / settings.json changes mid-session |
 | `elicitation.js` | Elicitation + ElicitationResult | Log MCP elicitation requests; never auto-responds |

--- a/docs/REPOSITORY_MEMORY.md
+++ b/docs/REPOSITORY_MEMORY.md
@@ -1,0 +1,105 @@
+# Cross-clone repository memory
+
+Citadel normally keeps project state inside the repository. Cross-clone memory
+is an optional local SQLite store for people who use disposable clones and want
+completed lessons to follow another clone of the same repository.
+
+It is disabled by default, requires Node.js 22.13 or newer, and makes no network
+requests.
+
+## Enable it
+
+From the repository:
+
+```bash
+citadel memory enable
+```
+
+Enabling registers an opaque repository key and immediately snapshots the
+durable files already present. Check it at any time:
+
+```bash
+citadel memory status
+```
+
+The store is user-level, not repository-level:
+
+- Windows: `%LOCALAPPDATA%\Citadel\repository-memory.sqlite3`
+- macOS: `~/Library/Application Support/Citadel/repository-memory.sqlite3`
+- Linux: `${XDG_STATE_HOME:-~/.local/state}/citadel/repository-memory.sqlite3`
+
+`CITADEL_MEMORY_DB` can override the path for testing or managed environments.
+
+## What crosses clones
+
+Only durable, human-readable knowledge is eligible:
+
+- `.planning/campaigns/completed/**/*.md`
+- `.planning/postmortems/**/*.md`
+- `.planning/research/**/*.md`
+- `.planning/discoveries/**/*.md`
+- `.planning/intake/**/*.md`, excluding `_TEMPLATE.md`
+- `.citadel/project.md`
+
+Citadel deliberately excludes active campaigns, fleet and worktree state,
+coordination claims, locks, telemetry, screenshots, consent, runtime settings,
+credentials, and hook configuration. Each file is limited to 2 MiB and each
+sync to 50 MiB.
+
+The fetch URL for `origin` is normalized so HTTPS and SSH clones of the same
+remote share an identity. Citadel stores only its SHA-256 digest, never the raw
+remote URL or clone path as identity metadata. A repository without a portable
+network `origin` receives a path-scoped identity and does not claim cross-clone
+restoration.
+Eligible documents are stored verbatim, so their content may itself contain
+paths, URLs, or other private project context.
+
+## Automatic behavior
+
+When enabled:
+
+1. Durable file edits are captured after a successful write.
+2. Session end performs a full durable-state sync as a fallback.
+3. Session start restores missing durable files into another clone with the
+   same repository identity.
+
+Automatic restore never overwrites an existing different file. It reports the
+conflict and leaves local content unchanged. Inspect or retry explicitly:
+
+```bash
+citadel memory restore
+citadel memory restore --force
+```
+
+`--force` is intentionally manual. Every distinct content digest remains in
+the version table, so replacing the current copy does not erase older lessons.
+List or recover a specific version explicitly:
+
+```bash
+citadel memory versions --path .planning/research/topic/REPORT.md
+citadel memory restore-version \
+  --path .planning/research/topic/REPORT.md \
+  --sha256 FULL_DIGEST
+```
+
+`restore-version` also refuses to replace different local content unless
+`--force` is supplied. A successful recovery makes that digest the current
+stored copy while retaining all other versions.
+
+## Manual control and removal
+
+```bash
+citadel memory sync
+citadel memory disable
+citadel memory purge --confirm PURGE
+```
+
+`disable` stops automatic sync and restore but preserves existing records.
+`purge` deletes every stored file version for the current repository. Neither
+command changes application files or contacts a remote service.
+
+On older Node.js releases, the rest of Citadel continues to work and the memory
+command returns an explicit unavailable status. Node 22.13 is the first release
+where `node:sqlite` is available without an experimental command-line flag. This
+avoids adding a native SQLite dependency or installer-time download to Citadel's
+core.

--- a/hooks_src/file-changed.js
+++ b/hooks_src/file-changed.js
@@ -87,8 +87,18 @@ function main() {
       queueSkillLint(relative);
     }
 
+    syncRepositoryMemory(filePath, relative);
+
     process.exit(0);
   });
+}
+
+function syncRepositoryMemory(filePath, relativePath) {
+  try {
+    const memory = require('../core/memory/repository-store');
+    if (!memory.isDurablePath(relativePath)) return;
+    memory.syncRepository(PROJECT_ROOT, { filePath });
+  } catch { /* optional, best-effort, and never blocks file notifications */ }
 }
 
 function queueDocSync(relative, trigger) {

--- a/hooks_src/init-project.js
+++ b/hooks_src/init-project.js
@@ -231,6 +231,10 @@ function main() {
       PLUGIN_ROOT
     );
 
+    // 6a. Restore opted-in durable knowledge from the user-level repository
+    // store. Existing files are never overwritten by this automatic path.
+    restoreRepositoryMemory();
+
     // 6b. Record proof-backed activation milestones. This is local-only,
     // deduplicated, and can never block session initialization.
     recordActivationMilestones();
@@ -248,6 +252,21 @@ function main() {
     // Non-fatal — don't block session start
     process.exit(0);
   }
+}
+
+function restoreRepositoryMemory() {
+  try {
+    const memory = require('../core/memory/repository-store');
+    const result = memory.restoreRepository(PROJECT_ROOT);
+    if (Array.isArray(result.restored) && result.restored.length > 0) {
+      process.stdout.write(`[citadel] restored ${result.restored.length} durable memory file(s) from the user store\n`);
+    }
+    if (Array.isArray(result.conflicts) && result.conflicts.length > 0) {
+      process.stdout.write(
+        `[citadel] cross-clone memory left ${result.conflicts.length} divergent local file(s) unchanged; run citadel memory restore to inspect\n`
+      );
+    }
+  } catch { /* optional, best-effort, and never blocks session start */ }
 }
 
 function activationRuntime() {

--- a/hooks_src/post-edit.js
+++ b/hooks_src/post-edit.js
@@ -85,6 +85,11 @@ function main() {
 
     const relativePath = path.relative(PROJECT_ROOT, filePath).replace(/\\/g, '/');
 
+    // Capture durable knowledge close to the write so a disposable clone does
+    // not depend solely on a clean SessionEnd event. Non-memory edits take only
+    // the allowlist check and never open SQLite.
+    syncRepositoryMemory(filePath, relativePath);
+
     // Determine which hot-path lenses apply to this file
     const lenses = selectHotPathLenses(filePath, relativePath);
 
@@ -108,6 +113,14 @@ function main() {
     const hotBlockOnErrors = config.verification?.hotBlockOnErrors === true;
     process.exit(hotBlockOnErrors ? exitCode : 0);
   });
+}
+
+function syncRepositoryMemory(filePath, relativePath) {
+  try {
+    const memory = require('../core/memory/repository-store');
+    if (!memory.isDurablePath(relativePath)) return;
+    memory.syncRepository(PROJECT_ROOT, { filePath });
+  } catch { /* optional, best-effort, and never changes edit verification */ }
 }
 
 // ── Hot-Path Lens Dispatch ──────────────────────────────────────────────────

--- a/hooks_src/session-end.js
+++ b/hooks_src/session-end.js
@@ -112,8 +112,19 @@ function main() {
     // Write doc sync queue entry (Tier 6 - processed by next session or doc-sync hook)
     queueDocSync();
 
+    // Snapshot only opted-in durable knowledge. Active execution state,
+    // telemetry, consent, and runtime configuration never enter this store.
+    syncRepositoryMemory();
+
     process.exit(0);
   });
+}
+
+function syncRepositoryMemory() {
+  try {
+    const memory = require('../core/memory/repository-store');
+    memory.syncRepository(PROJECT_ROOT);
+  } catch { /* optional, best-effort, and never blocks session end */ }
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "update": "node scripts/update.js",
     "memory:compile": "node scripts/memory-compile.js compile",
     "memory:lint": "node scripts/memory-compile.js lint",
+    "memory:repository": "node scripts/repository-memory.js",
     "evidence:validate": "node scripts/evidence-validate.js",
     "sandbox:matrix": "node scripts/sandbox-provider.js matrix",
     "skill:catalog": "node scripts/skill-catalog.js",

--- a/scripts/repository-memory.js
+++ b/scripts/repository-memory.js
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const path = require('path');
+const memory = require('../core/memory/repository-store');
+
+const HELP = `Citadel cross-clone memory
+
+Usage:
+  citadel memory status [--project-root PATH] [--json]
+  citadel memory enable [--project-root PATH] [--json]
+  citadel memory sync [--project-root PATH] [--json]
+  citadel memory restore [--project-root PATH] [--force] [--json]
+  citadel memory versions [--project-root PATH] [--path RELATIVE] [--json]
+  citadel memory restore-version --path RELATIVE --sha256 DIGEST [--force] [--json]
+  citadel memory disable [--project-root PATH] [--json]
+  citadel memory purge [--project-root PATH] --confirm PURGE [--json]
+
+The opt-in store keeps durable Citadel knowledge in a user-level SQLite database.
+It never stores active campaigns, worktree state, telemetry, consent, or runtime
+configuration, and it never sends data over the network. Node.js 22.13+ is required
+for this optional capability; the rest of Citadel remains compatible with Node 18+.
+`;
+
+function has(args, flag) {
+  return args.includes(flag);
+}
+
+function value(args, flag, fallback = null) {
+  const inline = args.find((item) => item.startsWith(`${flag}=`));
+  if (inline) return inline.slice(flag.length + 1);
+  const index = args.indexOf(flag);
+  return index >= 0 && args[index + 1] !== undefined ? args[index + 1] : fallback;
+}
+
+function parse(argv) {
+  const command = argv[0] || 'status';
+  return {
+    command,
+    projectRoot: path.resolve(value(argv, '--project-root', process.cwd())),
+    json: has(argv, '--json'),
+    force: has(argv, '--force'),
+    confirm: value(argv, '--confirm'),
+    relativePath: value(argv, '--path'),
+    contentSha256: value(argv, '--sha256'),
+  };
+}
+
+function printHuman(result) {
+  const lines = [`Citadel memory: ${result.status}`];
+  if (result.repository_id) lines.push(`Repository key: ${result.repository_id.slice(0, 12)}`);
+  if (typeof result.portable === 'boolean') {
+    lines.push(`Cross-clone identity: ${result.portable ? 'remote-backed' : 'local-path only'}`);
+  }
+  if (result.database_path) lines.push(`Database: ${result.database_path}`);
+  if (Number.isInteger(result.entries_synced)) lines.push(`Synced: ${result.entries_synced} files (${result.versions_added} new versions)`);
+  if (Number.isInteger(result.entries)) lines.push(`Stored: ${result.entries} files, ${result.versions} versions`);
+  if (Array.isArray(result.restored)) lines.push(`Restored: ${result.restored.length} files`);
+  if (Array.isArray(result.conflicts) && result.conflicts.length) {
+    lines.push(`Conflicts left unchanged: ${result.conflicts.length}`);
+    for (const conflict of result.conflicts) lines.push(`  - ${conflict.path}`);
+  }
+  if (Array.isArray(result.skipped) && result.skipped.length) lines.push(`Skipped: ${result.skipped.length}`);
+  if (Array.isArray(result.versions)) {
+    lines.push(`Versions: ${result.versions.length}`);
+    for (const version of result.versions) {
+      lines.push(`  ${version.is_current ? '*' : ' '} ${version.relative_path} ${version.content_sha256} ${version.captured_at}`);
+    }
+  }
+  if (result.status === 'version-restored') {
+    lines.push(`Restored version: ${result.relative_path} (${result.content_sha256})`);
+  }
+  if (result.reason) lines.push(result.reason);
+  process.stdout.write(`${lines.join('\n')}\n`);
+}
+
+function main(argv = process.argv.slice(2)) {
+  if (has(argv, '--help') || has(argv, '-h')) {
+    process.stdout.write(HELP);
+    return 0;
+  }
+  const options = parse(argv);
+  let result;
+  if (options.command === 'status') result = memory.repositoryStatus(options.projectRoot);
+  else if (options.command === 'enable') result = memory.enableRepository(options.projectRoot);
+  else if (options.command === 'sync') result = memory.syncRepository(options.projectRoot);
+  else if (options.command === 'restore') result = memory.restoreRepository(options.projectRoot, { force: options.force });
+  else if (options.command === 'versions') result = memory.listVersions(options.projectRoot, { relativePath: options.relativePath });
+  else if (options.command === 'restore-version') {
+    result = memory.restoreVersion(options.projectRoot, {
+      relativePath: options.relativePath,
+      contentSha256: options.contentSha256,
+      force: options.force,
+    });
+  }
+  else if (options.command === 'disable') result = memory.disableRepository(options.projectRoot);
+  else if (options.command === 'purge') result = memory.purgeRepository(options.projectRoot, { confirm: options.confirm });
+  else {
+    const error = new Error(`Unknown memory command: ${options.command}`);
+    error.code = 'CITADEL_MEMORY_USAGE';
+    throw error;
+  }
+
+  if (options.json) process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  else printHuman(result);
+  if (result.status === 'unavailable') return 78;
+  if (options.command === 'restore-version' && ['conflict', 'corrupt-version', 'disabled', 'not-configured', 'version-not-found'].includes(result.status)) return 1;
+  return 0;
+}
+
+if (require.main === module) {
+  try {
+    process.exitCode = main();
+  } catch (error) {
+    const json = process.argv.includes('--json');
+    const payload = { status: 'error', code: error.code || 'CITADEL_MEMORY_FAILED', message: error.message };
+    if (json) process.stderr.write(`${JSON.stringify(payload)}\n`);
+    else process.stderr.write(`citadel memory: ${error.message}\n`);
+    process.exitCode = error.code === 'CITADEL_MEMORY_USAGE'
+      ? 64
+      : error.code === 'CITADEL_SQLITE_UNAVAILABLE' ? 78 : 1;
+  }
+}
+
+module.exports = Object.freeze({ HELP, main, parse });

--- a/scripts/test-all.js
+++ b/scripts/test-all.js
@@ -34,6 +34,7 @@ const RUNTIME_MATRIX_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-runtime-matr
 const TELEMETRY_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-telemetry-core.js');
 const TELEMETRY_INTEGRITY_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-telemetry-integrity.js');
 const MEMORY_BLOCK_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-memory-blocks.js');
+const REPOSITORY_MEMORY_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-repository-memory.js');
 const EVIDENCE_CONTRACT_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-evidence-contracts.js');
 const SANDBOX_PROVIDER_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-sandbox-provider.js');
 const SKILL_PACKAGING_TEST = path.join(PLUGIN_ROOT, 'scripts', 'test-skill-packaging.js');
@@ -183,6 +184,7 @@ const demoPassed = run('Demo Routing Check', DEMO_TEST);
 const telemetryPassed = run('Telemetry Core Check', TELEMETRY_TEST);
 const telemetryIntegrityPassed = run('Telemetry Integrity Check', TELEMETRY_INTEGRITY_TEST);
 const memoryBlockPassed = run('Memory Block Check', MEMORY_BLOCK_TEST);
+const repositoryMemoryPassed = run('Cross-Clone Repository Memory', REPOSITORY_MEMORY_TEST);
 const evidenceContractPassed = run('Evidence Contract Check', EVIDENCE_CONTRACT_TEST);
 const sandboxProviderPassed = run('Sandbox Provider Check', SANDBOX_PROVIDER_TEST);
 const skillPackagingPassed = run('Skill Packaging Check', SKILL_PACKAGING_TEST);
@@ -269,6 +271,7 @@ console.log(`  Demo routing check: ${demoPassed ? 'PASS' : 'FAIL'}`);
 console.log(`  Telemetry core:     ${telemetryPassed ? 'PASS' : 'FAIL'}`);
 console.log(`  Telemetry integrity: ${telemetryIntegrityPassed ? 'PASS' : 'FAIL'}`);
 console.log(`  Memory blocks:      ${memoryBlockPassed ? 'PASS' : 'FAIL'}`);
+console.log(`  Repository memory:  ${repositoryMemoryPassed ? 'PASS' : 'FAIL'}`);
 console.log(`  Evidence contracts: ${evidenceContractPassed ? 'PASS' : 'FAIL'}`);
 console.log(`  Sandbox provider:   ${sandboxProviderPassed ? 'PASS' : 'FAIL'}`);
 console.log(`  Skill packaging:    ${skillPackagingPassed ? 'PASS' : 'FAIL'}`);
@@ -341,7 +344,7 @@ for (const [label, passed] of unlockResults) {
 }
 console.log('');
 
-if (hooksPassed && securityPassed && contractsPassed && operationsProtocolPassed && appContractsPassed && supervisorClientPassed && runtimeRegistryPassed && runtimeMatrixPassed && hookEventsPassed && skillsPassed && demoPassed && telemetryPassed && telemetryIntegrityPassed && memoryBlockPassed && evidenceContractPassed && sandboxProviderPassed && skillPackagingPassed && mapSubstratePassed && deliveryPassed && deliveryPackagePassed && continueActionPassed && nextActionPassed && routePreviewPassed && loopsPassed && operatingProofPassed && usefulnessTrialPassed && operatorConsolePassed && operatorJourneyPassed && firstUseOperatorPassed && verificationPlanPassed && prReadyPassed && stackPlanPassed && deployStewardPassed && agentsMdOnlyStewardPassed && coordinationPassed && hookInstallerPassed && campaignPassed && discoveryPassed && discoveryWriterPassed && momentumPassed && momentumWatcherPassed && policyPassed && claudeRuntimePassed && codexRuntimePassed && codexNativeIntegrationPassed && codexOperationalImprovementPassed && installerPassed && cliPackagePassed && projectBootstrapPassed && compatFixturePassed && backwardCompatPassed && costTrackerPassed && dashboardPassed && docSyncPassed && fleetSessionPassed && worktreeReadinessPassed && postEditTypecheckPassed && routingSyncPassed && watchDedupPassed && teammateRebalancePassed && docSurfacesPassed && siteStoryPassed && telemetryOtlpPassed && stateHygienePassed && permissionAuditPassed && secretsLensPassed && dashboardWebPassed && dashboardPerfPassed && dashboardVisualPassed && noopDetectPassed && releaseIntegrityPassed && activationTelemetryPassed && activationCohortPassed && githubTrafficSnapshotPassed && goldenPathPassed && goldenPathMatrixPassed && productBenchmarkPassed && productProofCohortPassed && sarifCoordinatesPassed && ecosystemCompatPassed && productProofReportPassed && unlockSuitePassed) {
+if (hooksPassed && securityPassed && contractsPassed && operationsProtocolPassed && appContractsPassed && supervisorClientPassed && runtimeRegistryPassed && runtimeMatrixPassed && hookEventsPassed && skillsPassed && demoPassed && telemetryPassed && telemetryIntegrityPassed && memoryBlockPassed && repositoryMemoryPassed && evidenceContractPassed && sandboxProviderPassed && skillPackagingPassed && mapSubstratePassed && deliveryPassed && deliveryPackagePassed && continueActionPassed && nextActionPassed && routePreviewPassed && loopsPassed && operatingProofPassed && usefulnessTrialPassed && operatorConsolePassed && operatorJourneyPassed && firstUseOperatorPassed && verificationPlanPassed && prReadyPassed && stackPlanPassed && deployStewardPassed && agentsMdOnlyStewardPassed && coordinationPassed && hookInstallerPassed && campaignPassed && discoveryPassed && discoveryWriterPassed && momentumPassed && momentumWatcherPassed && policyPassed && claudeRuntimePassed && codexRuntimePassed && codexNativeIntegrationPassed && codexOperationalImprovementPassed && installerPassed && cliPackagePassed && projectBootstrapPassed && compatFixturePassed && backwardCompatPassed && costTrackerPassed && dashboardPassed && docSyncPassed && fleetSessionPassed && worktreeReadinessPassed && postEditTypecheckPassed && routingSyncPassed && watchDedupPassed && teammateRebalancePassed && docSurfacesPassed && siteStoryPassed && telemetryOtlpPassed && stateHygienePassed && permissionAuditPassed && secretsLensPassed && dashboardWebPassed && dashboardPerfPassed && dashboardVisualPassed && noopDetectPassed && releaseIntegrityPassed && activationTelemetryPassed && activationCohortPassed && githubTrafficSnapshotPassed && goldenPathPassed && goldenPathMatrixPassed && productBenchmarkPassed && productProofCohortPassed && sarifCoordinatesPassed && ecosystemCompatPassed && productProofReportPassed && unlockSuitePassed) {
   console.log('All tests pass.\n');
   console.log('Next steps:');
   console.log('  node scripts/skill-bench.js --list      see benchmark scenarios');
@@ -440,6 +443,7 @@ if (!demoPassed) console.log('Demo routing check failed. Fix routing bugs in doc
 if (!telemetryPassed) console.log('Telemetry core check failed. Fix telemetry regressions before shipping.');
 if (!telemetryIntegrityPassed) console.log('Telemetry integrity check failed. Fix hashing, IDs, signing, or verifier behavior before shipping.');
 if (!memoryBlockPassed) console.log('Memory block check failed. Fix memory compilation, source linting, or scoped load behavior before shipping.');
+if (!repositoryMemoryPassed) console.log('Repository memory check failed. Fix cross-clone identity, SQLite storage, restore conflicts, or privacy boundaries before shipping.');
 if (!evidenceContractPassed) console.log('Evidence contract check failed. Fix exit evidence parsing, validation, or repair task behavior before shipping.');
 if (!sandboxProviderPassed) console.log('Sandbox provider check failed. Fix provider capabilities, worktree status, or unsupported-provider errors before shipping.');
 if (!skillPackagingPassed) console.log('Skill packaging check failed. Fix metadata, catalog, or scaffold behavior before shipping.');

--- a/scripts/test-cli-package.js
+++ b/scripts/test-cli-package.js
@@ -69,6 +69,7 @@ for (const command of [
   'install', 'doctor', 'update', 'rollback', 'uninstall', 'pack', 'journey',
   'receipt', 'fork', 'adopt', 'config', 'governance',
   'control-plane', 'trial',
+  'memory',
 ]) {
   assert(help.stdout.includes(command), `root help missing ${command}`);
 }
@@ -84,6 +85,7 @@ assert.equal(invoke(['config', '--help']).status, 0);
 assert.equal(invoke(['governance', '--help']).status, 0);
 assert.equal(invoke(['control-plane', '--help']).status, 0);
 assert.equal(invoke(['trial', '--help']).status, 0);
+assert.equal(invoke(['memory', '--help']).status, 0);
 
 const installRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'citadel-cli-install & literal-'));
 const install = invoke(['install', '--runtime', 'codex', '--project-root', installRoot, '--plugin-only', '--dry-run', '--json']);
@@ -151,6 +153,7 @@ for (const required of [
   'package/core/config/index.js', 'package/scripts/citadel-config.js',
   'package/core/governance/index.js', 'package/scripts/governance-gate.js',
   'package/core/control-plane/index.js', 'package/scripts/control-plane-stdio.js',
+  'package/core/memory/repository-store.js', 'package/scripts/repository-memory.js',
   'package/core/product-proof/index.js', 'package/scripts/product-proof-trial.js',
   'package/schemas/harness-config-v2.schema.json',
   'package/skills/unharness/SKILL.md',

--- a/scripts/test-repository-memory.js
+++ b/scripts/test-repository-memory.js
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const memory = require('../core/memory/repository-store');
+
+const ROOT = path.resolve(__dirname, '..');
+
+function git(root, args) {
+  const result = spawnSync('git', ['-C', root, ...args], {
+    encoding: 'utf8', shell: false, stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  assert.equal(result.status, 0, result.stderr);
+}
+
+function write(root, relative, content) {
+  const target = path.join(root, ...relative.split('/'));
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, content);
+  return target;
+}
+
+function initialize(root, remote) {
+  fs.mkdirSync(root, { recursive: true });
+  git(root, ['init', '--quiet']);
+  git(root, ['remote', 'add', 'origin', remote]);
+}
+
+assert.equal(
+  memory.normalizeRemoteUrl('https://github.com/Example/Memory.git'),
+  'github.com/Example/Memory',
+);
+assert.equal(
+  memory.normalizeRemoteUrl('git@github.com:Example/Memory.git'),
+  'github.com/Example/Memory',
+);
+assert.equal(
+  memory.normalizeRemoteUrl('ssh://git@github.com/Example/Memory.git'),
+  'github.com/Example/Memory',
+);
+assert.equal(
+  memory.normalizeRemoteUrl('ssh://git@github.com:22/Example/Memory.git'),
+  'github.com/Example/Memory',
+);
+assert.equal(
+  memory.normalizeRemoteUrl('ssh://git@git.example.test:2222/Example/Memory.git'),
+  'git.example.test:2222/Example/Memory',
+);
+assert.equal(memory.normalizeRemoteUrl('../local-origin.git'), null);
+assert(memory.isDurablePath('.planning/campaigns/completed/one.md'));
+assert(memory.isDurablePath('.planning/research/fleet-topic/REPORT.md'));
+assert(memory.isDurablePath('.citadel/project.md'));
+assert(!memory.isDurablePath('.planning/campaigns/active.md'));
+assert(!memory.isDurablePath('.planning/telemetry/session.jsonl'));
+assert(!memory.isDurablePath('.planning/intake/_TEMPLATE.md'));
+assert(!memory.isDurablePath('../outside.md'));
+
+const capability = memory.sqliteCapability();
+if (!capability.available) {
+  assert.equal(capability.code, 'CITADEL_SQLITE_UNAVAILABLE');
+  process.stdout.write(`Repository memory pure-contract tests passed; SQLite exercise skipped on Node ${process.versions.node}.\n`);
+  process.exit(0);
+}
+
+const suite = fs.mkdtempSync(path.join(os.tmpdir(), 'citadel-repository-memory-'));
+const source = path.join(suite, 'source clone');
+const target = path.join(suite, 'target clone');
+const databasePath = path.join(suite, 'user-state', 'memory.sqlite3');
+initialize(source, 'https://github.com/Example/Memory.git');
+initialize(target, 'git@github.com:Example/Memory.git');
+
+const unsafeDatabasePath = path.join(suite, 'unsafe-database-target');
+fs.mkdirSync(unsafeDatabasePath, { recursive: true });
+assert.throws(
+  () => memory.enableRepository(source, { databasePath: unsafeDatabasePath }),
+  (error) => error.code === 'CITADEL_MEMORY_DB_UNSAFE',
+);
+
+write(source, '.citadel/project.md', '# Project\nDurable project context.\n');
+write(source, '.planning/campaigns/completed/alpha.md', '# Alpha\nCompleted.\n');
+const researchPath = write(source, '.planning/research/nested/note.md', '# Note\nFirst lesson.\n');
+write(source, '.planning/intake/follow-up.md', '# Follow-up\nLater.\n');
+write(source, '.planning/intake/_TEMPLATE.md', '# Template\n');
+write(source, '.planning/campaigns/active.md', '# Active\nMust stay clone-local.\n');
+write(source, '.planning/telemetry/session.jsonl', '{"private":"runtime"}\n');
+
+const enabled = memory.enableRepository(source, { databasePath });
+assert.equal(enabled.status, 'enabled');
+assert.equal(enabled.portable, true);
+assert.equal(enabled.entries_synced, 4);
+assert.equal(enabled.versions_added, 4);
+assert(fs.existsSync(databasePath));
+if (process.platform !== 'win32') {
+  assert.equal(fs.statSync(databasePath).mode & 0o077, 0, 'database must not grant group or other permissions');
+}
+const initialResearchVersions = memory.listVersions(source, {
+  databasePath,
+  relativePath: '.planning/research/nested/note.md',
+});
+assert.equal(initialResearchVersions.versions.length, 1);
+const firstLessonDigest = initialResearchVersions.versions[0].content_sha256;
+
+const sourceIdentity = memory.repositoryIdentity(source);
+const targetIdentity = memory.repositoryIdentity(target);
+assert.equal(sourceIdentity.repository_id, targetIdentity.repository_id, 'HTTPS and SSH clones must share identity');
+const databaseBytes = fs.readFileSync(databasePath);
+assert(!databaseBytes.includes(Buffer.from('github.com/Example/Memory')), 'raw remote identity must not enter SQLite');
+
+write(target, '.planning/research/nested/note.md', '# Note\nLocal divergent lesson.\n');
+const restored = memory.restoreRepository(target, { databasePath });
+assert.equal(restored.status, 'restored-with-conflicts');
+assert.equal(restored.restored.length, 3);
+assert.equal(restored.conflicts.length, 1);
+assert.equal(fs.readFileSync(path.join(target, '.planning/research/nested/note.md'), 'utf8'), '# Note\nLocal divergent lesson.\n');
+assert(!fs.existsSync(path.join(target, '.planning/campaigns/active.md')));
+assert(!fs.existsSync(path.join(target, '.planning/telemetry/session.jsonl')));
+
+const forced = memory.restoreRepository(target, { databasePath, force: true });
+assert.equal(forced.conflicts.length, 0);
+assert.equal(fs.readFileSync(path.join(target, '.planning/research/nested/note.md'), 'utf8'), '# Note\nFirst lesson.\n');
+
+fs.writeFileSync(researchPath, '# Note\nSecond lesson.\n');
+const synced = memory.syncRepository(source, { databasePath, filePath: researchPath });
+assert.equal(synced.entries_synced, 1);
+assert.equal(synced.versions_added, 1);
+const status = memory.repositoryStatus(source, { databasePath });
+assert.equal(status.status, 'enabled');
+assert.equal(status.entries, 4);
+assert.equal(status.versions, 5, 'prior content versions must be retained');
+
+fs.writeFileSync(researchPath, '# Note\nThird lesson from a file-change event.\n');
+const fileChanged = spawnSync(process.execPath, [path.join(ROOT, 'hooks_src', 'file-changed.js')], {
+  cwd: source,
+  env: { ...process.env, CLAUDE_PROJECT_DIR: source, CITADEL_MEMORY_DB: databasePath },
+  input: JSON.stringify({ file_path: researchPath, change_type: 'modified', session_id: 'memory-test' }),
+  encoding: 'utf8', shell: false, stdio: ['pipe', 'pipe', 'pipe'],
+});
+assert.equal(fileChanged.status, 0, fileChanged.stderr);
+assert.equal(memory.repositoryStatus(source, { databasePath }).versions, 6, 'file-change hook must capture durable edits');
+
+const researchVersions = memory.listVersions(source, {
+  databasePath,
+  relativePath: '.planning/research/nested/note.md',
+});
+assert.equal(researchVersions.versions.length, 3, 'all distinct lesson versions must remain recoverable');
+assert.equal(researchVersions.versions.filter((version) => version.is_current).length, 1);
+
+write(target, '.planning/research/nested/note.md', '# Note\nDo not overwrite this manually edited copy.\n');
+const versionConflict = memory.restoreVersion(target, {
+  databasePath,
+  relativePath: '.planning/research/nested/note.md',
+  contentSha256: firstLessonDigest,
+});
+assert.equal(versionConflict.status, 'conflict');
+const recoveredVersion = memory.restoreVersion(target, {
+  databasePath,
+  relativePath: '.planning/research/nested/note.md',
+  contentSha256: firstLessonDigest,
+  force: true,
+});
+assert.equal(recoveredVersion.status, 'version-restored');
+assert.equal(fs.readFileSync(path.join(target, '.planning/research/nested/note.md'), 'utf8'), '# Note\nFirst lesson.\n');
+
+const cli = spawnSync(process.execPath, [path.join(ROOT, 'bin', 'citadel.js'), 'memory', 'status', '--project-root', source, '--json'], {
+  cwd: ROOT,
+  env: { ...process.env, CITADEL_MEMORY_DB: databasePath },
+  encoding: 'utf8', shell: false, stdio: ['ignore', 'pipe', 'pipe'],
+});
+assert.equal(cli.status, 0, cli.stderr);
+assert.equal(JSON.parse(cli.stdout).versions, 6);
+
+const versionsCli = spawnSync(process.execPath, [
+  path.join(ROOT, 'bin', 'citadel.js'), 'memory', 'versions', '--project-root', source,
+  '--path', '.planning/research/nested/note.md', '--json',
+], {
+  cwd: ROOT,
+  env: { ...process.env, CITADEL_MEMORY_DB: databasePath },
+  encoding: 'utf8', shell: false, stdio: ['ignore', 'pipe', 'pipe'],
+});
+assert.equal(versionsCli.status, 0, versionsCli.stderr);
+assert.equal(JSON.parse(versionsCli.stdout).versions.length, 3);
+
+const linkedOutside = path.join(suite, 'outside-memory');
+fs.mkdirSync(linkedOutside, { recursive: true });
+write(linkedOutside, 'escaped.md', '# Outside\nNever capture through a link.\n');
+const linkedDirectory = path.join(source, '.planning', 'research', 'linked-outside');
+try {
+  fs.symlinkSync(linkedOutside, linkedDirectory, process.platform === 'win32' ? 'junction' : 'dir');
+  assert(memory.pathContainsSymlink(source, '.planning/research/linked-outside/escaped.md'));
+  const symlinkSync = memory.syncRepository(source, {
+    databasePath,
+    filePath: path.join(linkedDirectory, 'escaped.md'),
+  });
+  assert.equal(symlinkSync.entries_synced, 0);
+  assert.equal(symlinkSync.skipped[0].reason, 'symlink-path');
+} catch (error) {
+  if (!['EPERM', 'EACCES', 'ENOTSUP'].includes(error.code)) throw error;
+}
+
+const disabled = memory.disableRepository(target, { databasePath });
+assert.equal(disabled.status, 'disabled');
+assert.equal(memory.syncRepository(source, { databasePath }).status, 'disabled');
+assert.equal(memory.restoreRepository(target, { databasePath }).status, 'disabled');
+
+memory.enableRepository(source, { databasePath });
+assert.throws(
+  () => memory.purgeRepository(source, { databasePath }),
+  (error) => error.code === 'CITADEL_MEMORY_CONFIRMATION_REQUIRED',
+);
+assert.equal(memory.purgeRepository(source, { databasePath, confirm: 'PURGE' }).status, 'purged');
+assert.equal(memory.repositoryStatus(source, { databasePath }).status, 'not-enabled');
+
+fs.rmSync(suite, { recursive: true, force: true });
+process.stdout.write('Repository memory tests passed.\n');

--- a/scripts/test-repository-memory.js
+++ b/scripts/test-repository-memory.js
@@ -98,6 +98,17 @@ assert(fs.existsSync(databasePath));
 if (process.platform !== 'win32') {
   assert.equal(fs.statSync(databasePath).mode & 0o077, 0, 'database must not grant group or other permissions');
 }
+const sourceAlias = path.join(suite, 'source-alias');
+try {
+  fs.symlinkSync(source, sourceAlias, process.platform === 'win32' ? 'junction' : 'dir');
+  const aliasSync = memory.syncRepository(sourceAlias, {
+    databasePath,
+    filePath: path.join(sourceAlias, '.planning', 'research', 'nested', 'note.md'),
+  });
+  assert.equal(aliasSync.entries_synced, 1, 'filesystem aliases must resolve within the canonical Git root');
+} catch (error) {
+  if (!['EPERM', 'EACCES', 'ENOTSUP'].includes(error.code)) throw error;
+}
 const initialResearchVersions = memory.listVersions(source, {
   databasePath,
   relativePath: '.planning/research/nested/note.md',
@@ -197,7 +208,7 @@ try {
     filePath: path.join(linkedDirectory, 'escaped.md'),
   });
   assert.equal(symlinkSync.entries_synced, 0);
-  assert.equal(symlinkSync.skipped[0].reason, 'symlink-path');
+  assert(['unsafe-path', 'symlink-path'].includes(symlinkSync.skipped[0].reason));
 } catch (error) {
   if (!['EPERM', 'EACCES', 'ENOTSUP'].includes(error.code)) throw error;
 }

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -177,6 +177,28 @@ Optional integrations — choose any, or press Enter to skip all:
 **GitHub:** create `.github/workflows/` if missing; copy `.planning/_templates/claude-triage.yml` → `.github/workflows/claude-triage.yml` and `.planning/_templates/REVIEW.md` → `REVIEW.md` (skip any that already exist). Output: `"Add ANTHROPIC_API_KEY to Settings > Secrets > Actions to activate."`
 **MCP:** copy `.planning/_templates/.mcp.json` → `.mcp.json` (skip if exists). Output: `"Edit .mcp.json to uncomment the servers you want."`
 
+### Step 5b: CROSS-CLONE MEMORY (Recommended + Full Tour only)
+
+Run `node {citadelRoot}/scripts/repository-memory.js status --project-root {projectRoot} --json`.
+
+- Already `enabled`: report the stored file/version counts and do not prompt.
+- `unavailable`: skip the prompt; this optional capability requires Node.js 22.13+.
+- Otherwise ask: `"Preserve completed Citadel lessons across disposable clones in a local user-level SQLite database? [y/N]"`
+
+On yes, run:
+
+```bash
+node {citadelRoot}/scripts/repository-memory.js enable --project-root {projectRoot}
+```
+
+State exactly what is stored: completed campaigns, postmortems, research,
+discoveries, backlog Markdown, and `.citadel/project.md`. State what is excluded:
+active work, telemetry, worktrees, consent, runtime config, and credentials. Raw
+remote URLs and clone paths are excluded as identity metadata, but allowlisted
+documents are stored verbatim and may mention either. Express mode never opts in
+automatically, but an already-enabled repository continues to restore and sync
+through lifecycle hooks.
+
 ### Step 6: LIVE DEMO (Recommended + Full Tour only)
 
 **Find target file:** `git diff --name-only HEAD~1 HEAD 2>/dev/null | head -5`, filter for source files, use the most recently changed. If no git history, use `find` for recently modified files.


### PR DESCRIPTION
## Summary

- add opt-in, user-level SQLite memory for durable Citadel knowledge across disposable clones
- identify clones of the same network remote with a versioned SHA-256 key while storing no raw remote URL or clone path as identity metadata
- capture allowlisted knowledge after durable edits and at session end, then restore only missing files at session start
- retain every distinct content version and expose status, sync, restore, version listing, specific-version recovery, disable, and confirmed purge commands
- add setup guidance, privacy/security/threat-model documentation, package coverage, and a Node 22 CI matrix on Windows, macOS, and Linux

## Research and architecture

- `node:sqlite` became available without an experimental flag in Node 22.13, so the optional feature can remain dependency-free while Citadel core stays compatible with older Node releases: https://nodejs.org/download/release/latest-jod/docs/api/sqlite.html
- Node 22 remains a supported LTS line: https://nodejs.org/en/about/previous-releases
- SQLite rollback journaling plus short `BEGIN IMMEDIATE` transactions and a busy timeout fit independent short-lived hook processes without adding WAL companion-file lifecycle complexity: https://www.sqlite.org/lockingv3.html and https://sqlite.org/wal.html
- repository identity uses the fetch URL reported by `git remote get-url origin`: https://git-scm.com/docs/git-remote/2.53.0.html

The database defaults outside the checkout, is disabled until the user opts in, receives user-only permissions where supported, and must be a plain file. Automatic restore never overwrites divergent local content. Active campaigns, fleet/worktree state, telemetry, consent, runtime configuration, credentials, and hook settings are excluded. Eligible Markdown is stored verbatim and can itself contain private context, which the privacy and security docs now state directly.

## Verification

- `node scripts/test-repository-memory.js`
- `node scripts/test-cli-package.js`
- `node scripts/test-security.js`
- `node hooks_src/smoke-test.js`
- `node scripts/verify-hooks.js`
- `node scripts/integration-test.js`
- `node scripts/test-hook-installers.js`
- `node scripts/test-postedit-typecheck.js`
- `node scripts/skill-lint.js`
- `node scripts/test-doc-surfaces.js`
- `node scripts/test-routing-sync.js`
- `node scripts/test-backward-compat.js`
- `node scripts/test-release-integrity.js`
- complete strict-suite coverage split across the restricted and permissioned local environments; all feature, hook, runtime, security, packaging, lifecycle, and optimizer gates passed in their intended environment

Hosted CI adds a dedicated Node 22 repository-memory job on Ubuntu, macOS, and Windows in addition to the existing full matrix.
