### PR TITLE
Version the public shared stylesheet

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="robots" content="noindex" />
   <title>Page not found | Citadel</title>
-  <link rel="stylesheet" href="site-system.css" />
+  <link rel="stylesheet" href="site-system.css?v=20260801-1" />
 </head>
 <body class="site-page">
   <main class="site-shell" style="min-height:100vh;display:grid;place-items:center;padding:48px 0;">

--- a/docs/evidence.html
+++ b/docs/evidence.html
@@ -113,7 +113,7 @@
       .reproduce, .funded-target { padding: 24px; }
     }
   </style>
-<link rel="stylesheet" href="site-system.css" />
+<link rel="stylesheet" href="site-system.css?v=20260801-1" />
 </head>
 <body class="site-page site-evidence">
   <a class="site-skip-link" href="#main-content">Skip to content</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1471,7 +1471,7 @@
       .scroll-cue svg:last-child { display: none; }
     }
   </style>
-  <link rel="stylesheet" href="site-system.css" />
+  <link rel="stylesheet" href="site-system.css?v=20260801-1" />
 </head>
 <body class="site-page site-home">
   <a class="site-skip-link" href="#main-content">Skip to content</a>

--- a/docs/operation-control.html
+++ b/docs/operation-control.html
@@ -423,7 +423,7 @@
       .button:hover { transform: none; }
     }
   </style>
-  <link rel="stylesheet" href="site-system.css" />
+  <link rel="stylesheet" href="site-system.css?v=20260801-1" />
 </head>
 <body class="site-page site-proof site-operation">
   <a class="site-skip-link" href="#main-content">Skip to content</a>

--- a/docs/optimizer.html
+++ b/docs/optimizer.html
@@ -463,7 +463,7 @@
       html { scroll-behavior: auto; }
     }
   </style>
-  <link rel="stylesheet" href="site-system.css" />
+  <link rel="stylesheet" href="site-system.css?v=20260801-1" />
 </head>
 <body class="site-page site-proof site-optimizer">
   <a class="site-skip-link" href="#main-content">Skip to content</a>

--- a/docs/research.html
+++ b/docs/research.html
@@ -17,7 +17,7 @@
   <meta name="twitter:image" content="https://sethgammon.github.io/Citadel/assets/citadel-social-preview.png" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 32 32%22><rect width=%2232%22 height=%2232%22 rx=%227%22 fill=%22%23070b12%22/><path d=%22M8 8h16v5H13v6h11v5H8z%22 fill=%22%2345ddff%22/></svg>" />
   <title>Citadel Research Program | Proof before optimization claims</title>
-  <link rel="stylesheet" href="site-system.css" />
+  <link rel="stylesheet" href="site-system.css?v=20260801-1" />
 </head>
 <body class="site-page site-proof site-research">
   <a class="site-skip-link" href="#main-content">Skip to content</a>

--- a/docs/site-release-manifest.json
+++ b/docs/site-release-manifest.json
@@ -4,8 +4,8 @@
   "files": [
     {
       "path": "404.html",
-      "bytes": 1065,
-      "digest": "sha256:f75a238d8003a6f213e91086cfd909c42a1847696081cf3939d58e4bbf4f1c5b"
+      "bytes": 1078,
+      "digest": "sha256:dba7effef32735c0a31a549de8f98bdbb6840652bdf4a3ed7b5b34edb62e1063"
     },
     {
       "path": "EVIDENCE_MANIFEST.md",
@@ -69,8 +69,8 @@
     },
     {
       "path": "evidence.html",
-      "bytes": 24968,
-      "digest": "sha256:843e2ba1b352c54cdaf5df1d93c4fc66ffa5c3709939f27a34c474649068e13b"
+      "bytes": 24981,
+      "digest": "sha256:bc9be5add0785088ac4072a1b8fe76351a9ad1cd9035f8342ccda592d4b6e541"
     },
     {
       "path": "grants/APPLICANT_AND_ADOPTION.md",
@@ -134,23 +134,23 @@
     },
     {
       "path": "index.html",
-      "bytes": 201634,
-      "digest": "sha256:9c7c2af8ed32aae0f08fa288818ee1a979e292babe99c4e37da599f0c4e5839b"
+      "bytes": 201647,
+      "digest": "sha256:522eddab43be3a811ebd9ba2c32bbb2d159263306842ac7c758c42045d8f6114"
     },
     {
       "path": "operation-control.html",
-      "bytes": 26447,
-      "digest": "sha256:56713acf9747a3f083a75976a2a28559a64ad103499a19d66d4810a1325d034f"
+      "bytes": 26460,
+      "digest": "sha256:e007b5b194ed9fb52ec442366577141b0d02f15c6f987a7380d6879c0d0c6eb2"
     },
     {
       "path": "optimizer.html",
-      "bytes": 31917,
-      "digest": "sha256:cfd427c918bf24b8ff943b4b1b454f3cb87da8eb73ddf22331d9377c9c657a84"
+      "bytes": 31930,
+      "digest": "sha256:bd916d5808be1d7687ce6348e6e0bcddcfc3c35592b397462dbe97720e0929c8"
     },
     {
       "path": "research.html",
-      "bytes": 17336,
-      "digest": "sha256:97d8aa08b3c2e049623ac49b461decfd38908d0babe707a4e7e0c94c2dcf0a87"
+      "bytes": 17349,
+      "digest": "sha256:0e3cdb60cde19d77398118b97f5f7961376f32fa0b823aa63563ce3505b7729d"
     },
     {
       "path": "robots.txt",
@@ -179,9 +179,9 @@
     },
     {
       "path": "walkthrough.html",
-      "bytes": 9099,
-      "digest": "sha256:ca3f39e33de6bd76dedd06c64f2703393de43da3ef98da3a2aa4e2540a29df7e"
+      "bytes": 9112,
+      "digest": "sha256:fe6a87df64bb6248b53a182bee63f7eb288e9128e669caf96e8b9ee26bc27f05"
     }
   ],
-  "source_digest": "sha256:4d11d88bc7ecf951bfdeb6b8f79a2bfb78ff4f07db5eacc1fe5d4aa39468c838"
+  "source_digest": "sha256:d656b11616bfc5a8cf3eb13ce086554484166c09f191f4558b23836b12d494d1"
 }

--- a/docs/walkthrough.html
+++ b/docs/walkthrough.html
@@ -34,7 +34,7 @@
     .walkthrough-footer { padding: 28px 0 48px; border-top: 1px solid var(--site-line); color: var(--site-dim); font: 12px/1.5 var(--site-mono); }
     @media (max-width: 760px) { .transcript, .verification-demo header { grid-template-columns: 1fr; gap: 20px; } .walkthrough-hero { padding-top: 64px; } }
   </style>
-<link rel="stylesheet" href="site-system.css" />
+<link rel="stylesheet" href="site-system.css?v=20260801-1" />
 </head>
 <body class="site-page site-walkthrough">
   <a class="site-skip-link" href="#main-content">Skip to content</a>


### PR DESCRIPTION
## What changed

- added a release version query to the shared stylesheet URL on every public page, including the 404 surface
- regenerated the site release manifest

## Why

Hosted verification after #225 found that GitHub Pages could serve newly deployed HTML while a browser reused the pre-facelift `site-system.css`. That produces a temporary mixed release where the new content still looks gray. Versioning the stylesheet URL forces the matching chromatic system to load immediately.

## Impact

First-time and returning visitors receive the new site presentation atomically with the new HTML.

## Validation

- `npm run site:story:test` — 44/44
- `npm run site:release:verify` — pass, digest `sha256:d656b11616bfc5a8cf3eb13ce086554484166c09f191f4558b23836b12d494d1`
- `git diff --check` — pass