### PR TITLE
Record completed hosted application-readiness checks

### DIFF
--- a/docs/grants/APPLICATION_CHECKLIST.md
+++ b/docs/grants/APPLICATION_CHECKLIST.md
@@ -16,7 +16,7 @@
 - [x] Representative replay retained: both policies 6/12 verified, zero false passes, zero path violations, 7.1% measured GPU-energy reduction below the 20% gate.
 - [x] Transitive source-closure manifests and local measurement audit published with explicit limitations.
 - [x] Claim-discipline contract rejects stale or inflated application wording.
-- [ ] Clean hosted browser smoke check on the final merged site.
+- [x] Clean hosted browser smoke check on the final merged site.
 
 ## Presentation
 
@@ -32,7 +32,15 @@
 - [x] Social preview source designed for the evaluator-facing site.
 - [x] Capture three final application images and rendered social preview.
 - [x] Verify sitemap, metadata, keyboard path, video playback, and local desktop/mobile layouts.
-- [ ] Confirm final responsive and console-clean checks on the merged hosted site.
+- [x] Confirm final responsive and console-clean checks on the merged hosted site.
+
+Post-merge evidence for `6a7413180b408e3b7397b06da174a3f2c7228957`:
+[Tests #153](https://github.com/SethGammon/Citadel/actions/runs/30689491568),
+[Pages deployment #158](https://github.com/SethGammon/Citadel/actions/runs/30689490997),
+and [Hosted Pages Smoke #1](https://github.com/SethGammon/Citadel/actions/runs/30689640454)
+all completed successfully on 2026-08-01. The hosted smoke exercised the final
+release manifest, responsive layouts, browser console, focus behavior, overflow,
+page titles, images, and application media.
 
 ## Submission authority
 

--- a/docs/site-release-manifest.json
+++ b/docs/site-release-manifest.json
@@ -79,8 +79,8 @@
     },
     {
       "path": "grants/APPLICATION_CHECKLIST.md",
-      "bytes": 2504,
-      "digest": "sha256:94cdcccfcef3f124230da0e1059f4cd49c33bd077cb5508deca61f0e328455cd"
+      "bytes": 3036,
+      "digest": "sha256:ced9989d65c55f82bd6fba044fab4600ea0cadb226204aed799c43bcb98b1809"
     },
     {
       "path": "grants/APPLICATION_MEDIA.md",
@@ -183,5 +183,5 @@
       "digest": "sha256:72ee2abbae6b4a1f500abeebf803e149640fa9f53da04343606c648766065121"
     }
   ],
-  "source_digest": "sha256:5727b949891123314e7df7d8b983c729271f982d80f84a309b3e7c93d5487f3b"
+  "source_digest": "sha256:337e6fa544ef832efe639763acf11a8279f88d9f5cd7e18de49c9c98e33e6194"
 }


### PR DESCRIPTION
## Outcome

Closes the two hosted-verification items that could only be completed after PR #223 merged and GitHub Pages deployed.

## Evidence

- main Tests #153 passed for merge `6a741318`
- Pages deployment #158 passed
- Hosted Pages Smoke #1 passed against the deployed release
- manual deployed review passed across all six pages at 1440px and 390px, with no overflow or broken images and both application videos ready

## Verification

- `npm run application:claims:test`
- `node scripts/test-application-evidence.js`
- `git diff --check`

This is a documentation-only closeout; it changes no application claim, benchmark result, product behavior, or public site asset.