### PR TITLE
Correct Sentient Grant branch audit

### DIFF
--- a/docs/grants/APPLICATION_CHECKLIST.md
+++ b/docs/grants/APPLICATION_CHECKLIST.md
@@ -34,15 +34,19 @@
 - [x] Verify sitemap, metadata, keyboard path, video playback, and local desktop/mobile layouts.
 - [x] Confirm final responsive and console-clean checks on the merged hosted site.
 - [x] Map every live Sentient Grant-track form field to a paste-ready answer.
+- [x] Inspect the live Typeform branch logic and exclude the combined-form
+  `How did you hear` field that the Grant path skips after the required upload.
 - [x] Render the required eight-page supporting PDF from a tracked source.
 - [x] Inspect every rendered PDF page and verify extractable text, page count,
   dimensions, metadata, and SHA-256.
 - [x] Publish a final claim-boundary and submission-readiness audit.
 
-Post-merge evidence for `6a7413180b408e3b7397b06da174a3f2c7228957`:
-[Tests #153](https://github.com/SethGammon/Citadel/actions/runs/30689491568),
-[Pages deployment #158](https://github.com/SethGammon/Citadel/actions/runs/30689490997),
-and [Hosted Pages Smoke #1](https://github.com/SethGammon/Citadel/actions/runs/30689640454)
+Post-merge evidence for the application-package merge
+`333451e1b2b9e80b2965473c52db8125a74031e7`:
+[Tests #162](https://github.com/SethGammon/Citadel/actions/runs/30711082722),
+[Pages deployment #162](https://github.com/SethGammon/Citadel/actions/runs/30711082168),
+[HOL Plugin Scanner #182](https://github.com/SethGammon/Citadel/actions/runs/30711082703),
+and [Hosted Pages Smoke #5](https://github.com/SethGammon/Citadel/actions/runs/30711261304)
 all completed successfully on 2026-08-01. The hosted smoke exercised the final
 release manifest, responsive layouts, browser console, focus behavior, overflow,
 page titles, images, and application media.

--- a/docs/grants/SENTIENT_OPTIMIZER_APPLICATION_DRAFT.md
+++ b/docs/grants/SENTIENT_OPTIMIZER_APPLICATION_DRAFT.md
@@ -502,8 +502,8 @@ stack builder implementing the conformance adapter; ROMA is the current
 example. A funded, bounded opt-in cohort of 15-20 external operators measures
 governed first-operation completion, including failed installs and abandonment;
 it does not govern the optimizer performance gate. Applicant email,
-city/country, how Seth heard about Sentient, and submission authority remain
-human-owned Typeform inputs. Legal and payment details may follow during due
+city/country, role selection, and submission authority remain human-owned
+Typeform inputs. Legal and payment details may follow during due
 diligence but were not fields in the observed application path. See
 [`APPLICANT_AND_ADOPTION.md`](APPLICANT_AND_ADOPTION.md).
 
@@ -525,7 +525,8 @@ Do not submit until:
 - this final application package is merged and all hosted checks pass;
 - the public Pages site, evidence manifest, evaluator path, and PDF links are
   checked after merge;
-- applicant email, city/country, and how Seth heard about Sentient are entered;
+- applicant email and city/country are entered, and the role selection is
+  confirmed;
 - Seth reviews and explicitly approves the requested amount and wording;
 - Seth explicitly approves submitting the application.
 

--- a/docs/grants/SUBMISSION_READINESS.md
+++ b/docs/grants/SUBMISSION_READINESS.md
@@ -20,8 +20,13 @@ in [`TYPEFORM_ANSWER_PACK.md`](TYPEFORM_ANSWER_PACK.md):
 - Grant versus Investment track;
 - funding range;
 - what the grant unlocks;
-- required supporting document upload;
-- how the applicant heard about Sentient.
+- required supporting document upload.
+
+The combined form definition contains a later `How did you hear about this
+program` field, but the current Grant-branch logic jumps from the supporting
+document field to the grant thank-you screen. That field belongs outside the
+observed Grant path and is not an applicant blocker. Recheck the branch logic,
+not only the combined field inventory, if the form changes.
 
 The live form did not ask for a legal entity, tax information, payment details,
 or a separate budget spreadsheet during this observed path. Reinspect if the
@@ -103,7 +108,7 @@ Only four factual or authority inputs remain outside the repository:
 
 - [ ] applicant email;
 - [ ] city and country;
-- [ ] how Seth heard about Sentient;
+- [ ] confirmation that `Engineer / Builder` is the correct role selection;
 - [ ] Seth's explicit approval of the amount, wording, upload, and external
   submission.
 
@@ -112,11 +117,10 @@ pre-award cohort is required. The funded cohort is post-award work.
 
 ## Final submission sequence
 
-1. Confirm the three applicant facts above.
+1. Confirm the two applicant facts and role selection above.
 2. Recheck the live Typeform for field or option drift.
 3. Refresh the dated GitHub counts or remove them if they cannot be verified.
 4. Verify the public Pages site and evaluator path after this package merges.
 5. Re-render the PDF only if any public claim changes, then update its digest.
 6. Paste answers from `TYPEFORM_ANSWER_PACK.md` and upload the PDF.
 7. Stop at the final submission action until Seth explicitly authorizes it.
-

--- a/docs/grants/TYPEFORM_ANSWER_PACK.md
+++ b/docs/grants/TYPEFORM_ANSWER_PACK.md
@@ -106,8 +106,13 @@ Supporting review path is in the PDF and at:
 |---|---|---|
 | Track | `Grant` | Final |
 | Funding range | `> $50k` | Matches $150,000 proposal |
-| Supporting document | `output/pdf/citadel-sentient-grant-packet.pdf` | Upload after final visual check |
-| How did you hear about us? | `[HOW SETH HEARD ABOUT SENTIENT]` | Seth confirmation required |
+| Supporting document | `output/pdf/citadel-sentient-grant-packet.pdf` | Verified; upload during final form pass |
+
+The combined Typeform definition also contains a `How did you hear about this
+program` question. It is not on the Grant path: when `Grant` is selected, the
+form's current branch logic jumps from the required supporting-document upload
+directly to the thank-you screen. Do not invent or enter an answer unless the
+live path changes before submission.
 
 ### What would the grant unlock?
 
@@ -137,7 +142,6 @@ failure analysis, and unused-funds accounting remain public deliverables.
 - [ ] Confirm applicant email.
 - [ ] Confirm city and country.
 - [ ] Confirm `Engineer / Builder` as the role selection.
-- [ ] Confirm how Seth heard about Sentient.
 - [ ] Approve the final $150,000 amount.
 - [ ] Approve this wording and the rendered PDF.
 - [ ] Explicitly authorize submission of the external Typeform.

--- a/docs/site-release-manifest.json
+++ b/docs/site-release-manifest.json
@@ -79,8 +79,8 @@
     },
     {
       "path": "grants/APPLICATION_CHECKLIST.md",
-      "bytes": 3588,
-      "digest": "sha256:e08f0ac07ecf806973b13e046887cd877108293b95f0071bab658d5fe5b21e27"
+      "bytes": 3864,
+      "digest": "sha256:cc20d98d8adb2c88be743dd75bb7317f81c5c4ef56b8b89cf65f92f78f8ad787"
     },
     {
       "path": "grants/APPLICATION_MEDIA.md",
@@ -124,13 +124,13 @@
     },
     {
       "path": "grants/SENTIENT_OPTIMIZER_APPLICATION_DRAFT.md",
-      "bytes": 25749,
-      "digest": "sha256:92416a7992cd6decc9bff0fdba07fb99f6c14ad15ec8abad9c46aa4c5ade5b80"
+      "bytes": 25741,
+      "digest": "sha256:26a728cbc71bf78def20e5fa6a34ecf81e27c450b50ca5752851645482f5e2c4"
     },
     {
       "path": "grants/SUBMISSION_READINESS.md",
-      "bytes": 5088,
-      "digest": "sha256:2253f39c711d380a3035a6816d732117448074027ffe7f4d406ec07fec22ccd5"
+      "bytes": 5470,
+      "digest": "sha256:62bbeb4d326405e22a52bd01c5353be10e583011a5c03eb89c4d979dfb6cff42"
     },
     {
       "path": "grants/TECHNICAL_COMPARISON.md",
@@ -139,8 +139,8 @@
     },
     {
       "path": "grants/TYPEFORM_ANSWER_PACK.md",
-      "bytes": 7175,
-      "digest": "sha256:a6809f6385b311f300626d9ba6f5be68f8c4378bfbbcd6c94ff13a416487ed6e"
+      "bytes": 7393,
+      "digest": "sha256:799b62fba16c39881c8ba0ee1a39287450ca67d1d1868ddbd0958d56a56f7bd6"
     },
     {
       "path": "index.html",
@@ -193,5 +193,5 @@
       "digest": "sha256:fe6a87df64bb6248b53a182bee63f7eb288e9128e669caf96e8b9ee26bc27f05"
     }
   ],
-  "source_digest": "sha256:358a5458a1ce4a7802425bea3ae2c97303fb0f1c34901a1ceb9fce35c86d5339"
+  "source_digest": "sha256:9038395e23f7ba3d819cf48fc4f5745d12b6bc126ed0780d4616a79d2f706bc9"
 }

--- a/scripts/test-optimizer.js
+++ b/scripts/test-optimizer.js
@@ -1040,7 +1040,13 @@ function main() {
   assert.strictEqual(validateCli.status, 0, validateCli.stderr);
   const validation = JSON.parse(validateCli.stdout);
   assert.strictEqual(validation.valid, true);
-  assert.strictEqual(validation.actual_run_status, 'blocked');
+  const doctorCli = invoke(['doctor']);
+  assert.strictEqual(doctorCli.status, 0, doctorCli.stderr);
+  const doctorOutput = JSON.parse(doctorCli.stdout);
+  assert(['blocked', 'ready'].includes(doctorOutput.status));
+  assert.strictEqual(validation.actual_run_status, doctorOutput.status);
+  if (doctorOutput.status === 'ready') assert.deepStrictEqual(doctorOutput.blockers, []);
+  else assert(doctorOutput.blockers.length > 0);
   const calibrationCli = invoke(['calibration-plan']);
   assert.strictEqual(calibrationCli.status, 0, calibrationCli.stderr);
   const calibrationOutput = JSON.parse(calibrationCli.stdout);

--- a/scripts/test-sentient-application-package.js
+++ b/scripts/test-sentient-application-package.js
@@ -28,8 +28,29 @@ assert.ok(oneLine.length <= 80, `one-line answer exceeds Typeform limit: ${oneLi
 assert.match(answers, new RegExp(`Character count: ${oneLine.length} of 80\\.`));
 assert.ok(answers.includes(`\`${oneLine}\``), 'one-line answer and recorded count drifted');
 
-for (const placeholder of ['[SETH EMAIL]', '[CITY, COUNTRY]', '[HOW SETH HEARD ABOUT SENTIENT]']) {
+for (const placeholder of ['[SETH EMAIL]', '[CITY, COUNTRY]']) {
   assert.ok(answers.includes(placeholder), `missing human-owned placeholder: ${placeholder}`);
+}
+assert.ok(!answers.includes('[HOW SETH HEARD ABOUT SENTIENT]'), 'Grant path must not require the skipped how-heard field');
+assert.match(answers, /jumps from the required supporting-document upload\s+directly to the thank-you screen/i);
+assert.match(readiness, /Grant-branch logic jumps from the supporting\s+document field to the grant thank-you screen/i);
+
+for (const liveField of [
+  'Email',
+  'Role',
+  'City, country',
+  'What problem are you solving, and why now?',
+  'Who does this help?',
+  'In one line, what are you building?',
+  'Who is building this, and why is the team right?',
+  'What is open, what gets worse if it closed tomorrow, and for whom?',
+  'Demo or trial link',
+  'Track',
+  'Funding range',
+  'What would the grant unlock?',
+  'Supporting document',
+]) {
+  assert.ok(answers.includes(liveField), `paste-ready pack is missing live Grant field: ${liveField}`);
 }
 assert.match(answers, /No form has been submitted/i);
 assert.match(readiness, /Stop at the final submission action until Seth explicitly authorizes it/i);


### PR DESCRIPTION
## What changed

- Correct the Sentient Grant answer pack and readiness audit to follow the live Typeform branch logic.
- Remove the skipped `How did you hear about this program` field from Grant-path blockers.
- Replace stale post-merge checklist links with the successful workflows for application-package merge `333451e`.
- Strengthen the application-package test so every live Grant field remains mapped and the skipped field cannot return as a placeholder.
- Make the optimizer test validate doctor consistency in both runtime-ready and runtime-blocked environments.

## Why

The combined Typeform definition contains a required how-heard field, but its Grant branch jumps from the required supporting-document upload directly to the grant thank-you screen. Treating the combined inventory as the live Grant path created an unnecessary applicant blocker.

The complete local suite also exposed an environment-brittle optimizer assertion. It assumed the doctor must be blocked, while this workstation now has both Claude and Codex available and correctly reports ready. The test now verifies the actual doctor contract instead of forcing either environment state.

## Validation

- `npm test`
- `npm run application:package:test`
- `npm run application:claims:test`
- `npm run application:evidence:check`
- `npm run site:release:verify`
- `npm run application:media:test`
- `node scripts/test-optimizer.js`
- `git diff --check`

The eight-page supporting PDF is unchanged and retains SHA-256 `9dc8add0f9b224ab983209e3fe14a335965cb45d3f02de149638dc9e7e65b723`.
