### PR TITLE
fix: keep site landing at the hero

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Citadel is the progressive operating layer for Claude Code and Codex: start with /do, then add durable state, coordination, and verifiable operation control only when the work needs it." />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 32 32%22><rect width=%2232%22 height=%2232%22 rx=%227%22 fill=%22%23070b12%22/><path d=%22M8 8h16v5H13v6h11v5H8z%22 fill=%22%2345ddff%22/></svg>" />
   <title>Citadel | The operating layer for Claude Code and Codex</title>
   <style>
     :root {
@@ -2963,9 +2964,6 @@
         goToScreen(0);
       });
     });
-
-    // Focus input on load
-    setTimeout(() => input.focus(), 100);
 
     // ─── Side panels ──────────────────────────────────────────────────────
     let activePanel = null;

--- a/scripts/test-citadel-site-story.js
+++ b/scripts/test-citadel-site-story.js
@@ -34,6 +34,7 @@ const checks = [
   ['hero shows the first-success path', html.includes('Citadel first-success path') && html.includes('/do next')],
   ['screen transition names its value', html.includes('See the work survive a session')],
   ['document uses native scrolling', siteCss.includes('body.site-home') && siteCss.includes('overflow-y: auto') && !html.includes('// Wheel interception')],
+  ['native-scroll landing does not autofocus below the hero', !html.includes('// Focus input on load') && !html.includes('setTimeout(() => input.focus(), 100)')],
   ['custom scrollbar and progress rail are explicit', siteCss.includes('*::-webkit-scrollbar-thumb') && siteCss.includes('scrollbar-color:') && html.includes('site-scroll-progress')],
   ['campaign scenario exists', html.includes('data-story-scenario="campaign"')],
   ['review scenario exists', html.includes('data-story-scenario="review"')],


### PR DESCRIPTION
## What changed

- removes the legacy on-load focus call that scrolled the new native-scroll homepage past its hero
- adds a data favicon so a fresh local or hosted load does not request a missing `/favicon.ico`
- adds a regression assertion that the native-scroll landing cannot restore the removed autofocus

## Root cause

The former fixed-screen experience focused the command input on load because the input was part of the first viewport. After PR #221 moved the demo below an editorial hero, that same delayed focus triggered browser scroll anchoring and skipped the page's orientation layer.

## Verification

- `node scripts/test-citadel-site-story.js` (42/42)
- `node scripts/test-operation-publication.js`
- `npm run optimizer:test`
- fresh browser session after 500 ms: `scrollY === 0`, active element is `BODY`, favicon is a data URL
- fresh browser console: zero errors and warnings
- `git diff --check`
