### PR TITLE
Close public evaluator dependency chain

### DIFF
--- a/.github/workflows/public-holdout-evaluation.yml
+++ b/.github/workflows/public-holdout-evaluation.yml
@@ -64,6 +64,12 @@ jobs:
           repository: microsoft/SWE-bench-Live
           ref: 70ec57e852e3f2d195790fe71f553e272c691833
           path: swe-bench-live
+          submodules: recursive
+      - name: Verify evaluator dependency closure
+        shell: bash
+        run: |
+          test "$(git -C swe-bench-live rev-parse HEAD)" = "70ec57e852e3f2d195790fe71f553e272c691833"
+          test "$(git -C swe-bench-live/launch rev-parse HEAD)" = "7735b1e7363dd3bbc69bd0ef80db646a2ae391fd"
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'

--- a/benchmarks/public-holdout-capstone/METHOD.md
+++ b/benchmarks/public-holdout-capstone/METHOD.md
@@ -6,6 +6,8 @@ Status: implementation and candidate-pool construction. No model has been run on
 
 The first public request, `sha256:2f82dbbdf4b71c0d3ff58946ba09c90bd95af7930b27f200513526f7b1a0c880`, was merged in PR #233 before selection. A non-benchmark smoke on Citadel's own repository then exposed `ENAMETOOLONG`: the Claude prompt was passed as a Windows command-line argument. No candidate was selected and no benchmark task was sent to any model. The replacement runner streams the same bounded prompt over stdin, and the replacement request explicitly binds the superseded request ID. Only the newest request merged before the committed round governs selection.
 
+The next governing request, `sha256:af8f4bc938bedd7f1f913b1f0c853972db99e5a4d194d1e8a3e0589de13d0755`, produced selection `sha256:720e46672c751c3d2d39dbc399f99d32b389f9efea8d5151a2cf645dacc529ff`. Its first public gold preflight (GitHub Actions run `30766637122`) correctly classified all cells as setup errors before assignment: the pinned Microsoft evaluator's `launch` dependency is a git submodule, but the workflow had not checked submodules out. No model was run and no task was assigned. The replacement workflow recursively checks out the evaluator closure, verifies both the parent and `launch` commits, and records process exit status plus both evaluator commits in every summary. A new prospective request and beacon selection are required after this source change; the failed preflight and prior selection remain public negative evidence.
+
 ## Question
 
 Can an evidence-conditioned Citadel controller reduce the comparison cost of real repository repair operations while remaining non-inferior to an always-Claude baseline under model-external tests?

--- a/scripts/public-holdout-evaluator-summary.js
+++ b/scripts/public-holdout-evaluator-summary.js
@@ -4,16 +4,26 @@ const fs = require('fs');
 const path = require('path');
 const { digest } = require('../core/operation-control/contracts');
 
-function readResult(file, instanceId) {
-  if (!fs.existsSync(file)) return { status: 'error', result_digest: null, reason: 'results-json-missing' };
+const EVALUATOR_COMMIT = '70ec57e852e3f2d195790fe71f553e272c691833';
+const EVALUATOR_LAUNCH_COMMIT = '7735b1e7363dd3bbc69bd0ef80db646a2ae391fd';
+
+function readExitStatus(file) {
+  if (!fs.existsSync(file)) return null;
+  const value = Number.parseInt(fs.readFileSync(file, 'utf8').trim(), 10);
+  return Number.isInteger(value) ? value : null;
+}
+
+function readResult(file, instanceId, exitStatusFile = path.join(path.dirname(file), 'process-exit-status.txt')) {
+  const processExitStatus = readExitStatus(exitStatusFile);
+  if (!fs.existsSync(file)) return { status: 'error', result_digest: null, process_exit_status: processExitStatus, reason: processExitStatus === null ? 'results-json-and-process-status-missing' : `evaluator-exit-${processExitStatus}-results-json-missing` };
   const result = JSON.parse(fs.readFileSync(file, 'utf8'));
   const status = result.success_ids?.includes(instanceId) ? 'passed' : result.failure_ids?.includes(instanceId) ? 'failed' : result.empty_patch_ids?.includes(instanceId) ? 'failed' : 'error';
-  return { status, result_digest: digest(result), reason: status === 'error' ? 'official-evaluator-error-or-incomplete' : null };
+  return { status, result_digest: digest(result), process_exit_status: processExitStatus, reason: status === 'error' ? 'official-evaluator-error-or-incomplete' : null };
 }
 
 function summarize({ mode, instanceId, split, featureKey, outputRoot, repetitions, outputFile }) {
   const attempts = Array.from({ length: repetitions }, (_, index) => ({ repetition: index + 1, ...readResult(path.join(outputRoot, `run-${index + 1}`, 'results.json'), instanceId) }));
-  const unsigned = { schema: 1, kind: 'citadel_public_holdout_evaluator_summary', summary_id: null, mode, instance_id: instanceId, repo: process.env.CITADEL_TASK_REPO || null, split, feature_key: featureKey, evaluator_repo: 'https://github.com/microsoft/SWE-bench-Live', evaluator_commit: '70ec57e852e3f2d195790fe71f553e272c691833', runner: { os: process.env.RUNNER_OS || null, arch: process.env.RUNNER_ARCH || null, name: process.env.RUNNER_NAME || null, image: process.env.ImageOS || null }, attempts, passes: attempts.filter((attempt) => attempt.status === 'passed').length, failures: attempts.filter((attempt) => attempt.status === 'failed').length, errors: attempts.filter((attempt) => attempt.status === 'error').length };
+  const unsigned = { schema: 1, kind: 'citadel_public_holdout_evaluator_summary', summary_id: null, mode, instance_id: instanceId, repo: process.env.CITADEL_TASK_REPO || null, split, feature_key: featureKey, evaluator_repo: 'https://github.com/microsoft/SWE-bench-Live', evaluator_commit: EVALUATOR_COMMIT, evaluator_launch_commit: EVALUATOR_LAUNCH_COMMIT, runner: { os: process.env.RUNNER_OS || null, arch: process.env.RUNNER_ARCH || null, name: process.env.RUNNER_NAME || null, image: process.env.ImageOS || null }, attempts, passes: attempts.filter((attempt) => attempt.status === 'passed').length, failures: attempts.filter((attempt) => attempt.status === 'failed').length, errors: attempts.filter((attempt) => attempt.status === 'error').length };
   const summary = { ...unsigned, summary_id: digest(unsigned) };
   fs.mkdirSync(path.dirname(outputFile), { recursive: true }); fs.writeFileSync(outputFile, `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
   return summary;
@@ -26,4 +36,4 @@ function main() {
 }
 
 if (require.main === module) main();
-module.exports = Object.freeze({ readResult, summarize });
+module.exports = Object.freeze({ EVALUATOR_COMMIT, EVALUATOR_LAUNCH_COMMIT, readExitStatus, readResult, summarize });

--- a/scripts/test-public-holdout-capstone.js
+++ b/scripts/test-public-holdout-capstone.js
@@ -15,6 +15,7 @@ const { buildAnalysis, buildAssignment, buildPreflight, buildRouteLedger, buildV
 const { retrieve } = require('../core/public-holdout/retrieval');
 const { parseFiles, promptFor } = require('../core/public-holdout/runner');
 const { goldMatrix } = require('./public-holdout-matrix');
+const { EVALUATOR_COMMIT, EVALUATOR_LAUNCH_COMMIT, readResult } = require('./public-holdout-evaluator-summary');
 
 function row(index, split, issueSize = 'short') {
   const extension = split === 'js' ? 'js' : 'ts';
@@ -48,8 +49,8 @@ function costs(amount) {
 }
 
 function evaluatorSummary(mode, candidate, status = 'passed', repetitions = 1) {
-  const attempts = Array.from({ length: repetitions }, (_, index) => ({ repetition: index + 1, status, result_digest: digest(`${candidate.instance_id}-${index}`), reason: null }));
-  const unsigned = { schema: 1, kind: 'citadel_public_holdout_evaluator_summary', summary_id: null, mode, instance_id: candidate.instance_id, repo: candidate.repo, split: candidate.split, feature_key: candidate.public_features.feature_key, evaluator_repo: 'https://github.com/microsoft/SWE-bench-Live', evaluator_commit: '70ec57e852e3f2d195790fe71f553e272c691833', runner: { os: 'Linux', arch: 'X64', name: 'test', image: 'ubuntu24' }, attempts, passes: status === 'passed' ? repetitions : 0, failures: status === 'failed' ? repetitions : 0, errors: status === 'error' ? repetitions : 0 };
+  const attempts = Array.from({ length: repetitions }, (_, index) => ({ repetition: index + 1, status, result_digest: digest(`${candidate.instance_id}-${index}`), process_exit_status: 0, reason: null }));
+  const unsigned = { schema: 1, kind: 'citadel_public_holdout_evaluator_summary', summary_id: null, mode, instance_id: candidate.instance_id, repo: candidate.repo, split: candidate.split, feature_key: candidate.public_features.feature_key, evaluator_repo: 'https://github.com/microsoft/SWE-bench-Live', evaluator_commit: EVALUATOR_COMMIT, evaluator_launch_commit: EVALUATOR_LAUNCH_COMMIT, runner: { os: 'Linux', arch: 'X64', name: 'test', image: 'ubuntu24' }, attempts, passes: status === 'passed' ? repetitions : 0, failures: status === 'failed' ? repetitions : 0, errors: status === 'error' ? repetitions : 0 };
   return { ...unsigned, summary_id: digest(unsigned) };
 }
 
@@ -65,6 +66,16 @@ function main() {
   assert.strictEqual(candidateFromRow({ row_idx: 1, row: row(1, 'ts') }, 'ts').public_features.feature_key, 'ts.issue-short');
 
   const pool = fakePool();
+  const evaluatorFixture = fs.mkdtempSync(path.join(os.tmpdir(), 'citadel-evaluator-summary-test-'));
+  try {
+    const exitStatusFile = path.join(evaluatorFixture, 'process-exit-status.txt');
+    fs.writeFileSync(exitStatusFile, '1\n', 'utf8');
+    assert.deepStrictEqual(readResult(path.join(evaluatorFixture, 'results.json'), 'fixture', exitStatusFile), { status: 'error', result_digest: null, process_exit_status: 1, reason: 'evaluator-exit-1-results-json-missing' });
+    const result = { success_ids: ['fixture'], failure_ids: [], empty_patch_ids: [], error_ids: [] };
+    fs.writeFileSync(path.join(evaluatorFixture, 'results.json'), `${JSON.stringify(result)}\n`, 'utf8');
+    fs.writeFileSync(exitStatusFile, '0\n', 'utf8');
+    assert.deepStrictEqual(readResult(path.join(evaluatorFixture, 'results.json'), 'fixture', exitStatusFile), { status: 'passed', result_digest: digest(result), process_exit_status: 0, reason: null });
+  } finally { fs.rmSync(evaluatorFixture, { recursive: true, force: true }); }
   assert.strictEqual(pool.counts.total, 180);
   const signature = 'ab'.repeat(96);
   const randomness = crypto.createHash('sha256').update(Buffer.from(signature, 'hex')).digest('hex');


### PR DESCRIPTION
## What changed

- recursively checks out the pinned Microsoft evaluator's RepoLaunch submodule
- verifies evaluator commit `70ec57e852e3f2d195790fe71f553e272c691833` and launch commit `7735b1e7363dd3bbc69bd0ef80db646a2ae391fd` before evaluation
- records both commits and each evaluator process exit status in content-addressed summaries
- documents failed gold run `30766637122` as setup-only negative evidence

## Why

The first public gold preflight correctly produced 80 setup errors before assignment. The pinned evaluator imports `launch.core`, but `launch` is a git submodule and the workflow had not checked it out. No model was run and no task was assigned.

## Verification

- `npm run holdout:test`
- branch-scoped public gold smoke: `30767102154`
- Mongoose: 3/3 gold passes, exit 0, identical result digests
- Ember CLI: 3/3 gold passes, exit 0, identical result digests
- Formbricks: 3/3 gold passes, exit 0, identical result digests
- MetaMask Mobile: 0/3 gold passes, exit 0, identical result digests; correctly classified environment-invalid rather than a setup/import error
- all four summaries record the pinned evaluator and RepoLaunch commits
- repository CI: 17/17 checks passed

After merge, the source change requires a new prospective request and future-beacon selection. The prior request, selection, failed preflight, and fix remain public.
