### PR TITLE
feat: redesign Citadel public site

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Citadel is the progressive operating layer for Claude Code and Codex: start with /do, then add durable state, coordination, and verifiable operation control only when the work needs it." />
   <title>Citadel | The operating layer for Claude Code and Codex</title>
   <style>
     :root {
@@ -1451,22 +1452,36 @@
       .scroll-cue svg:last-child { display: none; }
     }
   </style>
+  <link rel="stylesheet" href="site-system.css" />
 </head>
-<body>
+<body class="site-page site-home">
   <canvas id="bg-dots"></canvas>
-
-  <nav>
-    <a class="nav-logo" href="https://github.com/SethGammon/Citadel">CITADEL</a>
-    <span class="nav-sep">·</span>
-    <button class="nav-link" onclick="openPanel('skills')">Skills</button>
-    <button class="nav-link" onclick="openPanel('hooks')">Hooks</button>
-    <button class="nav-link" onclick="openPanel('campaigns')">Campaigns</button>
-    <a class="nav-link" href="operation-control.html">Operation Proof</a>
-    <a class="nav-link" href="optimizer.html">Optimizer Proof</a>
-    <div class="nav-right">
-      <span class="nav-badge">v1.3</span>
-      <a class="nav-star" id="nav-star" href="https://github.com/SethGammon/Citadel">★ Star on GitHub</a>
-      <a class="nav-cta" href="#install-section" onclick="scrollToInstall(); return false;">Install Citadel</a>
+  <div class="site-scroll-progress" aria-hidden="true"><span></span></div>
+  <nav class="site-nav" aria-label="Primary navigation">
+    <div class="site-nav-inner">
+      <a class="site-brand" href="index.html"><span class="site-brand-mark">C</span><span>Citadel</span></a>
+      <div class="site-nav-links">
+        <a class="site-nav-link" href="#product-story">How it works</a>
+        <a class="site-nav-link" href="#proof">Proof</a>
+        <a class="site-nav-link" href="operation-control.html">Operation Proof</a>
+        <a class="site-nav-link" href="optimizer.html">Optimizer Proof</a>
+        <a class="site-nav-link" href="research.html">Research</a>
+        <button class="site-nav-link" type="button" onclick="openPanel('skills')">Explore</button>
+      </div>
+      <div class="site-nav-actions">
+        <a class="site-nav-github" id="nav-star" href="https://github.com/SethGammon/Citadel">GitHub</a>
+        <a class="site-nav-cta" href="#install-section">Install</a>
+        <button class="site-nav-toggle" type="button" data-site-nav-toggle aria-expanded="false" aria-controls="site-nav-mobile">Menu</button>
+      </div>
+    </div>
+    <div class="site-nav-mobile" id="site-nav-mobile" data-site-nav-mobile hidden>
+      <a class="site-nav-link" href="#product-story">How it works</a>
+      <a class="site-nav-link" href="#proof">Proof</a>
+      <a class="site-nav-link" href="operation-control.html">Operation Proof</a>
+      <a class="site-nav-link" href="optimizer.html">Optimizer Proof</a>
+      <a class="site-nav-link" href="research.html">Research program</a>
+      <button class="site-nav-link" type="button" onclick="openPanel('skills')">Explore capabilities</button>
+      <a class="site-nav-link" href="https://github.com/SethGammon/Citadel">GitHub repository</a>
     </div>
   </nav>
 
@@ -1475,27 +1490,38 @@
   <div id="screen-1">
 
   <!-- Hero -->
-  <div class="hero">
-    <div class="hero-eyebrow">
-      <span>The operating layer for Claude Code and Codex</span>
-      <span class="eyebrow-sep">·</span>
-      <span>Local · repo-native · inspectable</span>
-    </div>
-    <h1>Route the work.<br><span class="h1-sub">Keep what the agents learn.</span></h1>
-    <p>Citadel chooses the lightest capable workflow, verifies what happened, and preserves the next action in your repository.</p>
-    <div class="hero-proof" aria-label="Citadel product proof">
-      <span><strong>15/15</strong> PRs landed</span>
-      <span><strong>30/30</strong> hosted journeys</span>
-      <span><strong>2</strong> runtime surfaces</span>
-      <span><strong>3</strong> operating systems</span>
-    </div>
-    <div class="hero-outcomes" aria-label="Citadel first-success path">
-      <div class="hero-outcome"><span class="hero-outcome-step">01</span><span>Install into your repository</span></div>
-      <div class="hero-outcome"><span class="hero-outcome-step">02</span><span>Route one task with <code>/do</code></span></div>
-      <div class="hero-outcome"><span class="hero-outcome-step">03</span><span>Resume from disk with <code>/do next</code></span></div>
+  <div class="hero site-home-hero">
+    <div class="home-hero-grid">
+      <div class="home-hero-copy">
+        <div class="hero-eyebrow">The operating layer for Claude Code and Codex</div>
+        <h1>Start with <code>/do</code>.<br><span class="h1-sub">Scale when the work demands it.</span></h1>
+        <p>Citadel adds <strong>durable state, verification, recovery, and coordination</strong> around the coding agent you already use. No new IDE. No orchestration vocabulary to memorize.</p>
+        <div class="site-button-row">
+          <a class="site-button primary" href="#do-demo">Try the live router</a>
+          <a class="site-button" href="#product-story">See the work survive a session</a>
+        </div>
+        <div class="home-proof-line" aria-label="Citadel product proof">
+          <div class="home-proof-item"><strong>15/15</strong><span>PRs landed</span></div>
+          <div class="home-proof-item"><strong>30/30</strong><span>hosted journeys</span></div>
+          <div class="home-proof-item"><strong>120</strong><span>signed proof cells</span></div>
+          <div class="home-proof-item"><strong>0</strong><span>adversarial false passes</span></div>
+        </div>
+      </div>
+      <aside class="level-map" aria-label="Four progressive Citadel usage levels" data-site-reveal>
+        <div class="level-map-head"><span class="level-map-title">One entry point, four levels</span><span class="level-map-note">Most users stay at 1-2</span></div>
+        <div class="level-card active"><span class="level-number">01</span><span class="level-copy"><strong>Do the work</strong><span>Route a task and verify the result.</span></span><code class="level-command">/do &lt;request&gt;</code></div>
+        <div class="level-card"><span class="level-number">02</span><span class="level-copy"><strong>Keep going</strong><span>Resume the next action from repository state.</span></span><code class="level-command">/do next</code></div>
+        <div class="level-card"><span class="level-number">03</span><span class="level-copy"><strong>Coordinate</strong><span>Make long and parallel work visible and recoverable.</span></span><code class="level-command">campaign · fleet</code></div>
+        <div class="level-card"><span class="level-number">04</span><span class="level-copy"><strong>Control</strong><span>Constrain models, tools, privacy, cost, and proof.</span></span><code class="level-command">citadel operation</code></div>
+      </aside>
     </div>
   </div>
 
+  <section class="do-demo" id="do-demo" aria-labelledby="do-demo-title" data-site-reveal>
+  <div class="do-demo-heading">
+    <div><div class="section-kicker">Level 1 · Do</div><h2 id="do-demo-title">Describe the outcome. Citadel chooses the lane.</h2></div>
+    <p>This deterministic demo shows the routing decision. In a real repository, the selected workflow executes under your project rules and writes a handoff.</p>
+  </div>
   <!-- Search bar -->
   <div class="search-wrap">
     <div class="search-bar">
@@ -1662,13 +1688,20 @@
 
   </div><!-- /playground -->
 
+  <div class="hero-outcomes" aria-label="Citadel first-success path">
+    <div class="hero-outcome"><span class="hero-outcome-step">01</span><span>Install into your repository</span></div>
+    <div class="hero-outcome"><span class="hero-outcome-step">02</span><span>Route one task with <code>/do</code></span></div>
+    <div class="hero-outcome"><span class="hero-outcome-step">03</span><span>Resume from disk with <code>/do next</code></span></div>
+  </div>
+  </section>
+
   </div><!-- /screen-1 -->
 
   <div class="screen-2" id="screen-2">
 
   <section class="story-section" id="product-story" aria-labelledby="story-title">
     <div class="story-heading">
-      <div><h2 id="story-title">Operate a real Citadel journey</h2></div>
+      <div><div class="section-kicker">Level 2 · Continue</div><h2 id="story-title">Operate a real Citadel journey</h2></div>
       <p>Choose a task, step through the operating loop, and inspect the repository state that survives after the conversation ends.</p>
     </div>
     <div class="story-shell">
@@ -1709,7 +1742,7 @@
   <section class="operation-fork-section" id="operation-fork" aria-labelledby="operation-fork-title">
     <div class="operation-fork-inner">
       <div class="operation-fork-heading">
-        <div><h2 id="operation-fork-title">One objective. Two runtimes. One proof standard.</h2></div>
+        <div><div class="section-kicker">Level 3 · Coordinate</div><h2 id="operation-fork-title">One objective. Two runtimes. One proof standard.</h2></div>
         <p>Operation Fork runs Claude Code and Codex from the same commit, under the same workflow and verifier, then compares receipts instead of personalities.</p>
       </div>
       <div class="operation-fork-shell">
@@ -1757,6 +1790,7 @@
   <!-- Vertical tier cascade -->
   <div class="cascade-section">
     <div class="cascade-section-heading">
+      <div class="section-kicker">Under the hood</div>
       <h2>How routing works</h2>
     </div>
 
@@ -2966,111 +3000,29 @@
     });
 
     // ─── Cinematic scroll ─────────────────────────────────────────────────────
-    let currentScreen = 0, isTransitioning = false;
+    let currentScreen = 0;
 
-    // Set layout heights imperatively from measured nav
     function setupLayout() {
       const nav = document.querySelector('nav');
-      const navH = nav ? nav.offsetHeight : 48;
-      const pageH = window.innerHeight - navH;
-      document.documentElement.style.setProperty('--nav-h', navH + 'px');
-      const pageWrap = document.getElementById('page-wrap');
-      const screen1 = document.getElementById('screen-1');
-      const screen2 = document.getElementById('screen-2');
-      if (pageWrap) pageWrap.style.height = pageH + 'px';
-      if (screen1) screen1.style.height = pageH + 'px';
-      if (screen2) screen2.style.height = pageH + 'px';
+      document.documentElement.style.setProperty('--nav-h', `${nav ? nav.offsetHeight : 64}px`);
     }
     setupLayout();
     window.addEventListener('resize', setupLayout);
 
-    function easeInOutQuart(t) {
-      return t < 0.5 ? 8*t*t*t*t : 1 - Math.pow(-2*t + 2, 4) / 2;
-    }
-
     function goToScreen(n) {
-      if (isTransitioning) return;
-      if (n === currentScreen) return;
-      const inner = document.getElementById('screens-inner');
-      const h = document.getElementById('page-wrap').clientHeight;
-      const startY = currentScreen * -h;
-      const endY = n * -h;
-      const diff = endY - startY;
-      isTransitioning = true;
-      const startTime = performance.now();
-      function tick(now) {
-        const t = Math.min((now - startTime) / 780, 1);
-        inner.style.transform = `translateY(${startY + diff * easeInOutQuart(t)}px)`;
-        if (t < 1) requestAnimationFrame(tick);
-        else {
-          inner.style.transform = `translateY(${endY}px)`;
-          currentScreen = n;
-          isTransitioning = false;
-          updateScrollCue();
-          if (n === 1 && !window._statsAnimated) { window._statsAnimated = true; animateStats(); }
-          if (n === 0) {
-            const s2 = document.getElementById('screen-2');
-            if (s2) s2.scrollTop = 0;
-          }
-        }
+      currentScreen = n === 0 ? 0 : 1;
+      const target = document.getElementById(currentScreen === 0 ? 'screen-1' : 'screen-2');
+      const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      target?.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'start' });
+      if (currentScreen === 1 && !window._statsAnimated) {
+        window._statsAnimated = true;
+        animateStats();
       }
-      currentScreen = n;
-      updateScrollCue();
-      requestAnimationFrame(tick);
     }
 
-    // Wheel interception
-    let wheelAcc = 0, wheelTimer = null;
-    window.addEventListener('wheel', (e) => {
-      if (e.target.closest('.panel-body, .side-panel')) return;
-      if (isTransitioning) { e.preventDefault(); return; }
-      if (document.body.classList.contains('mode-result')) {
-        // Allow native scroll within screen-1; block everything else
-        if (e.target.closest('#screen-1')) return;
-        e.preventDefault(); return;
-      }
-      if (currentScreen === 1) {
-        const s2 = document.getElementById('screen-2');
-        const atTop = !s2 || s2.scrollTop <= 0;
-        if (e.deltaY < 0 && atTop) {
-          e.preventDefault();
-          goToScreen(0);
-        }
-        // else let screen-2 scroll naturally
-        return;
-      }
-      // On screen 1
-      e.preventDefault();
-      wheelAcc += e.deltaY;
-      clearTimeout(wheelTimer);
-      wheelTimer = setTimeout(() => { wheelAcc = 0; }, 300);
-      if (wheelAcc > 40) { wheelAcc = 0; goToScreen(1); }
-    }, { passive: false });
-
-    // Touch support
-    let touchStartY = 0;
-    window.addEventListener('touchstart', e => {
-      if (e.target.closest('.panel-body')) return;
-      touchStartY = e.touches[0].clientY;
-    }, { passive: true });
-    window.addEventListener('touchend', e => {
-      if (e.target.closest('.panel-body')) return;
-      if (isTransitioning || document.body.classList.contains('mode-result')) return;
-      const diff = touchStartY - e.changedTouches[0].clientY;
-      if (diff > 50 && currentScreen === 0) goToScreen(1);
-      else if (diff < -50 && currentScreen === 1) {
-        const s2 = document.getElementById('screen-2');
-        if (!s2 || s2.scrollTop <= 0) goToScreen(0);
-      }
-    }, { passive: true });
-
-    // Scroll cue
-    const scrollCue = document.getElementById('scroll-cue');
     function updateScrollCue() {
-      const show = currentScreen === 0 && !document.body.classList.contains('mode-result');
-      scrollCue.classList.toggle('visible', show);
+      // Retained for the router's state transitions; native scroll has no cue state.
     }
-    setTimeout(() => updateScrollCue(), 1200);
 
     // ─── Dot grid background (physics: liquid repulsion + spring) ─────────────
     (function () {
@@ -3211,38 +3163,9 @@
 
     // ─── scrollToInstall  -  bypasses cinematic snap ────────────────────────
     function scrollToInstall() {
-      const screen2 = document.getElementById('screen-2');
       const installEl = document.getElementById('install-section');
-      const doScroll = () => {
-        if (screen2 && installEl) {
-          screen2.scrollTo({ top: installEl.offsetTop, behavior: 'smooth' });
-        }
-      };
-      if (currentScreen !== 1) {
-        if (isTransitioning) return;
-        const inner = document.getElementById('screens-inner');
-        const h = document.getElementById('page-wrap').clientHeight;
-        const startY = currentScreen * -h;
-        const endY = -h;
-        const diff = endY - startY;
-        isTransitioning = true;
-        const startTime = performance.now();
-        function tick(now) {
-          const t = Math.min((now - startTime) / 780, 1);
-          inner.style.transform = `translateY(${startY + diff * easeInOutQuart(t)}px)`;
-          if (t < 1) { requestAnimationFrame(tick); }
-          else {
-            inner.style.transform = `translateY(${endY}px)`;
-            currentScreen = 1;
-            isTransitioning = false;
-            updateScrollCue();
-            doScroll();
-          }
-        }
-        requestAnimationFrame(tick);
-      } else {
-        doScroll();
-      }
+      const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      installEl?.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'start' });
     }
 
     // ─── Idle placeholder cycling ─────────────────────────────────────────
@@ -3376,5 +3299,6 @@
         .catch(() => {});
     })();
   </script>
+  <script src="site-system.js"></script>
 </body>
 </html>

--- a/docs/interactive-story-contract.md
+++ b/docs/interactive-story-contract.md
@@ -1,19 +1,22 @@
-# Citadel Interactive Product Story v2
+# Citadel Public Experience Contract v3
 
-Operation Fork is now a first-class product story beside routing and durable
-resume. The page must show one objective branching into Claude Code and Codex,
-the shared contract, branch evidence, and the honest comparison outcome. A user
-must be able to switch the same fixture between complete proof and a missing
-receipt, with the latter becoming `Insufficient evidence`, never a winner.
+The public site now has one progressive story across the product overview,
+Operation Control, Optimizer, and Research surfaces. A visitor must understand
+the useful first command before seeing the advanced machinery, then be able to
+follow every major claim to a bounded result or an explicit open gate.
+
+Native document scrolling is part of the contract. Wheel and touch input must
+never be intercepted to simulate pages, sections must be directly linkable, and
+the visible scrollbar and progress rail must communicate real page position.
 
 ## Experience identity
 
 | Variable | Status | Decision |
 |---|---|---|
-| Name | Decided | Citadel Interactive Product Story |
-| Purpose | Decided | Let a stranger operate a deterministic Citadel journey and inspect why each state changes |
-| Current problem | Decided | The existing site explains routing well but does not let visitors experience persistence, evidence, fleet coordination, or delivery proof as one system |
-| Mode | Decided | Major refinement of the existing public site |
+| Name | Decided | Citadel Public Experience |
+| Purpose | Decided | Let a stranger reach first value through `/do`, then inspect persistence, control, verification, economics, and research evidence |
+| Current problem | Decided | Citadel's complexity and strongest proof were scattered across surfaces, while custom scroll hid the story from ordinary browsing |
+| Mode | Decided | Unified public product and research system |
 
 ## User and emotional contract
 
@@ -37,7 +40,17 @@ receipt, with the latter becoming `Insufficient evidence`, never a winner.
 | Deploy steward | Decided | Serialized mainline gate |
 | Medieval ornament | Rejected | The metaphor changes structure and motion, not the page into fantasy art |
 
-## Story sequence
+## Progressive complexity
+
+1. **Level 1: Do.** `/do <request>` selects the lightest capable lane and verifies the result.
+2. **Level 2: Continue.** `/do next` restores the next action from repository state in a fresh session.
+3. **Level 3: Coordinate.** Campaigns and fleets expose durable phases, isolated worktrees, evidence, and landing order.
+4. **Level 4: Control.** Operation Control binds runtime identity, topology, tools, artifacts, economics, and independent verification.
+
+Most users can remain at levels one and two. Advanced vocabulary must not be a
+prerequisite for first value.
+
+## Interactive story sequence
 
 1. **Choose a scenario.** The visitor selects a typo, review, persistent feature, fleet migration, or deploy lane.
 2. **Route the request.** The tier cascade explains each evaluated gate and why it stopped.
@@ -90,12 +103,13 @@ Every proof receipt contains:
 
 | Layer | Decision |
 |---|---|
-| Global shell | Lightweight navigation with product, proof, install, release, and GitHub anchors |
-| Hero | One command input, scenario presets, and bounded proof strip |
+| Global shell | Shared sticky navigation with overview, operation, optimizer, research, GitHub, and one contextual action |
+| Hero | Plain operating promise, four-level map, bounded proof strip, and direct first-value action |
 | Journey stage | Left timeline, central operating surface, right repository inspector on desktop |
 | Mobile | One column with state tabs; no horizontal miniature desktop |
 | Proof gallery | Receipt grid with one expanded artifact at a time |
 | Installation | Runtime tabs followed by setup and first verified command |
+| Research | Evidence ladder, falsifiable milestones, funded targets, and demonstrated/not-demonstrated boundary |
 
 ## Visual language
 
@@ -133,7 +147,9 @@ Rules:
 
 ## Responsiveness and accessibility
 
-- Complete layouts at 1440px, 1024px, 768px, and 380px
+- Complete layouts at 1440px, 1024px, 768px, and 390px
+- No horizontal document overflow at any accepted width
+- Native vertical scrolling with a visible custom scrollbar; tables may scroll horizontally inside a labeled region
 - Keyboard path covers scenario selection, playback, inspector tabs, proof expansion, runtime tabs, and copy buttons
 - Status always uses icon or text in addition to color
 - `prefers-reduced-motion` retains all information
@@ -157,6 +173,9 @@ Rules:
 | Evidence unknown | required | required | required | required | required |
 | Deploy replay | required | required | required | required | required |
 | Install tabs | required | required | required | not applicable | required |
+| Operation prospective proof | required | required | required | required | required |
+| Optimizer evidence ledger | required | required | required | required | required |
+| Research milestones | required | required | required | required | required |
 
 ## Provisional and unknown decisions
 
@@ -178,3 +197,9 @@ The experience is ready only when a first-time visitor can answer these question
 5. What happens when evidence is missing?
 6. What real proof supports the claims?
 7. How do I install it for my runtime and reach one verified success?
+
+A technical evaluator must also be able to answer:
+
+8. What has Citadel demonstrated prospectively?
+9. Which performance and economic claims remain open?
+10. What specific research result would funding buy?

--- a/docs/operation-control.html
+++ b/docs/operation-control.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Citadel controls complete agent operations and proves what actually ran. A frozen 24-cell diagnostic against Sentient ROMA, Codex, and local Ollama models." />
+  <meta name="description" content="Citadel controls complete coding-agent operations, preserves failures, and independently verifies what actually ran. Inspect the prospective runtime cell and signed evidence history." />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 32 32%22><rect width=%2232%22 height=%2232%22 rx=%227%22 fill=%22%23070a0f%22/><path d=%22M8 8h16v5H13v6h11v5H8z%22 fill=%22%2353e2ff%22/></svg>" />
-  <title>Citadel Operation Control | Signed ROMA proof</title>
+  <title>Citadel Operation Control | Real-runtime proof</title>
   <style>
     :root {
       --ink: #f5f7fb;
@@ -412,51 +412,104 @@
       .button:hover { transform: none; }
     }
   </style>
+  <link rel="stylesheet" href="site-system.css" />
 </head>
-<body>
-  <nav>
-    <div class="shell nav-inner">
-      <a class="brand" href="index.html">CITADEL</a>
-      <span class="status">Signed actual run</span>
-      <div class="nav-links">
-        <a href="#control">Control plane</a>
-        <a href="#result">Result</a>
-        <a href="#boundary">Claim boundary</a>
-        <a href="https://github.com/SethGammon/Citadel">GitHub</a>
+<body class="site-page site-proof site-operation">
+  <div class="site-scroll-progress" aria-hidden="true"><span></span></div>
+  <nav class="site-nav" aria-label="Primary navigation">
+    <div class="site-nav-inner">
+      <a class="site-brand" href="index.html"><span class="site-brand-mark">C</span><span>Citadel</span></a>
+      <div class="site-nav-links">
+        <a class="site-nav-link" href="index.html#product-story">How it works</a>
+        <a class="site-nav-link" href="index.html#proof">Proof</a>
+        <a class="site-nav-link" href="operation-control.html" aria-current="page">Operation Control</a>
+        <a class="site-nav-link" href="optimizer.html">Optimizer</a>
+        <a class="site-nav-link" href="research.html">Research</a>
       </div>
+      <div class="site-nav-actions">
+        <a class="site-nav-github" href="https://github.com/SethGammon/Citadel">GitHub</a>
+        <a class="site-nav-cta" href="#prospective">Latest proof</a>
+        <button class="site-nav-toggle" type="button" data-site-nav-toggle aria-expanded="false" aria-controls="site-nav-mobile">Menu</button>
+      </div>
+    </div>
+    <div class="site-nav-mobile" id="site-nav-mobile" data-site-nav-mobile hidden>
+      <a class="site-nav-link" href="index.html">Overview</a>
+      <a class="site-nav-link" href="#prospective">Latest proof</a>
+      <a class="site-nav-link" href="#control">Control contract</a>
+      <a class="site-nav-link" href="#result">Earlier ROMA result</a>
+      <a class="site-nav-link" href="#boundary">Claim boundary</a>
+      <a class="site-nav-link" href="optimizer.html">Optimizer</a>
+      <a class="site-nav-link" href="research.html">Research program</a>
     </div>
   </nav>
 
   <main class="shell">
     <header class="hero">
       <div>
-        <div class="eyebrow">Stack-neutral agent operation control</div>
+        <div class="eyebrow">Outcome-aware operation control</div>
         <h1>Control the operation. <span>Prove what ran.</span></h1>
         <p class="hero-copy">
-          Citadel sits above an agent stack and binds its model assignments,
-          decomposition, concurrency, retries, tools, timeouts, and escalation
-          to a signed plan. <strong>A separate verifier decides whether the work
-          actually completed.</strong>
+          Citadel binds the requested model, topology, tools, worktree, artifact
+          scope, receipts, and verifier into one operation. <strong>The agent does
+          the work. A separate contract decides what the result proves.</strong>
         </p>
       </div>
       <aside class="claim-card" aria-label="Current claim boundary">
         <div class="claim-label">Current claim boundary</div>
-        <h2>Evidence passed. Efficiency did not.</h2>
+        <h2>Integration passed. Savings remain unproven.</h2>
         <p>
-          Citadel doubled the always-local completion rate in this six-task
-          diagnostic, but used the same number of strong whole-operation
-          attempts. The precommitted optimizer hypothesis therefore failed.
+          One preregistered Claude Code cell completed a real repository change,
+          matched its requested model and topology, and passed an independent
+          verifier. Two infrastructure failures remain visible.
         </p>
-        <code>freeze sha256:f1ecf932...2ded5<br />bundle sha256:95b49d26...7b719</code>
+        <code>v2 prospective: 1 / 3 passed<br />history: 120 signed cells<br />comparative gate: open</code>
       </aside>
     </header>
 
-    <div class="proof-strip" aria-label="Frozen diagnostic summary">
-      <div class="proof-stat"><strong>24 / 24</strong><span>frozen measured cells</span></div>
-      <div class="proof-stat"><strong>0</strong><span>false passes</span></div>
-      <div class="proof-stat"><strong>4 / 6</strong><span>Citadel verified local completions</span></div>
-      <div class="proof-stat"><strong>2 / 6</strong><span>direct 7B local completions</span></div>
+    <div class="proof-strip" aria-label="Current operation-control evidence summary">
+      <div class="proof-stat"><strong>120</strong><span>signed historical cells</span></div>
+      <div class="proof-stat"><strong>3</strong><span>preregistered runtime attempts</span></div>
+      <div class="proof-stat"><strong>1</strong><span>independently verified result</span></div>
+      <div class="proof-stat"><strong>0</strong><span>adversarial false passes</span></div>
     </div>
+
+    <section id="prospective">
+      <div class="section-heading">
+        <div><div class="proof-kicker">Current proof · prospective v2</div><h2>One real task passed. The failures stayed evidence.</h2></div>
+        <p>
+          The frozen controller invoked a public coding-agent runtime against a
+          fresh public clone, reconciled the requested model and direct topology,
+          required the declared test file to change, then handed the repository
+          to an independent verifier. Attempts that never reached model work were
+          retained instead of silently disappearing from the result.
+        </p>
+      </div>
+      <div class="prospective-panel">
+        <div class="proof-kicker">Published attempts</div>
+        <div class="attempt-grid">
+          <article class="attempt-card">
+            <span class="attempt-state">Failed</span>
+            <h3>Codex via WindowsApps</h3>
+            <p>Launch failed in 353 ms. No model or repository work was observed, so no completion was claimed.</p>
+          </article>
+          <article class="attempt-card">
+            <span class="attempt-state">Failed</span>
+            <h3>Claude in restricted sandbox</h3>
+            <p>The runtime exited nonzero after 185.6 seconds. Provider output remains private and the report records no model work.</p>
+          </article>
+          <article class="attempt-card passed">
+            <span class="attempt-state">Passed</span>
+            <h3>Claude on a fresh public clone</h3>
+            <p>Exact model and topology matched, the required artifact changed, and the independent verifier exited zero.</p>
+          </article>
+        </div>
+        <div class="evidence-note">
+          <strong>Honest economics</strong>
+          <span>Actual cash and marginal cash are unknown. Market-equivalent telemetry is $0.704256 and is labeled as such, never presented as spend.</span>
+          <a href="https://github.com/SethGammon/Citadel/blob/main/benchmarks/operation-control-v2/prospective/RESULTS.md">Inspect results →</a>
+        </div>
+      </div>
+    </section>
 
     <section id="control">
       <div class="section-heading">
@@ -469,22 +522,28 @@
         </p>
       </div>
       <div class="control-flow" aria-label="Citadel operation control flow">
-        <article class="flow-step"><small>01 / INPUT</small><h3>Frozen task</h3><p>Prompt, answer digest, stack commit, model manifests, and policy order are bound before execution.</p></article>
-        <article class="flow-step"><small>02 / PLAN</small><h3>Signed controls</h3><p>Per-module models, depth, concurrency, subtask ceiling, token budgets, tools, retries, and timeout.</p></article>
-        <article class="flow-step"><small>03 / STACK</small><h3>Sentient ROMA</h3><p>A thin adapter configures the pinned recursive solver without replacing its planning or execution logic.</p></article>
-        <article class="flow-step"><small>04 / OBSERVE</small><h3>Provider truth</h3><p>Configured modules, actual model calls, tokens, tools, nodes, status, and partial timeout evidence.</p></article>
-        <article class="flow-step"><small>05 / VERIFY</small><h3>Outcome receipt</h3><p>A deterministic verifier, content-addressed cells, and an Ed25519 bundle decide what can be claimed.</p></article>
+        <article class="flow-step"><small>01 / REQUEST</small><h3>Freeze intent</h3><p>Task, repository commit, required artifacts, executor profiles, attempt limits, and verifier are fixed before work.</p></article>
+        <article class="flow-step"><small>02 / SELECT</small><h3>Bind controls</h3><p>Requested model, topology, tools, worktree, timeouts, privacy, and cost lens become an inspectable contract.</p></article>
+        <article class="flow-step"><small>03 / EXECUTE</small><h3>Use the real stack</h3><p>Claude Code, Codex, ROMA, or another adapter does the work without Citadel impersonating its planning logic.</p></article>
+        <article class="flow-step"><small>04 / OBSERVE</small><h3>Reconcile reality</h3><p>Requested and observed model, receipts, changed paths, duration, tokens, and available cost evidence are compared.</p></article>
+        <article class="flow-step"><small>05 / VERIFY</small><h3>Bound the claim</h3><p>An independent repository verifier and signed report decide whether the operation passed, failed, or remains unknown.</p></article>
       </div>
     </section>
 
     <section id="result">
       <div class="section-heading">
-        <h2>A result that is useful because it can say no.</h2>
+        <div><div class="proof-kicker">Earlier evidence · ROMA diagnostic</div><h2>A result that is useful because it can say no.</h2></div>
         <p>
           Six previously unexecuted tasks ran under four frozen policies. Codex
           was the frontier reference. Qwen2.5-Coder 3B and 7B ran locally through
           Ollama. Citadel controlled Sentient's pinned ROMA stack module by module.
         </p>
+      </div>
+      <div class="proof-strip" aria-label="Earlier frozen ROMA diagnostic summary" style="margin-bottom:28px;">
+        <div class="proof-stat"><strong>24 / 24</strong><span>frozen measured cells</span></div>
+        <div class="proof-stat"><strong>0</strong><span>false passes</span></div>
+        <div class="proof-stat"><strong>4 / 6</strong><span>Citadel verified local completions</span></div>
+        <div class="proof-stat"><strong>2 / 6</strong><span>direct 7B local completions</span></div>
       </div>
       <div class="table-scroll" role="region" aria-label="Frozen policy result table" tabindex="0">
         <table class="result-table" data-testid="operation-result-table">
@@ -590,5 +649,6 @@
   <footer>
     <div class="shell">Citadel operation-control proof · observed 2026-07-31 · signed actual run · evidence passed · performance hypothesis failed.</div>
   </footer>
+  <script src="site-system.js"></script>
 </body>
 </html>

--- a/docs/optimizer.html
+++ b/docs/optimizer.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Citadel Optimizer: the engineering proof surface for outcome-aware economic routing across open agent stacks." />
-  <title>Citadel Optimizer | Proof before claims</title>
+  <title>Citadel Optimizer | Outcome-aware economic routing</title>
   <style>
     :root {
       --bg: #091018;
@@ -452,18 +452,34 @@
       html { scroll-behavior: auto; }
     }
   </style>
+  <link rel="stylesheet" href="site-system.css" />
 </head>
-<body>
-  <nav>
-    <div class="shell nav-inner">
-      <a class="brand" href="index.html">CITADEL</a>
-      <span class="nav-state">Engineering contract only</span>
-      <div class="nav-links">
-        <a href="#policies">Policies</a>
-        <a href="#evidence">Evidence</a>
-        <a href="#blockers">Blockers</a>
-        <a href="https://github.com/SethGammon/Citadel">GitHub</a>
+<body class="site-page site-proof site-optimizer">
+  <div class="site-scroll-progress" aria-hidden="true"><span></span></div>
+  <nav class="site-nav" aria-label="Primary navigation">
+    <div class="site-nav-inner">
+      <a class="site-brand" href="index.html"><span class="site-brand-mark">C</span><span>Citadel</span></a>
+      <div class="site-nav-links">
+        <a class="site-nav-link" href="index.html#product-story">How it works</a>
+        <a class="site-nav-link" href="index.html#proof">Proof</a>
+        <a class="site-nav-link" href="operation-control.html">Operation Control</a>
+        <a class="site-nav-link" href="optimizer.html" aria-current="page">Optimizer</a>
+        <a class="site-nav-link" href="research.html">Research</a>
       </div>
+      <div class="site-nav-actions">
+        <a class="site-nav-github" href="https://github.com/SethGammon/Citadel">GitHub</a>
+        <a class="site-nav-cta" href="#policies">Explore policies</a>
+        <button class="site-nav-toggle" type="button" data-site-nav-toggle aria-expanded="false" aria-controls="site-nav-mobile">Menu</button>
+      </div>
+    </div>
+    <div class="site-nav-mobile" id="site-nav-mobile" data-site-nav-mobile hidden>
+      <a class="site-nav-link" href="index.html">Overview</a>
+      <a class="site-nav-link" href="operation-control.html">Operation Control</a>
+      <a class="site-nav-link" href="#policies">Policies</a>
+      <a class="site-nav-link" href="#evidence">Evidence</a>
+      <a class="site-nav-link" href="#blockers">Open gates</a>
+      <a class="site-nav-link" href="research.html">Research program</a>
+      <a class="site-nav-link" href="https://github.com/SethGammon/Citadel">GitHub repository</a>
     </div>
   </nav>
 
@@ -471,17 +487,18 @@
     <header class="hero">
       <div>
         <div class="eyebrow">Outcome-aware economic routing</div>
-        <h1>Spend less. Prove the work still counts.</h1>
+        <h1>Route by evidence. <span>Keep unknowns honest.</span></h1>
         <p class="hero-copy">
           Citadel Optimizer chooses and revises the path through models,
           agents, topology, tools, retries, and stopping. <strong>Receipts and
-          verifiers prevent cheap failure from masquerading as savings.</strong>
+          independent verifiers prevent cheap failure from masquerading as savings.</strong>
         </p>
       </div>
       <aside class="claim-card" aria-label="Current claim boundary">
         <div class="claim-label">Current claim boundary</div>
-        <p>The signed actual matrix is complete. The proof contract passed and the current routing claim failed.</p>
-        <code>status: engineering-contract-only<br />actual-run: 120 / 120 signed<br />performance gate: failed</code>
+        <h2>Proof passed. Performance did not.</h2>
+        <p>The signed actual matrix is complete. Clean hosted verification passed and the current routing claim failed.</p>
+        <code>status: Engineering contract only<br />actual-run: 120 / 120 signed<br />performance gate: failed</code>
       </aside>
     </header>
 
@@ -494,7 +511,7 @@
 
     <section id="policies">
       <div class="section-heading">
-        <h2>The route is the product.</h2>
+        <div><div class="proof-kicker">Interactive contract</div><h2>The route is the product.</h2></div>
         <p>
           The benchmark holds task and verification constant while changing
           the economic policy. Explore the same Nano ID task under each policy.
@@ -552,7 +569,7 @@
 
     <section id="evidence">
       <div class="section-heading">
-        <h2>Two ledgers: what exists, what is proven.</h2>
+        <div><div class="proof-kicker">Claim discipline</div><h2>Two ledgers: what exists, what is proven.</h2></div>
         <p>
           Citadel keeps implementation maturity separate from performance
           evidence. That boundary is the difference between a credible grant
@@ -575,6 +592,7 @@
             <li>Future failed attempts retain bounded, path- and secret-redacted verifier and patch receipts.</li>
             <li>120/120 matrix cells completed and all actual-run attestations verify.</li>
             <li>The engineering gate passed with zero adversarial false passes.</li>
+            <li>The committed proof bundle passed its clean GitHub-hosted verification job.</li>
           </ul>
         </article>
         <article class="truth-card blocked">
@@ -583,7 +601,7 @@
             <li>Any matrix-level cost reduction.</li>
             <li>Adaptive routing better than prompt-only routing.</li>
             <li>A setup-complete benchmark across all three repositories.</li>
-            <li>Clean hosted verification of this committed signed proof bundle.</li>
+            <li>A prospective multi-policy comparison that meets the cost and completion target.</li>
             <li>Usefulness beyond the three frozen repositories.</li>
           </ul>
         </article>
@@ -598,7 +616,7 @@
 
     <section id="blockers">
       <div class="section-heading">
-        <h2>The proof did its job by saying no.</h2>
+        <div><div class="proof-kicker">Open research gates</div><h2>The proof did its job by saying no.</h2></div>
         <p>
           The matrix is complete, but its precommitted performance conditions
           are not. A fixture, partial cost ledger, or relabeled failure cannot
@@ -609,7 +627,7 @@
         <div class="blocker"><b>PRELIMINARY_PERFORMANCE_GATE_OPEN</b><span>Adaptive verified 6/12 held-out cells, equal to prompt-only, with a higher descriptive known-cost median.</span></div>
         <div class="blocker"><b>UNKNOWN_SETUP_COST</b><span>All 36 Nano ID cells failed setup before a model call, so unknown cost remains unknown and blocks a savings calculation.</span></div>
         <div class="blocker"><b>BENCHMARK_V2_REQUIRED</b><span>Setup preflights, task-scoped verifiers, artifact contracts, and route-sequence semantics need a new frozen method identity.</span></div>
-        <div class="blocker"><b>CLEAN_HOSTED_VERIFICATION_PENDING</b><span>The 46-file proof bundle verifies locally; the committed bundle still needs the clean GitHub-hosted job.</span></div>
+        <div class="blocker"><b>PROSPECTIVE_COMPARISON_PENDING</b><span>The controller now has a real-runtime integration pass, but it still needs a preregistered multi-policy comparison to establish savings or a quality advantage.</span></div>
       </div>
     </section>
 
@@ -642,7 +660,7 @@
 
   <footer>
     <div class="shell">
-      Citadel Optimizer proof surface · observed 2026-07-30 · 120 signed actual-run cells · current claim: engineering contract only.
+      Citadel Optimizer proof surface · observed 2026-07-31 · 120 signed actual-run cells · clean hosted verification passed · current claim: engineering contract only.
     </div>
   </footer>
 
@@ -720,5 +738,6 @@
       });
     }
   </script>
+  <script src="site-system.js"></script>
 </body>
 </html>

--- a/docs/research.html
+++ b/docs/research.html
@@ -1,0 +1,253 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="The Citadel research program: open operation control, independent outcome verification, economic evidence, current proof, and funded milestones." />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 32 32%22><rect width=%2232%22 height=%2232%22 rx=%227%22 fill=%22%23070b12%22/><path d=%22M8 8h16v5H13v6h11v5H8z%22 fill=%22%2345ddff%22/></svg>" />
+  <title>Citadel Research Program | Proof before optimization claims</title>
+  <link rel="stylesheet" href="site-system.css" />
+</head>
+<body class="site-page site-proof site-research">
+  <div class="site-scroll-progress" aria-hidden="true"><span></span></div>
+  <nav class="site-nav" aria-label="Primary navigation">
+    <div class="site-nav-inner">
+      <a class="site-brand" href="index.html"><span class="site-brand-mark">C</span><span>Citadel</span></a>
+      <div class="site-nav-links">
+        <a class="site-nav-link" href="index.html#product-story">How it works</a>
+        <a class="site-nav-link" href="operation-control.html">Operation Control</a>
+        <a class="site-nav-link" href="optimizer.html">Optimizer</a>
+        <a class="site-nav-link" href="research.html" aria-current="page">Research</a>
+      </div>
+      <div class="site-nav-actions">
+        <a class="site-nav-github" href="https://github.com/SethGammon/Citadel">GitHub</a>
+        <a class="site-nav-cta" href="#milestones">Funded work</a>
+        <button class="site-nav-toggle" type="button" data-site-nav-toggle aria-expanded="false" aria-controls="site-nav-mobile">Menu</button>
+      </div>
+    </div>
+    <div class="site-nav-mobile" id="site-nav-mobile" data-site-nav-mobile hidden>
+      <a class="site-nav-link" href="index.html">Overview</a>
+      <a class="site-nav-link" href="operation-control.html">Operation Control</a>
+      <a class="site-nav-link" href="optimizer.html">Optimizer</a>
+      <a class="site-nav-link" href="#evidence">Evidence ledger</a>
+      <a class="site-nav-link" href="#milestones">Funded milestones</a>
+      <a class="site-nav-link" href="#claims">Claim boundary</a>
+    </div>
+  </nav>
+
+  <main class="shell">
+    <header class="hero">
+      <div>
+        <div class="eyebrow">Open agent optimization research</div>
+        <h1>Make agent optimization <span>falsifiable.</span></h1>
+        <p class="hero-copy">
+          Citadel is building the evidence layer between an optimization policy
+          and its claim. It controls what an agent operation may run, records
+          what actually ran, and asks an independent verifier whether the work
+          counts. <strong>A cheaper failure is not a saving. An unknown is not zero.</strong>
+        </p>
+        <div class="site-button-row" style="margin-top:30px;">
+          <a class="site-button primary" href="#evidence">Inspect the evidence</a>
+          <a class="site-button" href="https://github.com/SethGammon/Citadel/blob/main/docs/grants/SENTIENT_OPTIMIZER_APPLICATION_DRAFT.md">Read the grant draft</a>
+        </div>
+      </div>
+      <aside class="claim-card" aria-label="Research status">
+        <div class="claim-label">Research status</div>
+        <h2>The control plane works. The economic result is still open.</h2>
+        <p>
+          Historical evidence and a prospective runtime cell establish the
+          measurement seam. They do not establish savings, broad reliability,
+          or best-in-class performance.
+        </p>
+        <code>control integration: passed<br />false-pass gate: passed<br />comparative performance: open</code>
+      </aside>
+    </header>
+
+    <div class="proof-strip" aria-label="Citadel research evidence summary">
+      <div class="proof-stat"><strong>120</strong><span>signed historical cells</span></div>
+      <div class="proof-stat"><strong>87</strong><span>real model attempts</span></div>
+      <div class="proof-stat"><strong>3</strong><span>prospective runtime attempts</span></div>
+      <div class="proof-stat"><strong>0</strong><span>adversarial false passes</span></div>
+    </div>
+
+    <section id="thesis">
+      <div class="section-heading">
+        <div><div class="proof-kicker">The research thesis</div><h2>Optimize the whole operation, then prove the outcome.</h2></div>
+        <p>
+          Prompt routing is only one decision. Real agent economics also depend
+          on topology, decomposition, retries, tools, timeouts, local versus
+          hosted execution, verification, and recovery. Citadel turns those
+          choices into a bounded contract whose result can be reproduced and
+          rejected.
+        </p>
+      </div>
+      <div class="research-thesis" data-site-reveal>
+        <article class="research-thesis-card">
+          <div class="proof-kicker">What is different</div>
+          <h3>The optimizer does not grade its own homework.</h3>
+          <p>
+            A selected executor cannot become the winner because it sounded
+            confident, reported a low number, or produced a patch. Requested
+            and observed runtime facts are reconciled, required artifacts are
+            checked, and an independent repository verifier decides completion.
+          </p>
+        </article>
+        <article class="research-thesis-card target">
+          <div class="proof-kicker">Funded target</div>
+          <h3>A result strong enough to survive a no.</h3>
+          <p>Across a preregistered multi-stack benchmark, the funded controller targets:</p>
+          <div class="target-pair">
+            <div class="target-number"><strong>≥95%</strong><span>of frontier verified completion</span></div>
+            <div class="target-number"><strong>≥30%</strong><span>lower measured end-to-end cost</span></div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section id="evidence">
+      <div class="section-heading">
+        <div><div class="proof-kicker">Evidence ladder</div><h2>What exists today, in order of claim strength.</h2></div>
+        <p>
+          Each rung answers a different question. Implementation evidence shows
+          the mechanism exists. Retrospective evidence calibrates it. Prospective
+          evidence shows the public runtime seam works. Comparative evidence is
+          the remaining research result.
+        </p>
+      </div>
+      <div class="proof-ledger">
+        <article class="proof-ledger-item">
+          <div class="ledger-id">01 / PRODUCT</div>
+          <h3>Durable operating layer</h3>
+          <p><code>/do</code>, repository state, campaigns, fleets, recovery, evidence, and handoffs work around the coding agent a developer already uses.</p>
+          <span class="ledger-state">Implemented</span>
+        </article>
+        <article class="proof-ledger-item">
+          <div class="ledger-id">02 / HISTORY</div>
+          <h3>Signed 120-cell matrix</h3>
+          <p>Ten frozen scenarios across three repositories and four economic policies preserve 33 verified, 51 failed, and 36 unknown outcomes.</p>
+          <span class="ledger-state">Verified</span>
+        </article>
+        <article class="proof-ledger-item">
+          <div class="ledger-id">03 / STACK</div>
+          <h3>Sentient ROMA binding</h3>
+          <p>A thin adapter controlled a pinned recursive solver module by module. Its 24-cell diagnostic passed the evidence gate and failed the efficiency hypothesis.</p>
+          <span class="ledger-state">Verified</span>
+        </article>
+        <article class="proof-ledger-item">
+          <div class="ledger-id">04 / RUNTIME</div>
+          <h3>Prospective public task</h3>
+          <p>One preregistered Claude Code operation on a fresh public clone matched model and topology, changed the required artifact, and passed an independent verifier.</p>
+          <span class="ledger-state">Verified</span>
+        </article>
+        <article class="proof-ledger-item">
+          <div class="ledger-id">05 / ECONOMICS</div>
+          <h3>Prospective policy comparison</h3>
+          <p>The decisive study must compare policies on unseen work with full cost attribution, frozen gates, multiple stacks, and every negative result retained.</p>
+          <span class="ledger-state open">Open gate</span>
+        </article>
+      </div>
+    </section>
+
+    <section id="milestones">
+      <div class="section-heading">
+        <div><div class="proof-kicker">Funded work</div><h2>Four milestones, each with a failure condition.</h2></div>
+        <p>
+          The grant does not fund a promise to make Citadel look intelligent.
+          It funds a public research program whose method, artifacts, cost
+          lenses, and negative results remain inspectable whether the final
+          performance target passes or fails.
+        </p>
+      </div>
+      <div class="milestone-grid">
+        <article class="milestone-card" data-step="01">
+          <small>Controller gate</small>
+          <h3>Learn operation value</h3>
+          <p>Choose models, topology, decomposition, retries, tools, and stopping from calibrated outcome evidence instead of prompt difficulty alone.</p>
+          <div class="milestone-gate">Exit: held-out decisions are reproducible and every rejected or unknown outcome remains in the ledger.</div>
+        </article>
+        <article class="milestone-card" data-step="02">
+          <small>Economic gate</small>
+          <h3>Measure the complete cost</h3>
+          <p>Separate reported, derived, market-equivalent, marginal, and end-to-end cost. Include local hardware and energy without converting missing evidence to zero.</p>
+          <div class="milestone-gate">Exit: every published comparison carries a complete cost basis or is explicitly blocked.</div>
+        </article>
+        <article class="milestone-card" data-step="03">
+          <small>Portability gate</small>
+          <h3>Generalize the adapter</h3>
+          <p>Exercise the same operation contract across multiple open and proprietary agent stacks without replacing their native planning or execution logic.</p>
+          <div class="milestone-gate">Exit: requested versus observed identity, artifacts, and outcome receipts reconcile across each stack.</div>
+        </article>
+        <article class="milestone-card" data-step="04">
+          <small>Scale gate</small>
+          <h3>Run the prospective study</h3>
+          <p>Freeze unseen tasks, baselines, policies, verifiers, stopping rules, and economic targets before execution. Publish passed, failed, and unknown cells.</p>
+          <div class="milestone-gate">Exit: the result reproduces offline and in clean hosted verification, even if the performance hypothesis fails.</div>
+        </article>
+      </div>
+    </section>
+
+    <section id="claims">
+      <div class="section-heading">
+        <div><div class="proof-kicker">Claim boundary</div><h2>Credibility comes from saying exactly where the proof ends.</h2></div>
+        <p>
+          Citadel has enough evidence to justify funding the next experiment.
+          It does not yet have enough evidence to claim the experiment's desired
+          economic result. The site and repository use the same boundary.
+        </p>
+      </div>
+      <div class="claim-boundary-list">
+        <article class="claim-boundary-column">
+          <h3>Demonstrated</h3>
+          <ul>
+            <li>Stack-neutral operation contracts can bind real agent runtimes.</li>
+            <li>Requested and observed model identity can be reconciled without inference.</li>
+            <li>Independent verification can reject false, partial, and adversarial outputs.</li>
+            <li>Signed evidence can preserve passed, failed, and unknown outcomes.</li>
+            <li>Clean hosted verification reproduces the committed proof bundle.</li>
+          </ul>
+        </article>
+        <article class="claim-boundary-column">
+          <h3>Not demonstrated</h3>
+          <ul>
+            <li>Best-in-class agent performance or broad benchmark leadership.</li>
+            <li>A general quality advantage across repositories or model families.</li>
+            <li>Lower latency than direct or frontier-only execution.</li>
+            <li>Thirty percent lower end-to-end cost at the quality target.</li>
+            <li>Production reliability across many external users and environments.</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section class="closing">
+      <article class="closing-card">
+        <div class="eyebrow">Why Sentient</div>
+        <h2>A native fit for token and economic optimization.</h2>
+        <p>
+          Sentient's product request asks for a layer that can optimize agents
+          across models and workflows. Citadel contributes the operation-level
+          control and proof discipline needed to tell a genuine economic win
+          from a cheaper failed attempt. The first ROMA adapter makes that fit
+          concrete rather than hypothetical.
+        </p>
+        <div class="links">
+          <a class="button primary" href="https://github.com/SethGammon/Citadel/tree/main/benchmarks/operation-control-v2">Inspect v2 evidence</a>
+          <a class="button" href="operation-control.html">Operation proof</a>
+          <a class="button" href="optimizer.html">Optimizer proof</a>
+          <a class="button" href="https://sentient.foundation/product-requests">Sentient request</a>
+        </div>
+      </article>
+      <aside class="closing-card">
+        <div class="claim-label">Public research principle</div>
+        <p style="font-size:22px;line-height:1.45;color:var(--site-text);">A failed frozen hypothesis is a result. A missing receipt is not.</p>
+        <p style="font:11px/1.65 var(--site-mono);color:var(--site-dim);">Observed 2026-07-31 · application not yet submitted</p>
+      </aside>
+    </section>
+  </main>
+
+  <footer>
+    <div class="shell">Citadel research program · operation control, independent verification, and honest agent economics · current performance gate open.</div>
+  </footer>
+  <script src="site-system.js"></script>
+</body>
+</html>

--- a/docs/site-system.css
+++ b/docs/site-system.css
@@ -1,0 +1,833 @@
+:root {
+  --site-bg: #070b12;
+  --site-bg-deep: #05080d;
+  --site-surface: #0d141f;
+  --site-surface-raised: #111c29;
+  --site-surface-soft: #162331;
+  --site-line: #24364a;
+  --site-line-strong: #35516c;
+  --site-text: #f2f7fb;
+  --site-muted: #a4b2c2;
+  --site-dim: #718095;
+  --site-cyan: #45ddff;
+  --site-cyan-soft: rgba(69, 221, 255, 0.1);
+  --site-green: #62e39d;
+  --site-amber: #ffc66d;
+  --site-violet: #b495ff;
+  --site-red: #ff8b87;
+  --site-shadow: 0 30px 90px rgba(0, 0, 0, 0.34);
+  --site-sans: "Segoe UI Variable", "Aptos", Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --site-mono: "SFMono-Regular", "Cascadia Code", "Roboto Mono", Consolas, monospace;
+  --site-shell: min(1240px, calc(100% - 48px));
+  --site-nav-height: 72px;
+}
+
+html {
+  color-scheme: dark;
+  scroll-behavior: smooth;
+  scrollbar-color: var(--site-cyan) var(--site-bg-deep);
+  scrollbar-width: thin;
+  background: var(--site-bg);
+}
+
+* {
+  scrollbar-color: rgba(69, 221, 255, 0.72) rgba(5, 8, 13, 0.88);
+  scrollbar-width: thin;
+}
+
+*::-webkit-scrollbar { width: 11px; height: 11px; }
+*::-webkit-scrollbar-track { background: rgba(5, 8, 13, 0.94); }
+*::-webkit-scrollbar-thumb {
+  min-height: 44px;
+  border: 3px solid rgba(5, 8, 13, 0.94);
+  border-radius: 999px;
+  background: linear-gradient(180deg, var(--site-cyan), #5c9dff);
+}
+*::-webkit-scrollbar-thumb:hover { background: linear-gradient(180deg, #7ee8ff, #83b5ff); }
+*::-webkit-scrollbar-corner { background: var(--site-bg-deep); }
+
+body.site-page {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+  color: var(--site-text);
+  font-family: var(--site-sans);
+  background:
+    radial-gradient(circle at 18% -8%, rgba(69, 221, 255, 0.13), transparent 34rem),
+    radial-gradient(circle at 92% 12%, rgba(180, 149, 255, 0.08), transparent 30rem),
+    linear-gradient(rgba(255, 255, 255, 0.022) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.022) 1px, transparent 1px),
+    var(--site-bg);
+  background-size: auto, auto, 48px 48px, 48px 48px, auto;
+  overflow-x: clip;
+}
+
+body.site-page::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  pointer-events: none;
+  background: linear-gradient(180deg, rgba(7, 11, 18, 0.04), rgba(7, 11, 18, 0.86) 78%, var(--site-bg));
+}
+
+body.site-page a { text-underline-offset: 0.22em; }
+body.site-page :focus-visible {
+  outline: 2px solid var(--site-cyan) !important;
+  outline-offset: 4px !important;
+  border-radius: 5px;
+}
+
+.site-scroll-progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1000;
+  width: 100%;
+  height: 2px;
+  pointer-events: none;
+}
+
+.site-scroll-progress span {
+  display: block;
+  width: 0;
+  height: 100%;
+  background: linear-gradient(90deg, var(--site-cyan), #63a6ff, var(--site-violet));
+  box-shadow: 0 0 18px rgba(69, 221, 255, 0.55);
+  transition: width 80ms linear;
+}
+
+.site-nav {
+  position: sticky;
+  top: 0;
+  z-index: 900;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  border-bottom: 1px solid rgba(53, 81, 108, 0.62);
+  background: rgba(7, 11, 18, 0.82);
+  backdrop-filter: blur(20px) saturate(130%);
+  -webkit-backdrop-filter: blur(20px) saturate(130%);
+}
+
+.site-nav-inner {
+  width: var(--site-shell);
+  min-height: var(--site-nav-height);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+}
+
+.site-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 11px;
+  color: var(--site-text);
+  text-decoration: none;
+  font: 800 14px/1 var(--site-mono);
+  letter-spacing: 0.19em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.site-brand-mark {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid rgba(69, 221, 255, 0.48);
+  border-radius: 9px;
+  color: var(--site-cyan);
+  background: linear-gradient(145deg, rgba(69, 221, 255, 0.13), rgba(69, 221, 255, 0.025));
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.08), 0 0 24px rgba(69, 221, 255, 0.08);
+  font-size: 13px;
+  letter-spacing: 0;
+}
+
+.site-nav-links {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: 16px;
+}
+
+.site-nav-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 40px;
+  padding: 0 11px;
+  border: 0;
+  border-radius: 9px;
+  color: var(--site-muted);
+  background: transparent;
+  font: 600 13px/1 var(--site-sans);
+  text-decoration: none;
+  cursor: pointer;
+  transition: color 160ms ease, background 160ms ease;
+}
+
+.site-nav-link:hover,
+.site-nav-link[aria-current="page"] {
+  color: var(--site-text);
+  background: rgba(255, 255, 255, 0.045);
+}
+
+.site-nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-left: auto;
+}
+
+.site-nav-github,
+.site-nav-cta,
+.site-nav-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 42px;
+  padding: 0 15px;
+  border: 1px solid var(--site-line);
+  border-radius: 10px;
+  font: 700 12px/1 var(--site-sans);
+  text-decoration: none;
+  cursor: pointer;
+  transition: transform 160ms ease, border-color 160ms ease, background 160ms ease, color 160ms ease;
+}
+
+.site-nav-github { color: var(--site-muted); background: rgba(255, 255, 255, 0.035); }
+.site-nav-cta { color: #031017; border-color: var(--site-cyan); background: var(--site-cyan); }
+.site-nav-github:hover { color: var(--site-text); border-color: var(--site-line-strong); }
+.site-nav-cta:hover { transform: translateY(-1px); background: #7be8ff; }
+.site-nav-toggle { display: none; color: var(--site-text); background: var(--site-surface); }
+
+.site-nav-mobile {
+  display: none;
+  width: var(--site-shell);
+  margin: 0 auto;
+  padding: 0 0 14px;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+
+.site-nav-mobile[hidden] { display: none; }
+.site-nav-mobile .site-nav-link { border: 1px solid rgba(36, 54, 74, 0.72); background: rgba(13, 20, 31, 0.9); }
+
+.site-shell { width: var(--site-shell); margin: 0 auto; }
+.site-kicker,
+.section-kicker {
+  color: var(--site-cyan);
+  font: 750 11px/1.2 var(--site-mono);
+  letter-spacing: 0.17em;
+  text-transform: uppercase;
+}
+
+.site-button-row { display: flex; align-items: center; flex-wrap: wrap; gap: 10px; }
+.site-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: 0 18px;
+  border: 1px solid var(--site-line-strong);
+  border-radius: 11px;
+  color: var(--site-text);
+  background: rgba(13, 20, 31, 0.84);
+  font: 750 13px/1 var(--site-sans);
+  text-decoration: none;
+  transition: transform 160ms ease, border-color 160ms ease, background 160ms ease;
+}
+.site-button:hover { transform: translateY(-2px); border-color: var(--site-cyan); background: var(--site-cyan-soft); }
+.site-button.primary { color: #031017; border-color: var(--site-cyan); background: var(--site-cyan); }
+.site-button.primary:hover { background: #7be8ff; }
+
+/* Homepage: native scroll and progressive first-use story */
+body.site-home {
+  height: auto;
+  overflow-y: auto;
+  display: block;
+  align-items: initial;
+  user-select: text;
+  -webkit-user-select: text;
+}
+
+.site-home #bg-dots { opacity: 0.5; }
+.site-home #page-wrap {
+  width: 100%;
+  height: auto !important;
+  min-height: 0;
+  overflow: visible;
+  position: static;
+}
+.site-home #screens-inner {
+  position: static;
+  inset: auto;
+  transform: none !important;
+  will-change: auto;
+}
+.site-home #screen-1 {
+  width: 100%;
+  height: auto !important;
+  min-height: calc(100svh - var(--site-nav-height));
+  justify-content: flex-start;
+  overflow: visible;
+  padding: 82px 0 72px;
+}
+.site-home #screen-2 {
+  width: 100%;
+  height: auto !important;
+  overflow: visible !important;
+}
+
+.site-home .hero.site-home-hero {
+  width: var(--site-shell);
+  max-width: none;
+  padding: 0;
+  text-align: left;
+}
+
+.home-hero-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.18fr) minmax(360px, 0.82fr);
+  gap: clamp(48px, 7vw, 96px);
+  align-items: center;
+}
+
+.home-hero-copy { min-width: 0; }
+.site-home .hero-eyebrow {
+  display: inline-flex;
+  max-height: none;
+  margin: 0 0 24px;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: none;
+  color: var(--site-cyan);
+  font: 750 11px/1.4 var(--site-mono);
+  letter-spacing: 0.17em;
+}
+.site-home .hero h1 {
+  max-width: 760px;
+  max-height: none;
+  margin: 0 0 24px;
+  overflow: visible;
+  color: var(--site-text);
+  background: none;
+  -webkit-text-fill-color: currentColor;
+  animation: none;
+  font-size: clamp(52px, 6.2vw, 88px);
+  font-weight: 780;
+  line-height: 0.98;
+  letter-spacing: -0.06em;
+  text-wrap: balance;
+}
+.site-home .hero h1 code { color: var(--site-cyan); font: inherit; }
+.site-home .hero h1 .h1-sub { color: var(--site-muted); }
+.site-home .hero p {
+  max-width: 700px;
+  max-height: none;
+  margin: 0 0 30px;
+  overflow: visible;
+  color: var(--site-muted);
+  font-size: clamp(18px, 1.8vw, 22px);
+  line-height: 1.62;
+}
+.site-home .hero p strong { color: var(--site-text); }
+
+.home-proof-line {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0;
+  margin-top: 36px;
+  border-top: 1px solid var(--site-line);
+}
+.home-proof-item { padding: 18px 18px 0 0; }
+.home-proof-item + .home-proof-item { padding-left: 18px; border-left: 1px solid var(--site-line); }
+.home-proof-item strong { display: block; color: var(--site-green); font: 750 18px/1 var(--site-mono); }
+.home-proof-item span { display: block; margin-top: 7px; color: var(--site-dim); font: 11px/1.45 var(--site-mono); }
+
+.level-map {
+  position: relative;
+  padding: 20px;
+  border: 1px solid var(--site-line);
+  border-radius: 22px;
+  background: linear-gradient(155deg, rgba(17, 28, 41, 0.96), rgba(8, 13, 21, 0.94));
+  box-shadow: var(--site-shadow);
+  overflow: hidden;
+}
+.level-map::before {
+  content: "";
+  position: absolute;
+  width: 260px;
+  height: 260px;
+  right: -110px;
+  top: -120px;
+  border-radius: 50%;
+  background: rgba(69, 221, 255, 0.1);
+  filter: blur(34px);
+}
+.level-map-head { position: relative; display: flex; align-items: center; justify-content: space-between; margin: 2px 2px 17px; }
+.level-map-title { color: var(--site-text); font: 750 13px/1 var(--site-sans); }
+.level-map-note { color: var(--site-dim); font: 10px/1 var(--site-mono); text-transform: uppercase; letter-spacing: 0.09em; }
+.level-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr) auto;
+  gap: 13px;
+  align-items: center;
+  min-height: 84px;
+  padding: 14px 15px;
+  border: 1px solid rgba(53, 81, 108, 0.72);
+  border-radius: 14px;
+  background: rgba(13, 20, 31, 0.8);
+}
+.level-card + .level-card { margin-top: 9px; }
+.level-card::after {
+  content: "";
+  position: absolute;
+  left: 35px;
+  bottom: -10px;
+  width: 1px;
+  height: 9px;
+  background: var(--site-line-strong);
+}
+.level-card:last-child::after { display: none; }
+.level-card.active { border-color: rgba(69, 221, 255, 0.72); background: linear-gradient(100deg, rgba(69, 221, 255, 0.13), rgba(13, 20, 31, 0.84)); }
+.level-number { display: grid; place-items: center; width: 34px; height: 34px; border: 1px solid var(--site-line-strong); border-radius: 10px; color: var(--site-muted); font: 750 11px/1 var(--site-mono); }
+.level-card.active .level-number { color: #031017; border-color: var(--site-cyan); background: var(--site-cyan); }
+.level-copy strong { display: block; margin-bottom: 5px; color: var(--site-text); font-size: 14px; }
+.level-copy span { display: block; color: var(--site-muted); font-size: 12px; line-height: 1.45; }
+.level-command { color: var(--site-cyan); font: 11px/1 var(--site-mono); white-space: nowrap; }
+
+.do-demo {
+  width: var(--site-shell);
+  margin: 66px auto 0;
+  padding: 26px;
+  border: 1px solid var(--site-line);
+  border-radius: 20px;
+  background: rgba(9, 15, 24, 0.76);
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.035);
+  scroll-margin-top: calc(var(--site-nav-height) + 18px);
+}
+.do-demo-heading { display: flex; align-items: end; justify-content: space-between; gap: 32px; padding: 2px 4px 22px; }
+.do-demo-heading h2 { margin: 8px 0 0; color: var(--site-text); font-size: clamp(24px, 3vw, 36px); letter-spacing: -0.04em; }
+.do-demo-heading p { max-width: 500px; margin: 0; color: var(--site-muted); font-size: 14px; line-height: 1.6; }
+.site-home .search-wrap { width: 100%; max-width: none; margin: 0; padding: 0; }
+.site-home #cmd-input { padding-right: 76px; border-color: var(--site-line-strong); background: var(--site-surface); }
+.site-home .search-actions .live-badge { display: none; }
+.site-home .playground { width: 100%; max-width: none; padding: 0; }
+.site-home .generators { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; margin: 18px 0 0; }
+.site-home .gen-btn { min-width: 0; padding: 16px; border-color: var(--site-line); background: rgba(17, 28, 41, 0.82); animation: none; }
+.site-home .gen-btn:hover { transform: translateY(-2px); }
+.site-home .gen-again { display: none; }
+.site-home .hero-outcomes {
+  max-width: none;
+  margin: 18px 0 0;
+  border-color: var(--site-line);
+  background: rgba(13, 20, 31, 0.72);
+}
+.site-home .hero-outcome { min-height: 48px; padding: 10px 13px; }
+
+.site-home .story-section,
+.site-home .operation-fork-section,
+.site-home .proof-section,
+.site-home .cascade-section,
+.site-home .stat-bar,
+.site-home .install-section,
+.site-home .final-cta,
+.site-home footer {
+  scroll-margin-top: calc(var(--site-nav-height) + 18px);
+}
+.site-home .story-section { padding-top: 112px; }
+.site-home .story-heading,
+.site-home .operation-fork-heading,
+.site-home .proof-heading { align-items: start; }
+.site-home .story-heading h2,
+.site-home .operation-fork-heading h2,
+.site-home .proof-heading h2,
+.site-home .cascade-section-heading h2 {
+  margin-top: 10px;
+  font-size: clamp(34px, 4.2vw, 56px);
+  line-height: 1.02;
+  letter-spacing: -0.055em;
+}
+.site-home .scroll-cue { display: none !important; }
+.site-home .up-cue { position: fixed; right: 22px; bottom: 22px; z-index: 40; }
+
+/* Routing expands the result in place; it never collapses or removes the story. */
+body.site-home.mode-result .hero.site-home-hero { padding: 0; }
+body.site-home.mode-result .hero-eyebrow {
+  max-height: none;
+  margin: 0 0 24px;
+  opacity: 1;
+}
+body.site-home.mode-result .hero h1 {
+  display: block;
+  max-height: none;
+  margin: 0 0 24px;
+  overflow: visible;
+  opacity: 1;
+}
+body.site-home.mode-result .hero h1 br,
+body.site-home.mode-result .hero h1 .h1-sub { display: initial; }
+body.site-home.mode-result .hero p { max-height: none; opacity: 1; }
+body.site-home.mode-result .search-wrap { padding-top: 0; }
+body.site-home.mode-result .search-hint { display: block; }
+body.site-home.mode-result .generators {
+  max-height: none;
+  margin: 18px 0 0;
+  opacity: 1;
+}
+body.site-home.mode-result .screen-2 { display: block; }
+body.site-home.mode-result .stat-bar { display: grid; }
+body.site-home.mode-result footer { display: block; }
+body.site-home.mode-result #screen-1 { overflow: visible; }
+body.site-home.mode-result #screen-1::-webkit-scrollbar { display: initial; }
+
+.site-reveal { opacity: 0; transform: translateY(18px); transition: opacity 480ms ease, transform 480ms ease; }
+.site-reveal.is-visible { opacity: 1; transform: none; }
+
+/* Evidence pages: one editorial system for operation, optimizer, and research. */
+body.site-proof {
+  --ink: var(--site-text);
+  --text: var(--site-text);
+  --muted: var(--site-muted);
+  --dim: var(--site-dim);
+  --night: var(--site-bg);
+  --bg: var(--site-bg);
+  --panel: var(--site-surface);
+  --panel-2: var(--site-surface-raised);
+  --surface: var(--site-surface);
+  --border: var(--site-line);
+  --line: var(--site-line);
+  --cyan: var(--site-cyan);
+  --green: var(--site-green);
+  --amber: var(--site-amber);
+  --purple: var(--site-violet);
+  --red: var(--site-red);
+  --mono: var(--site-mono);
+  --sans: var(--site-sans);
+}
+
+.site-proof .shell {
+  width: var(--site-shell);
+  max-width: none;
+  margin-inline: auto;
+}
+
+.site-proof main.shell { padding-bottom: 48px; }
+.site-proof .site-nav .site-nav-inner { width: var(--site-shell); }
+.site-proof .site-nav-mobile { width: var(--site-shell); }
+
+.site-proof .hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.22fr) minmax(340px, 0.78fr);
+  gap: clamp(52px, 7vw, 96px);
+  align-items: center;
+  padding: clamp(80px, 10vw, 132px) 0 64px;
+}
+
+.site-proof .eyebrow {
+  color: var(--site-cyan);
+  font: 750 11px/1.35 var(--site-mono);
+  letter-spacing: 0.17em;
+}
+
+.site-proof h1 {
+  max-width: 900px;
+  margin: 20px 0 25px;
+  color: var(--site-text);
+  font-size: clamp(54px, 6.5vw, 92px);
+  font-weight: 780;
+  line-height: 0.97;
+  letter-spacing: -0.062em;
+  text-wrap: balance;
+}
+
+.site-proof h1 span { color: var(--site-cyan); }
+.site-proof .hero-copy { max-width: 760px; color: var(--site-muted); font-size: clamp(18px, 1.8vw, 22px); line-height: 1.65; }
+.site-proof .hero-copy strong { color: var(--site-text); }
+
+.site-proof .claim-card {
+  position: relative;
+  padding: 26px;
+  border: 1px solid var(--site-line-strong);
+  border-radius: 19px;
+  background: linear-gradient(150deg, rgba(17, 28, 41, 0.97), rgba(8, 13, 21, 0.96));
+  box-shadow: var(--site-shadow);
+  overflow: hidden;
+}
+
+.site-proof .claim-card::after {
+  content: "";
+  position: absolute;
+  width: 180px;
+  height: 180px;
+  top: -100px;
+  right: -90px;
+  border-radius: 50%;
+  background: rgba(69, 221, 255, 0.13);
+  filter: blur(26px);
+}
+
+.site-proof .claim-label { color: var(--site-amber); font: 750 10px/1.2 var(--site-mono); letter-spacing: 0.14em; }
+.site-proof .claim-card h2 { position: relative; margin: 14px 0 11px; color: var(--site-text); font-size: clamp(24px, 2.6vw, 33px); line-height: 1.12; letter-spacing: -0.035em; }
+.site-proof .claim-card p { position: relative; color: var(--site-muted); font-size: 15px; line-height: 1.66; }
+.site-proof .claim-card code { position: relative; color: var(--site-dim); }
+
+.site-proof .proof-strip {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border: 1px solid var(--site-line);
+  border-radius: 16px;
+  background: rgba(10, 16, 25, 0.84);
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.035);
+}
+
+.site-proof .proof-stat { min-height: 128px; padding: 23px; }
+.site-proof .proof-stat + .proof-stat { border-color: var(--site-line); }
+.site-proof .proof-stat strong { color: var(--site-green); font: 750 30px/1 var(--site-mono); }
+.site-proof .proof-stat span { color: var(--site-muted); font: 11px/1.55 var(--site-mono); }
+
+.site-proof section {
+  padding: clamp(76px, 8vw, 112px) 0;
+  scroll-margin-top: calc(var(--site-nav-height) + 18px);
+}
+
+.site-proof section + section { border-top: 1px solid rgba(36, 54, 74, 0.64); }
+.site-proof .section-heading { grid-template-columns: minmax(280px, 0.78fr) minmax(0, 1.22fr); gap: clamp(36px, 7vw, 92px); margin-bottom: 42px; }
+.site-proof .section-heading h2,
+.site-proof .closing h2 {
+  color: var(--site-text);
+  font-size: clamp(36px, 4.6vw, 60px);
+  line-height: 1.02;
+  letter-spacing: -0.055em;
+  text-wrap: balance;
+}
+.site-proof .section-heading p { color: var(--site-muted); font-size: 17px; line-height: 1.75; }
+
+.proof-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  margin-bottom: 16px;
+  color: var(--site-cyan);
+  font: 750 10px/1.2 var(--site-mono);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+.proof-kicker::before { content: ""; width: 22px; height: 1px; background: currentColor; }
+
+.prospective-panel {
+  padding: clamp(24px, 4vw, 44px);
+  border: 1px solid var(--site-line-strong);
+  border-radius: 22px;
+  background: linear-gradient(145deg, rgba(14, 24, 36, 0.95), rgba(8, 13, 21, 0.92));
+  box-shadow: var(--site-shadow);
+}
+
+.attempt-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; margin-top: 28px; }
+.attempt-card {
+  min-height: 190px;
+  padding: 20px;
+  border: 1px solid var(--site-line);
+  border-radius: 14px;
+  background: rgba(13, 20, 31, 0.78);
+}
+.attempt-card.passed { border-color: rgba(98, 227, 157, 0.48); background: linear-gradient(145deg, rgba(98, 227, 157, 0.09), rgba(13, 20, 31, 0.82)); }
+.attempt-state { display: inline-flex; min-height: 24px; align-items: center; padding: 0 8px; border: 1px solid rgba(255, 139, 135, 0.38); border-radius: 999px; color: var(--site-red); font: 750 9px/1 var(--site-mono); letter-spacing: 0.09em; text-transform: uppercase; }
+.attempt-card.passed .attempt-state { color: var(--site-green); border-color: rgba(98, 227, 157, 0.42); }
+.attempt-card h3 { margin: 22px 0 9px; color: var(--site-text); font-size: 17px; }
+.attempt-card p { margin: 0; color: var(--site-muted); font-size: 13px; line-height: 1.6; }
+
+.evidence-note {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 15px;
+  align-items: center;
+  margin-top: 14px;
+  padding: 17px 18px;
+  border: 1px solid var(--site-line);
+  border-radius: 13px;
+  color: var(--site-muted);
+  background: rgba(5, 8, 13, 0.48);
+  font-size: 13px;
+  line-height: 1.55;
+}
+.evidence-note strong { color: var(--site-amber); font: 750 11px/1 var(--site-mono); text-transform: uppercase; letter-spacing: 0.08em; }
+.evidence-note a { color: var(--site-cyan); font: 700 12px/1 var(--site-sans); text-decoration: none; }
+
+.site-proof .control-flow,
+.site-proof .route-flow { gap: 12px; }
+.site-proof .flow-step,
+.site-proof .route-step,
+.site-proof .truth-card,
+.site-proof .boundary-card,
+.site-proof .case-card,
+.site-proof .blocker,
+.site-proof .closing-card,
+.site-proof .policy-lab {
+  border-color: var(--site-line);
+  background: linear-gradient(150deg, rgba(17, 28, 41, 0.86), rgba(9, 14, 22, 0.9));
+  box-shadow: inset 0 1px rgba(255, 255, 255, 0.035);
+}
+.site-proof .flow-step { min-height: 210px; border-radius: 14px; }
+.site-proof .flow-step:not(:last-child)::after { background: var(--site-bg); }
+.site-proof .flow-step p,
+.site-proof .route-step span,
+.site-proof .truth-card li,
+.site-proof .boundary-card li,
+.site-proof .blocker span { color: var(--site-muted); }
+
+.site-proof .table-scroll {
+  border: 1px solid var(--site-line);
+  border-radius: 15px;
+  background: rgba(7, 11, 18, 0.72);
+  overflow-x: auto;
+}
+.site-proof table { background: transparent; }
+.site-proof th { color: var(--site-dim); background: rgba(13, 20, 31, 0.92); }
+.site-proof td, .site-proof th { border-color: var(--site-line); }
+.site-proof tbody tr:hover { background: rgba(69, 221, 255, 0.035); }
+.site-proof .receipt { border-color: var(--site-line-strong); border-radius: 14px; color: var(--site-muted); background: rgba(5, 8, 13, 0.74); }
+.site-proof .button { min-height: 47px; border-color: var(--site-line-strong); border-radius: 10px; }
+.site-proof .button.primary { color: #031017; border-color: var(--site-cyan); background: var(--site-cyan); }
+.site-proof footer { border-color: var(--site-line); color: var(--site-dim); background: var(--site-bg-deep); }
+
+.research-thesis {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
+  gap: 14px;
+}
+.research-thesis-card {
+  padding: clamp(24px, 4vw, 42px);
+  border: 1px solid var(--site-line);
+  border-radius: 20px;
+  background: linear-gradient(145deg, rgba(17, 28, 41, 0.9), rgba(8, 13, 21, 0.92));
+}
+.research-thesis-card h3 { margin: 12px 0 16px; color: var(--site-text); font-size: clamp(25px, 3vw, 38px); line-height: 1.12; letter-spacing: -0.04em; }
+.research-thesis-card p { margin: 0; color: var(--site-muted); font-size: 16px; line-height: 1.72; }
+.research-thesis-card.target { border-color: rgba(98, 227, 157, 0.34); }
+.target-pair { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-top: 26px; }
+.target-number { padding: 18px; border: 1px solid var(--site-line); border-radius: 13px; background: rgba(5, 8, 13, 0.48); }
+.target-number strong { display: block; color: var(--site-green); font: 750 clamp(28px, 4vw, 44px)/1 var(--site-mono); }
+.target-number span { display: block; margin-top: 9px; color: var(--site-muted); font-size: 12px; line-height: 1.45; }
+
+.proof-ledger { border-top: 1px solid var(--site-line); }
+.proof-ledger-item {
+  display: grid;
+  grid-template-columns: 90px minmax(220px, 0.72fr) minmax(0, 1.28fr) auto;
+  gap: 24px;
+  align-items: start;
+  padding: 27px 0;
+  border-bottom: 1px solid var(--site-line);
+}
+.proof-ledger-item .ledger-id { color: var(--site-dim); font: 750 11px/1.4 var(--site-mono); }
+.proof-ledger-item h3 { margin: 0; color: var(--site-text); font-size: 19px; letter-spacing: -0.025em; }
+.proof-ledger-item p { margin: 0; color: var(--site-muted); font-size: 14px; line-height: 1.65; }
+.ledger-state { display: inline-flex; min-height: 27px; align-items: center; padding: 0 9px; border: 1px solid rgba(98, 227, 157, 0.4); border-radius: 999px; color: var(--site-green); font: 750 9px/1 var(--site-mono); letter-spacing: 0.08em; text-transform: uppercase; white-space: nowrap; }
+.ledger-state.open { color: var(--site-amber); border-color: rgba(255, 198, 109, 0.42); }
+
+.milestone-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+.milestone-card { position: relative; min-height: 260px; padding: 26px; border: 1px solid var(--site-line); border-radius: 16px; background: rgba(13, 20, 31, 0.78); overflow: hidden; }
+.milestone-card::before { content: attr(data-step); position: absolute; right: 16px; top: 9px; color: rgba(69, 221, 255, 0.08); font: 800 72px/1 var(--site-mono); }
+.milestone-card small { position: relative; color: var(--site-cyan); font: 750 10px/1 var(--site-mono); letter-spacing: 0.12em; }
+.milestone-card h3 { position: relative; margin: 35px 0 12px; color: var(--site-text); font-size: 22px; letter-spacing: -0.035em; }
+.milestone-card p { position: relative; margin: 0; color: var(--site-muted); font-size: 14px; line-height: 1.65; }
+.milestone-gate { position: relative; margin-top: 18px; padding-top: 16px; border-top: 1px solid var(--site-line); color: var(--site-dim); font: 11px/1.5 var(--site-mono); }
+
+.claim-boundary-list { display: grid; grid-template-columns: 1fr 1fr; border: 1px solid var(--site-line); border-radius: 18px; overflow: hidden; }
+.claim-boundary-column { padding: clamp(24px, 4vw, 40px); background: rgba(13, 20, 31, 0.78); }
+.claim-boundary-column + .claim-boundary-column { border-left: 1px solid var(--site-line); background: rgba(8, 13, 21, 0.82); }
+.claim-boundary-column h3 { margin: 0 0 20px; color: var(--site-text); font-size: 23px; }
+.claim-boundary-column ul { margin: 0; padding-left: 19px; color: var(--site-muted); }
+.claim-boundary-column li { margin: 10px 0; padding-left: 5px; font-size: 14px; line-height: 1.58; }
+
+@media (max-width: 1080px) {
+  .site-proof .hero { grid-template-columns: 1fr; gap: 40px; }
+  .site-proof .claim-card { max-width: 760px; }
+  .site-proof .control-flow { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .site-proof .flow-step:not(:last-child)::after { display: none; }
+}
+
+@media (max-width: 760px) {
+  .site-proof .hero { padding: 64px 0 46px; }
+  .site-proof h1 { font-size: clamp(46px, 14vw, 66px); }
+  .site-proof .hero-copy { font-size: 18px; }
+  .site-proof .proof-strip { grid-template-columns: 1fr 1fr; }
+  .site-proof .proof-stat { min-height: 112px; padding: 18px; }
+  .site-proof .proof-stat:nth-child(odd) { border-left: 0; }
+  .site-proof .proof-stat:nth-child(n+3) { border-top: 1px solid var(--site-line); }
+  .site-proof .section-heading { display: block; }
+  .site-proof .section-heading p { margin-top: 20px; font-size: 16px; }
+  .attempt-grid,
+  .site-proof .control-flow { grid-template-columns: 1fr; }
+  .attempt-card { min-height: auto; }
+  .evidence-note { grid-template-columns: 1fr; }
+  .site-proof .closing { grid-template-columns: 1fr; }
+  .research-thesis,
+  .milestone-grid,
+  .claim-boundary-list { grid-template-columns: 1fr; }
+  .target-pair { grid-template-columns: 1fr; }
+  .proof-ledger-item { grid-template-columns: 1fr; gap: 10px; }
+  .ledger-state { justify-self: start; }
+  .claim-boundary-column + .claim-boundary-column { border-left: 0; border-top: 1px solid var(--site-line); }
+}
+
+@media (max-width: 1080px) {
+  .site-nav-links { display: none; }
+  .site-nav-toggle { display: inline-flex; }
+  .site-nav-mobile:not([hidden]) { display: grid; }
+  .home-hero-grid { grid-template-columns: 1fr; gap: 52px; }
+  .level-map { max-width: 760px; }
+  .site-home #screen-1 { padding-top: 64px; }
+}
+
+@media (max-width: 760px) {
+  :root { --site-shell: min(100% - 32px, 1240px); --site-nav-height: 64px; }
+  .site-nav-inner { min-height: var(--site-nav-height); gap: 10px; }
+  .site-brand { font-size: 12px; letter-spacing: 0.14em; }
+  .site-brand-mark { width: 28px; height: 28px; }
+  .site-nav-github { display: none; }
+  .site-nav-cta { min-height: 40px; padding: 0 12px; }
+  .site-nav-toggle { min-width: 44px; min-height: 40px; padding: 0 10px; }
+  .site-home #screen-1 { min-height: auto; padding: 48px 0 44px; }
+  .site-home .hero h1 { font-size: clamp(44px, 13vw, 64px); }
+  .site-home .hero p { font-size: 18px; }
+  .site-button-row { align-items: stretch; }
+  .site-button { flex: 1 1 150px; padding-inline: 12px; font-size: 12px; }
+  .home-proof-line { grid-template-columns: 1fr 1fr; }
+  .home-proof-item:nth-child(3) { padding-left: 0; border-left: 0; }
+  .home-proof-item:nth-child(n+3) { margin-top: 16px; padding-top: 16px; border-top: 1px solid var(--site-line); }
+  .level-map { padding: 14px; border-radius: 18px; }
+  .level-card { grid-template-columns: 38px minmax(0, 1fr); min-height: 78px; padding: 12px; }
+  .level-command { grid-column: 2; margin-top: -2px; }
+  .do-demo { margin-top: 46px; padding: 18px 14px; border-radius: 17px; }
+  .do-demo-heading { display: block; padding: 2px 4px 18px; }
+  .do-demo-heading p { margin-top: 12px; }
+  .site-home #cmd-input { padding: 18px 60px 18px 66px; font-size: 14px; }
+  .site-home .search-prompt { left: 20px; font-size: 15px; }
+  .site-home .search-actions { right: 10px; }
+  .site-home .generators { grid-template-columns: 1fr 1fr; overflow: visible; max-height: none; padding: 0; }
+  .site-home .gen-btn { min-width: 0; min-height: 122px; }
+  .site-home .hero-outcomes { grid-template-columns: 1fr; }
+  .site-home .hero-outcome { grid-template-columns: 28px 1fr; text-align: left; font-size: 11px; }
+  .site-home .hero-outcome + .hero-outcome { border-left: 0; border-top: 1px solid var(--site-line); }
+  .site-home .story-section { padding-top: 84px; }
+  .site-home .story-heading h2,
+  .site-home .operation-fork-heading h2,
+  .site-home .proof-heading h2,
+  .site-home .cascade-section-heading h2 { font-size: clamp(32px, 10vw, 44px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  *, *::before, *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+  .site-reveal { opacity: 1; transform: none; }
+}

--- a/docs/site-system.js
+++ b/docs/site-system.js
@@ -1,0 +1,50 @@
+(function () {
+  'use strict';
+
+  const toggle = document.querySelector('[data-site-nav-toggle]');
+  const mobile = document.querySelector('[data-site-nav-mobile]');
+  if (toggle && mobile) {
+    toggle.addEventListener('click', () => {
+      const open = toggle.getAttribute('aria-expanded') === 'true';
+      toggle.setAttribute('aria-expanded', String(!open));
+      mobile.hidden = open;
+      toggle.textContent = open ? 'Menu' : 'Close';
+    });
+    mobile.querySelectorAll('a, button').forEach((control) => control.addEventListener('click', () => {
+      toggle.setAttribute('aria-expanded', 'false');
+      toggle.textContent = 'Menu';
+      mobile.hidden = true;
+    }));
+  }
+
+  const progress = document.querySelector('.site-scroll-progress span');
+  let progressFrame = 0;
+  function updateProgress() {
+    progressFrame = 0;
+    if (!progress) return;
+    const scrollable = Math.max(1, document.documentElement.scrollHeight - window.innerHeight);
+    progress.style.width = `${Math.min(100, Math.max(0, (window.scrollY / scrollable) * 100))}%`;
+  }
+  window.addEventListener('scroll', () => {
+    if (!progressFrame) progressFrame = requestAnimationFrame(updateProgress);
+  }, { passive: true });
+  updateProgress();
+
+  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const revealTargets = [...document.querySelectorAll('[data-site-reveal]')];
+  if (reduceMotion || !('IntersectionObserver' in window)) {
+    revealTargets.forEach((element) => element.classList.add('is-visible'));
+  } else {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) return;
+        entry.target.classList.add('is-visible');
+        observer.unobserve(entry.target);
+      });
+    }, { threshold: 0.12, rootMargin: '0px 0px -5% 0px' });
+    revealTargets.forEach((element) => {
+      element.classList.add('site-reveal');
+      observer.observe(element);
+    });
+  }
+})();

--- a/scripts/test-citadel-site-story.js
+++ b/scripts/test-citadel-site-story.js
@@ -6,7 +6,24 @@ const path = require('node:path');
 
 const root = path.resolve(__dirname, '..');
 const html = fs.readFileSync(path.join(root, 'docs', 'index.html'), 'utf8');
+const siteCss = fs.readFileSync(path.join(root, 'docs', 'site-system.css'), 'utf8');
+const siteJs = fs.readFileSync(path.join(root, 'docs', 'site-system.js'), 'utf8');
+const operation = fs.readFileSync(path.join(root, 'docs', 'operation-control.html'), 'utf8');
+const optimizer = fs.readFileSync(path.join(root, 'docs', 'optimizer.html'), 'utf8');
+const research = fs.readFileSync(path.join(root, 'docs', 'research.html'), 'utf8');
 const contract = fs.readFileSync(path.join(root, 'docs', 'interactive-story-contract.md'), 'utf8');
+
+function localLinksResolve(file, source) {
+  const docsRoot = path.join(root, 'docs');
+  const hrefs = [...source.matchAll(/href="([^"]+)"/g)].map(match => match[1]);
+  return hrefs.every((href) => {
+    if (/^(?:https?:|data:|mailto:)/.test(href) || href === '#') return true;
+    const target = href.split('#')[0].split('?')[0];
+    if (!target) return true;
+    const resolved = path.resolve(path.dirname(path.join(docsRoot, file)), target);
+    return resolved.startsWith(docsRoot) && fs.existsSync(resolved);
+  });
+}
 
 const checks = [
   ['story section exists', html.includes('id="product-story"')],
@@ -16,7 +33,8 @@ const checks = [
   ['Operation Fork mobile comparison stacks', html.includes('.operation-fork-runtimes { grid-template-columns: 1fr; }')],
   ['hero shows the first-success path', html.includes('Citadel first-success path') && html.includes('/do next')],
   ['screen transition names its value', html.includes('See the work survive a session')],
-  ['short screens remove the duplicate cue chevron', html.includes('.scroll-cue svg:last-child { display: none; }')],
+  ['document uses native scrolling', siteCss.includes('body.site-home') && siteCss.includes('overflow-y: auto') && !html.includes('// Wheel interception')],
+  ['custom scrollbar and progress rail are explicit', siteCss.includes('*::-webkit-scrollbar-thumb') && siteCss.includes('scrollbar-color:') && html.includes('site-scroll-progress')],
   ['campaign scenario exists', html.includes('data-story-scenario="campaign"')],
   ['review scenario exists', html.includes('data-story-scenario="review"')],
   ['fleet scenario exists', html.includes('data-story-scenario="fleet"')],
@@ -35,13 +53,22 @@ const checks = [
   ['fleet worktrees exist', html.includes('wt-fleet-api') && html.includes('wt-fleet-components') && html.includes('wt-fleet-utils')],
   ['reduced motion participates in playback', html.includes("prefers-reduced-motion: reduce")],
   ['mobile story layout exists', html.includes('.story-layout { grid-template-columns: 1fr; }')],
-  ['mobile router choices use a horizontal rail', html.includes('scroll-snap-type: x proximity') && html.includes('.gen-btn { flex: 0 0 150px;')],
+  ['mobile router choices use a readable grid', siteCss.includes('.site-home .generators { grid-template-columns: 1fr 1fr;') && siteCss.includes('overflow: visible')],
+  ['progressive complexity starts with do', html.includes('One entry point, four levels') && html.includes('/do &lt;request&gt;') && html.includes('Most users stay at 1-2')],
+  ['all public surfaces use the shared system', [html, operation, optimizer, research].every(page => page.includes('site-system.css') && page.includes('site-system.js') && page.includes('site-nav'))],
+  ['operation proof leads with the prospective runtime cell', operation.includes('Current proof · prospective v2') && operation.includes('1 / 3 passed') && operation.includes('$0.704256')],
+  ['optimizer publishes the hosted result and open gate', optimizer.includes('Clean hosted verification passed') && optimizer.includes('PROSPECTIVE_COMPARISON_PENDING')],
+  ['research page separates evidence from funded targets', research.includes('Evidence ladder') && research.includes('≥95%') && research.includes('≥30%') && research.includes('Not demonstrated')],
+  ['all public local links resolve', [
+    ['index.html', html], ['operation-control.html', operation],
+    ['optimizer.html', optimizer], ['research.html', research]
+  ].every(([file, source]) => localLinksResolve(file, source))],
   ['experience contract names all acceptance questions', (contract.match(/^\d+\. /gm) || []).length >= 7],
   ['public story copy contains no em dash', !html.slice(html.indexOf('<section class="story-section"'), html.indexOf('<!-- Vertical tier cascade -->')).includes('—')]
   ,['fallback documentation links are real', html.includes('href="CAMPAIGNS.md"') && html.includes('href="CLAUDE_INSTALLATION_GUIDE.md"')]
   ,['public skill count is current', html.includes('Skills  -  49 built in') && !html.includes('Skills  -  45 installed')]
   ,['public proof and install copy contains no em dash', !html.slice(html.indexOf('<section class="proof-section"'), html.indexOf('<!-- Final CTA')).includes('—')]
-  ,['site remains under declared 250KB source budget', Buffer.byteLength(html, 'utf8') < 250 * 1024]
+  ,['homepage payload remains under declared 250KB source budget', Buffer.byteLength(html + siteCss + siteJs, 'utf8') < 250 * 1024]
   ,['animated stats preserve the published values', html.includes('const targets = [49, 4, 29, 2]') && !html.includes('const targets = [33, 4, 14, 0]')]
 ];
 


### PR DESCRIPTION
## What changed

- rebuilds the homepage around a plain `/do` first-value path and four progressive usage levels
- replaces hidden cinematic wheel navigation with native scrolling, a custom scrollbar, a progress rail, and responsive shared navigation
- unifies the Operation Control and Optimizer proof pages around the latest checked-in evidence and honest claim boundaries
- adds a Research page that connects the thesis, evidence ladder, open gates, funded milestones, and Sentient fit
- strengthens the public-site contract with shared-system, current-proof, budget, and local-link checks

## Why

The existing site exposed complexity before orientation, used different visual and navigation systems across proof pages, and still prioritized older evidence over the newly merged Operation Control v2 prospective result. The redesign makes the beginner path immediate while preserving the technical depth evaluators and funders need.

## User impact

New visitors can understand and try Citadel without learning orchestration vocabulary. Technical reviewers can move from product behavior to prospective proof, earlier diagnostics, optimizer boundaries, and the funded research program through one consistent site.

## Verification

- `npm run test` (full repository suite, all categories passed)
- `node scripts/test-citadel-site-story.js` (41/41)
- `node scripts/test-operation-publication.js`
- `npm run optimizer:test`
- `git diff --check`
- Playwright at 1440, 1024, 768, and 390 pixels across all four pages: zero horizontal overflow and zero console errors
- router, story, missing receipt, keyboard tabs, runtime tabs, optimizer policy, mobile menu, and reduced-motion interactions exercised
