### PR TITLE
Add live Sentient form drift gate

### DIFF
--- a/docs/grants/APPLICATION_CHECKLIST.md
+++ b/docs/grants/APPLICATION_CHECKLIST.md
@@ -36,6 +36,8 @@
 - [x] Map every live Sentient Grant-track form field to a paste-ready answer.
 - [x] Inspect the live Typeform branch logic and exclude the combined-form
   `How did you hear` field that the Grant path skips after the required upload.
+- [x] Add a read-only live-form drift gate covering all 13 required Grant
+  fields, their types, the 80-character limit, funding choices, and branch exit.
 - [x] Render the required eight-page supporting PDF from a tracked source.
 - [x] Inspect every rendered PDF page and verify extractable text, page count,
   dimensions, metadata, and SHA-256.

--- a/docs/grants/SUBMISSION_READINESS.md
+++ b/docs/grants/SUBMISSION_READINESS.md
@@ -28,6 +28,16 @@ document field to the grant thank-you screen. That field belongs outside the
 observed Grant path and is not an applicant blocker. Recheck the branch logic,
 not only the combined field inventory, if the form changes.
 
+Run `npm run application:form:check` immediately before the final form pass.
+The read-only check fetches the public definition, verifies all 13 required
+Grant inputs and their types, confirms the 80-character limit and funding
+choices, proves the upload-to-thank-you branch, and requires a matching answer
+surface without entering or submitting response data.
+
+Observed live Grant contract fingerprint on 2026-08-01:
+`sha256:611739716b3eb5ad7b16a2e93778f91b9b8cc06ff5ffcbe2eb843c4683544dcd`.
+Any mismatch is a review stop, not an instruction to update the digest blindly.
+
 The live form did not ask for a legal entity, tax information, payment details,
 or a separate budget spreadsheet during this observed path. Reinspect if the
 form changes before submission.
@@ -118,7 +128,8 @@ pre-award cohort is required. The funded cohort is post-award work.
 ## Final submission sequence
 
 1. Confirm the two applicant facts and role selection above.
-2. Recheck the live Typeform for field or option drift.
+2. Run `npm run application:form:check` to reject live field, option, or branch
+   drift.
 3. Refresh the dated GitHub counts or remove them if they cannot be verified.
 4. Verify the public Pages site and evaluator path after this package merges.
 5. Re-render the PDF only if any public claim changes, then update its digest.

--- a/docs/site-release-manifest.json
+++ b/docs/site-release-manifest.json
@@ -79,8 +79,8 @@
     },
     {
       "path": "grants/APPLICATION_CHECKLIST.md",
-      "bytes": 3864,
-      "digest": "sha256:cc20d98d8adb2c88be743dd75bb7317f81c5c4ef56b8b89cf65f92f78f8ad787"
+      "bytes": 4019,
+      "digest": "sha256:8fd7922b103fd2dd66b4685137e5cebaae6f81956dd8408f19a28ee64af35d60"
     },
     {
       "path": "grants/APPLICATION_MEDIA.md",
@@ -129,8 +129,8 @@
     },
     {
       "path": "grants/SUBMISSION_READINESS.md",
-      "bytes": 5470,
-      "digest": "sha256:62bbeb4d326405e22a52bd01c5353be10e583011a5c03eb89c4d979dfb6cff42"
+      "bytes": 6077,
+      "digest": "sha256:dd2ce23b38947c1cab7fc0c32fd3eeb8cf1e8b89e2d1b15c4b61d44ecce65658"
     },
     {
       "path": "grants/TECHNICAL_COMPARISON.md",
@@ -193,5 +193,5 @@
       "digest": "sha256:fe6a87df64bb6248b53a182bee63f7eb288e9128e669caf96e8b9ee26bc27f05"
     }
   ],
-  "source_digest": "sha256:9038395e23f7ba3d819cf48fc4f5745d12b6bc126ed0780d4616a79d2f706bc9"
+  "source_digest": "sha256:a76e348fb5077578766212e978812e846d8cd17e305867a4d62265bfe1e4597b"
 }

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "application:evidence": "node scripts/application-evidence.js build",
     "application:evidence:check": "node scripts/application-evidence.js check",
     "application:evidence:test": "node scripts/test-application-evidence.js",
+    "application:form:check": "node scripts/check-sentient-grant-form.js",
     "application:claims:test": "node scripts/test-application-claim-discipline.js",
     "application:media:walkthrough": "python scripts/render-application-walkthrough.py",
     "application:media:verification": "python scripts/render-live-verification-demo.py",

--- a/scripts/check-sentient-grant-form.js
+++ b/scripts/check-sentient-grant-form.js
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('assert');
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const FORM_URL = 'https://form.typeform.com/to/IRj7WaKH';
+const ANSWER_FILE = path.join(ROOT, 'docs', 'grants', 'TYPEFORM_ANSWER_PACK.md');
+const EXPECTED_FINGERPRINT = '611739716b3eb5ad7b16a2e93778f91b9b8cc06ff5ffcbe2eb843c4683544dcd';
+
+const EXPECTED_GRANT_FIELDS = Object.freeze([
+  ['Your email address', 'email', '| Email |'],
+  ['What best describes your primary role?', 'multiple_choice', '| Role |'],
+  ['Where are you currently based?', 'short_text', '| City, country |'],
+  ['What problem are you solving, and why now?', 'long_text', '### What problem are you solving, and why now?'],
+  ['Who does this help?', 'long_text', '### Who does this help?'],
+  ['In one line, what are you building?', 'short_text', '### In one line, what are you building?'],
+  ['Who is building this, and why is your team the right one to do it?', 'short_text', '### Who is building this, and why is the team right?'],
+  ['What’s open about it, and what would get worse if it closed tomorrow, and for whom?', 'long_text', '### What is open, what gets worse if it closed tomorrow, and for whom?'],
+  ['Please provide demo or trial links', 'website', '### Demo or trial link'],
+  ['Are you interested in applying for the grant track or the investment track?', 'multiple_choice', '| Track |'],
+  ['How much grant funding are you asking for?', 'multiple_choice', '| Funding range |'],
+  ['What would the grant unlock?', 'long_text', '### What would the grant unlock?'],
+  ['Please upload any supporting documents, decks, or research materials.', 'file_upload', '| Supporting document |'],
+]);
+
+function extractObject(source, marker) {
+  const markerIndex = source.indexOf(marker);
+  assert(markerIndex >= 0, `live form HTML is missing ${marker}`);
+  const start = source.indexOf('{', markerIndex + marker.length);
+  assert(start >= 0, `live form HTML has no object after ${marker}`);
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let index = start; index < source.length; index += 1) {
+    const character = source[index];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (character === '\\') escaped = true;
+      else if (character === '"') inString = false;
+      continue;
+    }
+    if (character === '"') inString = true;
+    else if (character === '{') depth += 1;
+    else if (character === '}') {
+      depth -= 1;
+      if (depth === 0) return source.slice(start, index + 1);
+    }
+  }
+  throw new Error(`unterminated object after ${marker}`);
+}
+
+function flattenFields(fields, result = []) {
+  for (const field of fields) {
+    if (Array.isArray(field.properties && field.properties.fields)) {
+      flattenFields(field.properties.fields, result);
+    } else result.push(field);
+  }
+  return result;
+}
+
+function findUnique(fields, title) {
+  const matches = fields.filter((field) => field.title === title);
+  assert.strictEqual(matches.length, 1, `expected one live field titled ${JSON.stringify(title)}, found ${matches.length}`);
+  return matches[0];
+}
+
+function conditionBindsGrant(action, trackRef, grantChoiceRef) {
+  const variables = action.condition && action.condition.vars;
+  return Array.isArray(variables)
+    && variables.some((value) => value.type === 'field' && value.value === trackRef)
+    && variables.some((value) => value.type === 'choice' && value.value === grantChoiceRef);
+}
+
+async function main() {
+  const response = await fetch(FORM_URL, {
+    headers: {
+      accept: 'text/html',
+      'user-agent': 'Citadel-Sentient-Grant-Contract/1.0',
+    },
+    redirect: 'follow',
+    signal: AbortSignal.timeout(15000),
+  });
+  assert.strictEqual(response.ok, true, `${FORM_URL} returned HTTP ${response.status}`);
+  const html = await response.text();
+  const rendererIndex = html.indexOf('window.rendererData =');
+  assert(rendererIndex >= 0, 'live form HTML is missing window.rendererData');
+  const form = JSON.parse(extractObject(html.slice(rendererIndex), '\n              form:'));
+  assert.strictEqual(form.id, 'IRj7WaKH');
+
+  const fields = flattenFields(form.fields);
+  const answers = fs.readFileSync(ANSWER_FILE, 'utf8');
+  const mappedFields = EXPECTED_GRANT_FIELDS.map(([title, type, marker]) => {
+    const field = findUnique(fields, title);
+    assert.strictEqual(field.type, type, `${title}: live field type drifted`);
+    assert.strictEqual(field.validations && field.validations.required, true, `${title}: live required status drifted`);
+    assert.ok(answers.includes(marker), `${title}: answer pack is missing ${JSON.stringify(marker)}`);
+    return {
+      ref: field.ref,
+      title: field.title,
+      type: field.type,
+      required: field.validations.required,
+      max_length: field.validations.max_length || null,
+    };
+  });
+
+  const oneLine = findUnique(fields, 'In one line, what are you building?');
+  assert.strictEqual(oneLine.validations.max_length, 80, 'one-line maximum length drifted');
+
+  const track = findUnique(fields, 'Are you interested in applying for the grant track or the investment track?');
+  const grantChoice = track.properties.choices.find((choice) => choice.label === 'Grant');
+  assert.ok(grantChoice, 'Grant choice is missing from the live track field');
+  const funding = findUnique(fields, 'How much grant funding are you asking for?');
+  assert.deepStrictEqual(funding.properties.choices.map((choice) => choice.label), ['10k', '25k', '50k', '>50k']);
+
+  const upload = findUnique(fields, 'Please upload any supporting documents, decks, or research materials.');
+  const howHeard = findUnique(fields, 'How did you hear about this program');
+  const uploadIndex = form.fields.findIndex((field) => field.ref === upload.ref);
+  const howHeardIndex = form.fields.findIndex((field) => field.ref === howHeard.ref);
+  assert(uploadIndex >= 0 && howHeardIndex > uploadIndex, 'combined form no longer places how-heard after the Grant upload');
+  const actualGrantPath = flattenFields(form.fields.slice(0, uploadIndex + 1))
+    .filter((field) => field.type !== 'statement');
+  assert.deepStrictEqual(
+    actualGrantPath.map((field) => field.title),
+    EXPECTED_GRANT_FIELDS.map(([title]) => title),
+    'ordered Grant path added, removed, or reordered an answer field',
+  );
+  const uploadLogic = form.logic.find((entry) => entry.ref === upload.ref);
+  assert(uploadLogic, 'Grant upload no longer has branch logic');
+  const grantExit = uploadLogic.actions.find((action) => (
+    action.action === 'jump'
+      && action.details && action.details.to && action.details.to.type === 'thankyou'
+      && conditionBindsGrant(action, track.ref, grantChoice.ref)
+  ));
+  assert(grantExit, 'Grant path no longer jumps from the required upload to thank-you');
+  assert.ok(!answers.includes('[HOW SETH HEARD ABOUT SENTIENT]'), 'answer pack reintroduced the skipped how-heard field');
+
+  const contract = {
+    schema: 1,
+    form_id: form.id,
+    form_title: form.title,
+    grant_fields: mappedFields,
+    branch: {
+      track_ref: track.ref,
+      grant_choice_ref: grantChoice.ref,
+      upload_ref: upload.ref,
+      thankyou_ref: grantExit.details.to.value,
+      skipped_how_heard_ref: howHeard.ref,
+    },
+  };
+  const fingerprint = crypto.createHash('sha256').update(JSON.stringify(contract)).digest('hex');
+  assert.strictEqual(fingerprint, EXPECTED_FINGERPRINT, 'live Grant contract fingerprint drifted');
+  process.stdout.write(`Sentient live Grant form passed: ${mappedFields.length} required fields, upload-to-thank-you branch, sha256:${fingerprint}\n`);
+}
+
+main().catch((error) => {
+  process.stderr.write(`Sentient live Grant form failed: ${error.stack || error.message}\n`);
+  process.exitCode = 1;
+});

--- a/scripts/test-sentient-application-package.js
+++ b/scripts/test-sentient-application-package.js
@@ -11,9 +11,11 @@ const answerFile = path.join(ROOT, 'docs', 'grants', 'TYPEFORM_ANSWER_PACK.md');
 const readinessFile = path.join(ROOT, 'docs', 'grants', 'SUBMISSION_READINESS.md');
 const checklistFile = path.join(ROOT, 'docs', 'grants', 'APPLICATION_CHECKLIST.md');
 const rendererFile = path.join(ROOT, 'scripts', 'render-sentient-grant-packet.py');
+const formCheckFile = path.join(ROOT, 'scripts', 'check-sentient-grant-form.js');
 const pdfFile = path.join(ROOT, 'output', 'pdf', 'citadel-sentient-grant-packet.pdf');
+const packageFile = path.join(ROOT, 'package.json');
 
-for (const file of [answerFile, readinessFile, checklistFile, rendererFile, pdfFile]) {
+for (const file of [answerFile, readinessFile, checklistFile, rendererFile, formCheckFile, pdfFile, packageFile]) {
   assert.ok(fs.existsSync(file), `missing application package file: ${path.relative(ROOT, file)}`);
 }
 
@@ -21,7 +23,9 @@ const answers = fs.readFileSync(answerFile, 'utf8');
 const readiness = fs.readFileSync(readinessFile, 'utf8');
 const checklist = fs.readFileSync(checklistFile, 'utf8');
 const renderer = fs.readFileSync(rendererFile, 'utf8');
+const formCheck = fs.readFileSync(formCheckFile, 'utf8');
 const pdf = fs.readFileSync(pdfFile);
+const packageJson = JSON.parse(fs.readFileSync(packageFile, 'utf8'));
 
 const oneLine = 'An open control layer that proves whether AI agents finished and what it cost.';
 assert.ok(oneLine.length <= 80, `one-line answer exceeds Typeform limit: ${oneLine.length}`);
@@ -34,6 +38,11 @@ for (const placeholder of ['[SETH EMAIL]', '[CITY, COUNTRY]']) {
 assert.ok(!answers.includes('[HOW SETH HEARD ABOUT SENTIENT]'), 'Grant path must not require the skipped how-heard field');
 assert.match(answers, /jumps from the required supporting-document upload\s+directly to the thank-you screen/i);
 assert.match(readiness, /Grant-branch logic jumps from the supporting\s+document field to the grant thank-you screen/i);
+assert.strictEqual(packageJson.scripts['application:form:check'], 'node scripts/check-sentient-grant-form.js');
+assert.match(readiness, /npm run application:form:check/);
+assert.match(formCheck, /EXPECTED_GRANT_FIELDS/);
+assert.match(formCheck, /611739716b3eb5ad7b16a2e93778f91b9b8cc06ff5ffcbe2eb843c4683544dcd/);
+assert.match(readiness, /611739716b3eb5ad7b16a2e93778f91b9b8cc06ff5ffcbe2eb843c4683544dcd/);
 
 for (const liveField of [
   'Email',


### PR DESCRIPTION
## What changed

- Add `npm run application:form:check`, a read-only live Sentient Typeform contract gate.
- Verify the exact ordered set of 13 required Grant inputs, field types, required status, the 80-character limit, and funding choices.
- Prove that the Grant branch exits from the supporting-document upload to the grant thank-you screen and skips the combined-form how-heard field.
- Pin the observed live contract fingerprint and bind the gate into the application package tests and readiness checklist.

## Why

The prior manual audit caught a meaningful difference between the combined Typeform field inventory and the actual Grant branch. A repeatable drift gate makes the final pre-submission check fail closed if Sentient adds, removes, reorders, or changes a Grant field or its branch logic.

The gate only fetches the public form definition. It does not enter applicant data, create a partial response, upload a document, or submit the form.

## Validation

- `npm run application:form:check`
- `npm run application:package:test`
- `npm run application:claims:test`
- `npm run application:evidence:check`
- `npm run application:media:test`
- `npm run site:release:verify`
- `npm test`
- `node --check scripts/check-sentient-grant-form.js`
- `git diff --check`

Observed live Grant fingerprint: `sha256:611739716b3eb5ad7b16a2e93778f91b9b8cc06ff5ffcbe2eb843c4683544dcd`.
