### PR TITLE
proof: freeze fast public holdout pilot

### DIFF
--- a/.github/workflows/public-holdout-pilot-evaluation.yml
+++ b/.github/workflows/public-holdout-pilot-evaluation.yml
@@ -1,0 +1,105 @@
+name: Public holdout fast pilot evaluator
+
+on:
+  workflow_dispatch:
+    inputs:
+      prediction_path:
+        description: Frozen pilot prediction JSON
+        required: true
+        type: string
+      selection_path:
+        description: Parent frozen public selection record
+        required: true
+        default: benchmarks/public-holdout-capstone/selection.json
+      pool_path:
+        description: Parent frozen candidate pool
+        required: true
+        default: benchmarks/public-holdout-capstone/candidate-pool.json
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+      count: ${{ steps.matrix.outputs.count }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: matrix
+        shell: bash
+        run: node scripts/public-holdout-matrix.js prediction "${{ inputs.selection_path }}" "${{ inputs.pool_path }}" "${{ inputs.prediction_path }}" 0 0 >> "$GITHUB_OUTPUT"
+
+  evaluate:
+    needs: prepare
+    if: ${{ needs.prepare.outputs.count != '0' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    steps:
+      - name: Check out Citadel protocol and predictions
+        uses: actions/checkout@v4
+        with:
+          path: citadel
+      - name: Check out pinned official evaluator
+        uses: actions/checkout@v4
+        with:
+          repository: microsoft/SWE-bench-Live
+          ref: 70ec57e852e3f2d195790fe71f553e272c691833
+          path: swe-bench-live
+          submodules: recursive
+      - name: Verify evaluator dependency closure
+        shell: bash
+        run: |
+          test "$(git -C swe-bench-live rev-parse HEAD)" = "70ec57e852e3f2d195790fe71f553e272c691833"
+          test "$(git -C swe-bench-live/launch rev-parse HEAD)" = "7735b1e7363dd3bbc69bd0ef80db646a2ae391fd"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: swe-bench-live/pyproject.toml
+      - name: Install official evaluator
+        run: python -m pip install -e ./swe-bench-live
+      - name: Evaluate with a graceful cell deadline
+        shell: bash
+        env:
+          INSTANCE_ID: ${{ matrix.instance_id }}
+          SPLIT: ${{ matrix.split }}
+          PREDICTION_PATH: ${{ github.workspace }}/citadel/${{ inputs.prediction_path }}
+        run: |
+          output="${{ github.workspace }}/evaluator-output/run-1"
+          mkdir -p "$output"
+          set +e
+          (
+            cd swe-bench-live
+            timeout --signal=TERM --kill-after=60s 60m \
+              python -m evaluation.evaluation \
+                --dataset SWE-bench-Live/MultiLang \
+                --split "$SPLIT" \
+                --instance_ids "$INSTANCE_ID" \
+                --platform linux \
+                --patch_dir "$PREDICTION_PATH" \
+                --output_dir "$output" \
+                --workers 1 \
+                --overwrite 1
+          )
+          status=$?
+          set -e
+          printf '%s\n' "$status" > "$output/process-exit-status.txt"
+      - name: Write content-addressed evaluator summary
+        if: always()
+        env:
+          CITADEL_TASK_REPO: ${{ matrix.repo }}
+        run: node citadel/scripts/public-holdout-evaluator-summary.js prediction "${{ matrix.instance_id }}" "${{ matrix.split }}" "${{ matrix.feature_key }}" "${{ github.workspace }}/evaluator-output" 1 "${{ github.workspace }}/evaluator-output/summary.json"
+      - name: Upload verifier evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: prediction-${{ matrix.artifact_name }}
+          path: evaluator-output
+          if-no-files-found: error
+          retention-days: 30

--- a/benchmarks/public-holdout-pilot/METHOD.md
+++ b/benchmarks/public-holdout-pilot/METHOD.md
@@ -1,0 +1,40 @@
+# Public holdout fast pilot — frozen secondary method
+
+## Status and provenance
+
+This is a bounded secondary pilot derived from the public capstone selection and signed gold preflight. It is not a continuation or reinterpretation of the primary capstone, which terminated `setup-unknown` before model inference because only 41 of 60 required evaluation tasks could be assigned. The terminal record remains unchanged.
+
+No model has been run on a pilot-assigned task when this method and its assignment are frozen. The reduced sample size and two-plan design were chosen using setup yield and runtime only. No model output or model verdict exists to influence the design.
+
+## Question
+
+Across a small, diverse sample of outside-authored repository repairs, can Citadel use calibration evidence to choose between local-first execution and direct Claude while preserving observed verified quality and reducing comparison cost?
+
+## Fixed sample
+
+The pilot reuses the parent drand selection and the signed 80-task gold preflight. Within each of the four frozen language/issue-length strata, it scans the existing public rank order and accepts only tasks with three of three gold passes. It assigns the first two eligible tasks to calibration and the next four to untouched evaluation, with a maximum of one task from any repository. The fixed result is 8 calibration tasks, 16 evaluation tasks, and 24 distinct repositories. If those quotas cannot be filled, the pilot stops `setup-unknown` before inference.
+
+This preflight-informed secondary design is disclosed precisely because the primary 20/60 quota failed. It makes no claim to preserve the primary study's preregistration or statistical power.
+
+## Plans and controller
+
+Every assigned task receives independent outputs from:
+
+1. Qwen 2.5 Coder 3B locally through the pinned Ollama model digest;
+2. Claude Sonnet through authenticated Claude Code 2.1.219.
+
+Calibration records the official verifier result, duration, measured local GPU economics, and provider-reported Claude comparison amount for both plans. For each evaluation task, Citadel compares two root paths: Qwen 3B then Claude after verifier rejection, or Claude directly. The direct-Claude conservative probability in the same stratum is the quality target. Citadel chooses the lower expected comparison-cost path meeting that target, or the highest conservative-quality path if neither meets it. All 16 routes and the calibration-history digest are signed and published before evaluation-task model calls.
+
+## Information and verifier boundary
+
+Models receive only the issue statement and deterministic repository files retrieved at the pinned base commit. They receive no accepted patch, test patch, hints, hidden test names, competing output, assignment phase, or verifier result. Model tools and network access are disabled. Microsoft's pinned SWE-bench-Live evaluator and per-instance containers remain the only completion authority.
+
+Prediction evaluation is bounded to 60 minutes per cell. A timeout or evaluator defect is `unknown`, never a model failure. The workflow still emits and uploads a content-addressed summary instead of allowing the entire run to end as an unexplained cancellation.
+
+## Policies, economics, and claims
+
+The paired policies are always-Claude, static local-first, and the sealed Citadel controller. A policy stops on its first official pass; speculative unvisited outputs are disclosed but excluded from policy comparison cost. Provider-reported Claude comparison USD and measured local GPU-derived comparison cost are kept separate from actual subscription cash, which remains unknown.
+
+The primary pilot readout is descriptive: observed paired verified rates and total comparison cost across the 16 tasks. A preliminary signal requires Citadel's observed verified rate to be no lower than always-Claude and its comparison cost to be lower. A stratified paired bootstrap is reported as exploratory uncertainty, not as a population noninferiority test. No universal savings, production reliability, or best-in-class claim is permitted.
+
+Passed, failed, and unknown results are all signed and published. There is no task replacement, model-result tuning, optional stopping, or positive-only publication.

--- a/benchmarks/public-holdout-pilot/assignment.json
+++ b/benchmarks/public-holdout-pilot/assignment.json
@@ -1,0 +1,425 @@
+{
+  "schema": 1,
+  "kind": "citadel_public_holdout_fast_pilot_assignment",
+  "assignment_id": "sha256:c5fa3f2a08617b1347fa402964fb91ae422036333a92fc1f551da073e3eb765e",
+  "freeze_id": "sha256:cfe2d091ccd01effd8cacc443986e649a9db442a828fbe20946673a9eff173c8",
+  "parent_selection_id": "sha256:ed6ee76eee129446a6100c93fa8be9bac917dd7d990c0d8d42c6c48c8216f662",
+  "parent_preflight_id": "sha256:f850bb657050fc71dea0846332db111758cde58c47571285f70cf5c815d613bc",
+  "status": "ready",
+  "assignments": {
+    "calibration": [
+      "rollup__rollup-6041",
+      "nodejs__undici-5011",
+      "codeceptjs__CodeceptJS-5072",
+      "siimon__prom-client-679",
+      "excalidraw__excalidraw-9760",
+      "mui__base-ui-2493",
+      "QwenLM__qwen-code-349",
+      "TypeCellOS__BlockNote-2629"
+    ],
+    "evaluation": [
+      "preactjs__preact-4880",
+      "GladysAssistant__Gladys-2504",
+      "simple-icons__simple-icons-13659",
+      "moment__luxon-1720",
+      "gsd-build__get-shit-done-2186",
+      "docsifyjs__docsify-2595",
+      "openai__codex-plugin-cc-83",
+      "aralroca__next-translate-1259",
+      "MetaMask__metamask-mobile-17294",
+      "denoland__std-6775",
+      "RocketChat__Rocket.Chat.ReactNative-6382",
+      "jhlywa__chess.js-546",
+      "code-yeongyu__oh-my-openagent-3013",
+      "honojs__hono-4269",
+      "TanStack__router-4611",
+      "openai__openai-agents-js-156"
+    ]
+  },
+  "decisions": [
+    {
+      "split": "js",
+      "feature_key": "js.issue-short",
+      "rank": 1,
+      "instance_id": "grommet__grommet-7719",
+      "repo": "grommet/grommet",
+      "gold_disposition": "gold-invalid",
+      "disposition": "gold-invalid"
+    },
+    {
+      "split": "js",
+      "feature_key": "js.issue-short",
+      "rank": 11,
+      "instance_id": "rollup__rollup-6041",
+      "repo": "rollup/rollup",
+      "gold_disposition": "gold-valid",
+      "disposition": "calibration"
+    },
+    {
+      "split": "js",
+      "feature_key": "js.issue-short",
+      "rank": 12,
+      "instance_id": "hotwired__turbo-1421",
+      "repo": "hotwired/turbo",
+      "gold_disposition": "gold-invalid",
+      "disposition": "gold-invalid"
+    },
+    {
+      "split": "js",
+      "feature_key": "js.issue-short",
+      "rank": 13,
+      "instance_id": "rollup__rollup-6071",
+      "repo": "rollup/rollup",
+      "gold_disposition": "gold-valid",
+      "disposition": "repo-cap"
+    },
+    {
+      "split": "js",
+      "feature_key": "js.issue-short",
+      "rank": 15,
+      "instance_id": "nodejs__undici-5011",
+      "repo": "nodejs/undici",
+      "gold_disposition": "gold-valid",
+      "disposition": "calibration"
+    },
+    {
+      "split": "js",
+      "feature_key": "js.issue-short",
+      "rank": 16,
+      "instance_id": "preactjs__preact-4880",
+      "repo": "preactjs/preact",
+      "gold_disposition": "gold-valid",
+      "disposition": "evaluation"
+    },
+    {
+      "split": "js",
+      "feature_key": "js.issue-short",
+      "rank": 17,
+      "instance_id": "GladysAssistant__Gladys-2504",
+      "repo": "GladysAssistant/Gladys",
+      "gold_disposition": "gold-valid",
+      "disposition": "evaluation"
+    },
+    {
+      "split": "js",
+      "feature_key": "js.issue-short",
+      "rank": 19,
+      "instance_id": "stdlib-js__stdlib-7672",
+      "repo": "stdlib-js/stdlib",
+      "gold_disposition": "setup-unknown",
+      "disposition": "setup-unknown"
+    },
+    {
+      "split": "js",
+      "feature_key": "js.issue-short",
+      "rank": 22,
+      "instance_id": "rollup__rollup-6051",
+      "repo": "rollup/rollup",
+      "gold_disposition": "gold-invalid",
+      "disposition": "gold-invalid"
+    },
+    {
+      "split": "js",
+      "feature_key": "js.issue-short",
+      "rank": 25,
+      "instance_id": "simple-icons__simple-icons-13659",
+      "repo": "simple-icons/simple-icons",
+      "gold_disposition": "gold-valid",
+      "disposition": "evaluation"
+    },
+    {
+      "split": "js",
+      "feature_key": "js.issue-short",
+      "rank": 26,
+      "instance_id": "TryGhost__Ghost-24345",
+      "repo": "TryGhost/Ghost",
+      "gold_disposition": "gold-invalid",
+      "disposition": "gold-invalid"
+    },
+    {
+      "split": "js",
+      "feature_key": "js.issue-short",
+      "rank": 29,
+      "instance_id": "moment__luxon-1720",
+      "repo": "moment/luxon",
+      "gold_disposition": "gold-valid",
+      "disposition": "evaluation"
+    },
+    {
+      "split": "js",
+      "feature_key": "js.issue-long",
+      "rank": 2,
+      "instance_id": "nodejs__undici-5000",
+      "repo": "nodejs/undici",
+      "gold_disposition": "gold-valid",
+      "disposition": "repo-cap"
+    },
+    {
+      "split": "js",
+      "feature_key": "js.issue-long",
+      "rank": 3,
+      "instance_id": "shaka-project__shaka-player-8835",
+      "repo": "shaka-project/shaka-player",
+      "gold_disposition": "gold-invalid",
+      "disposition": "gold-invalid"
+    },
+    {
+      "split": "js",
+      "feature_key": "js.issue-long",
+      "rank": 4,
+      "instance_id": "nodejs__undici-4453",
+      "repo": "nodejs/undici",
+      "gold_disposition": "gold-valid",
+      "disposition": "repo-cap"
+    },
+    {
+      "split": "js",
+      "feature_key": "js.issue-long",
+      "rank": 5,
+      "instance_id": "codeceptjs__CodeceptJS-5072",
+      "repo": "codeceptjs/CodeceptJS",
+      "gold_disposition": "gold-valid",
+      "disposition": "calibration"
+    },
+    {
+      "split": "js",
+      "feature_key": "js.issue-long",
+      "rank": 6,
+      "instance_id": "rollup__rollup-6038",
+      "repo": "rollup/rollup",
+      "gold_disposition": "gold-valid",
+      "disposition": "repo-cap"
+    },
+    {
+      "split": "js",
+      "feature_key": "js.issue-long",
+      "rank": 7,
+      "instance_id": "siimon__prom-client-679",
+      "repo": "siimon/prom-client",
+      "gold_disposition": "gold-valid",
+      "disposition": "calibration"
+    },
+    {
+      "split": "js",
+      "feature_key": "js.issue-long",
+      "rank": 8,
+      "instance_id": "gsd-build__get-shit-done-2186",
+      "repo": "gsd-build/get-shit-done",
+      "gold_disposition": "gold-valid",
+      "disposition": "evaluation"
+    },
+    {
+      "split": "js",
+      "feature_key": "js.issue-long",
+      "rank": 9,
+      "instance_id": "Automattic__mongoose-16153",
+      "repo": "Automattic/mongoose",
+      "gold_disposition": "setup-unknown",
+      "disposition": "setup-unknown"
+    },
+    {
+      "split": "js",
+      "feature_key": "js.issue-long",
+      "rank": 10,
+      "instance_id": "docsifyjs__docsify-2595",
+      "repo": "docsifyjs/docsify",
+      "gold_disposition": "gold-valid",
+      "disposition": "evaluation"
+    },
+    {
+      "split": "js",
+      "feature_key": "js.issue-long",
+      "rank": 14,
+      "instance_id": "openai__codex-plugin-cc-83",
+      "repo": "openai/codex-plugin-cc",
+      "gold_disposition": "gold-valid",
+      "disposition": "evaluation"
+    },
+    {
+      "split": "js",
+      "feature_key": "js.issue-long",
+      "rank": 18,
+      "instance_id": "facebook__stylex-1209",
+      "repo": "facebook/stylex",
+      "gold_disposition": "gold-invalid",
+      "disposition": "gold-invalid"
+    },
+    {
+      "split": "js",
+      "feature_key": "js.issue-long",
+      "rank": 20,
+      "instance_id": "aralroca__next-translate-1259",
+      "repo": "aralroca/next-translate",
+      "gold_disposition": "gold-valid",
+      "disposition": "evaluation"
+    },
+    {
+      "split": "ts",
+      "feature_key": "ts.issue-short",
+      "rank": 2,
+      "instance_id": "excalidraw__excalidraw-9760",
+      "repo": "excalidraw/excalidraw",
+      "gold_disposition": "gold-valid",
+      "disposition": "calibration"
+    },
+    {
+      "split": "ts",
+      "feature_key": "ts.issue-short",
+      "rank": 5,
+      "instance_id": "mui__base-ui-2493",
+      "repo": "mui/base-ui",
+      "gold_disposition": "gold-valid",
+      "disposition": "calibration"
+    },
+    {
+      "split": "ts",
+      "feature_key": "ts.issue-short",
+      "rank": 7,
+      "instance_id": "MetaMask__metamask-mobile-17294",
+      "repo": "MetaMask/metamask-mobile",
+      "gold_disposition": "gold-valid",
+      "disposition": "evaluation"
+    },
+    {
+      "split": "ts",
+      "feature_key": "ts.issue-short",
+      "rank": 8,
+      "instance_id": "MetaMask__metamask-mobile-17208",
+      "repo": "MetaMask/metamask-mobile",
+      "gold_disposition": "gold-invalid",
+      "disposition": "gold-invalid"
+    },
+    {
+      "split": "ts",
+      "feature_key": "ts.issue-short",
+      "rank": 9,
+      "instance_id": "denoland__std-6775",
+      "repo": "denoland/std",
+      "gold_disposition": "gold-valid",
+      "disposition": "evaluation"
+    },
+    {
+      "split": "ts",
+      "feature_key": "ts.issue-short",
+      "rank": 10,
+      "instance_id": "lightdash__lightdash-15838",
+      "repo": "lightdash/lightdash",
+      "gold_disposition": "gold-invalid",
+      "disposition": "gold-invalid"
+    },
+    {
+      "split": "ts",
+      "feature_key": "ts.issue-short",
+      "rank": 11,
+      "instance_id": "RocketChat__Rocket.Chat.ReactNative-6382",
+      "repo": "RocketChat/Rocket.Chat.ReactNative",
+      "gold_disposition": "gold-valid",
+      "disposition": "evaluation"
+    },
+    {
+      "split": "ts",
+      "feature_key": "ts.issue-short",
+      "rank": 12,
+      "instance_id": "jhlywa__chess.js-546",
+      "repo": "jhlywa/chess.js",
+      "gold_disposition": "gold-valid",
+      "disposition": "evaluation"
+    },
+    {
+      "split": "ts",
+      "feature_key": "ts.issue-long",
+      "rank": 1,
+      "instance_id": "QwenLM__qwen-code-349",
+      "repo": "QwenLM/qwen-code",
+      "gold_disposition": "gold-valid",
+      "disposition": "calibration"
+    },
+    {
+      "split": "ts",
+      "feature_key": "ts.issue-long",
+      "rank": 3,
+      "instance_id": "TypeCellOS__BlockNote-2629",
+      "repo": "TypeCellOS/BlockNote",
+      "gold_disposition": "gold-valid",
+      "disposition": "calibration"
+    },
+    {
+      "split": "ts",
+      "feature_key": "ts.issue-long",
+      "rank": 4,
+      "instance_id": "code-yeongyu__oh-my-openagent-3013",
+      "repo": "code-yeongyu/oh-my-openagent",
+      "gold_disposition": "gold-valid",
+      "disposition": "evaluation"
+    },
+    {
+      "split": "ts",
+      "feature_key": "ts.issue-long",
+      "rank": 6,
+      "instance_id": "maplibre__maplibre-gl-js-6216",
+      "repo": "maplibre/maplibre-gl-js",
+      "gold_disposition": "setup-unknown",
+      "disposition": "setup-unknown"
+    },
+    {
+      "split": "ts",
+      "feature_key": "ts.issue-long",
+      "rank": 13,
+      "instance_id": "honojs__hono-4269",
+      "repo": "honojs/hono",
+      "gold_disposition": "gold-valid",
+      "disposition": "evaluation"
+    },
+    {
+      "split": "ts",
+      "feature_key": "ts.issue-long",
+      "rank": 14,
+      "instance_id": "TanStack__router-4611",
+      "repo": "TanStack/router",
+      "gold_disposition": "gold-valid",
+      "disposition": "evaluation"
+    },
+    {
+      "split": "ts",
+      "feature_key": "ts.issue-long",
+      "rank": 16,
+      "instance_id": "MetaMask__metamask-mobile-17623",
+      "repo": "MetaMask/metamask-mobile",
+      "gold_disposition": "gold-invalid",
+      "disposition": "gold-invalid"
+    },
+    {
+      "split": "ts",
+      "feature_key": "ts.issue-long",
+      "rank": 17,
+      "instance_id": "mui__base-ui-2231",
+      "repo": "mui/base-ui",
+      "gold_disposition": "gold-valid",
+      "disposition": "repo-cap"
+    },
+    {
+      "split": "ts",
+      "feature_key": "ts.issue-long",
+      "rank": 19,
+      "instance_id": "maplibre__maplibre-gl-js-6266",
+      "repo": "maplibre/maplibre-gl-js",
+      "gold_disposition": "setup-unknown",
+      "disposition": "setup-unknown"
+    },
+    {
+      "split": "ts",
+      "feature_key": "ts.issue-long",
+      "rank": 20,
+      "instance_id": "openai__openai-agents-js-156",
+      "repo": "openai/openai-agents-js",
+      "gold_disposition": "gold-valid",
+      "disposition": "evaluation"
+    }
+  ],
+  "unique_repository_count": 24,
+  "attestation": {
+    "algorithm": "Ed25519",
+    "payload_digest": "sha256:c71a6525b3774edca275e8104571f85e2f9eee82da61d709b84bdbee45401a67",
+    "signature": "7zdtSDyQacR8DSwVsGz60PaVZG4M9jERATgZnEuZ6hxRWE6NoNKVe31zGNO2w8UtiuJfKaSUxoeYTcIhZUAQCw=="
+  }
+}

--- a/benchmarks/public-holdout-pilot/freeze.json
+++ b/benchmarks/public-holdout-pilot/freeze.json
@@ -1,0 +1,64 @@
+{
+  "schema": 1,
+  "kind": "citadel_public_holdout_fast_pilot_freeze",
+  "freeze_id": "sha256:cfe2d091ccd01effd8cacc443986e649a9db442a828fbe20946673a9eff173c8",
+  "frozen_at": "2026-08-03T17:44:32.478Z",
+  "parent_request_id": "sha256:404f1a5571d1dbcf27120cc750e935e6e8957e2b18653ee90faa0a7e11f36c11",
+  "parent_selection_id": "sha256:ed6ee76eee129446a6100c93fa8be9bac917dd7d990c0d8d42c6c48c8216f662",
+  "parent_preflight_id": "sha256:f850bb657050fc71dea0846332db111758cde58c47571285f70cf5c815d613bc",
+  "parent_terminal_assignment_id": "sha256:320f090a5ac6103fa006d176c5154ffd4d44317a28a0416bc4d33a0c7eb7a102",
+  "parent_terminal_status": "setup-unknown",
+  "design": {
+    "design_id": "public-holdout-fast-pilot-v1",
+    "parent_protocol": "public-holdout-capstone-v1-terminal-setup-unknown",
+    "feature_strata": [
+      "js.issue-short",
+      "js.issue-long",
+      "ts.issue-short",
+      "ts.issue-long"
+    ],
+    "calibration_per_feature_stratum": 2,
+    "evaluation_per_feature_stratum": 4,
+    "calibration_total": 8,
+    "evaluation_total": 16,
+    "maximum_tasks_per_repo": 1,
+    "required_gold_passes": 3,
+    "gold_attempts": 3,
+    "plan_ids": [
+      "qwen-3b",
+      "claude-sonnet"
+    ],
+    "assignment_rule": "within each frozen feature-stratum order, take the first two gold-valid tasks from unique repositories for calibration and the next four for untouched evaluation",
+    "stopping_rule": "if any stratum cannot fill two calibration and four evaluation tasks under the one-task-per-repository cap, stop setup-unknown before model inference",
+    "inference_scope": "bounded paired descriptive pilot; no population-wide noninferiority or universal savings claim"
+  },
+  "source_digests": {
+    ".github/workflows/public-holdout-pilot-evaluation.yml": "sha256:48427908ec4921e005a062ca4dcbb4242955d4a3c9888e4c261e5e1dadaf008d",
+    "benchmarks/public-holdout-pilot/METHOD.md": "sha256:b398c8132c1e20983fe3d57ab7ea92ef63723940287b40fa967fa982bf55ba69",
+    "core/operation-control/contracts.js": "sha256:d91adea8e5f5649dd38712e0fe244a0beb7dbe6e221e308ee975fd152f2fb5be",
+    "core/operation-control/receipt.js": "sha256:3ef5cfce5e17d22f5dbd68ff69cadf9138e95fa6b952c6ac26b29f4e7dc5aa66",
+    "core/operation-controller/contracts.js": "sha256:c7d6c4d25a45d9e153382a6e9e15919b134bb2a83397b7703f42235abcecb6a1",
+    "core/operation-controller/controller.js": "sha256:1c020300887916b7a73cf3cb01a06ab9d94a1036fe91529b9603bfd028923e53",
+    "core/public-holdout/artifacts.js": "sha256:745014481a8c2fe75ab878aed9a47de677c2b71446536ae5062fe615ac475051",
+    "core/public-holdout/dataset.js": "sha256:3457d10311d575357cda8b038cf2c649a11c803ecc516c6a2dfe3e38a1fa429d",
+    "core/public-holdout/retrieval.js": "sha256:47a2604ad57f5a171e82fe7f59e2fd8f6bd16ef3a8f36d679c3a3be40570c0e9",
+    "core/public-holdout/runner.js": "sha256:790d23fb3b17e377270cc9327a34952d7eff2d3ea01a6518018725b83b278768",
+    "core/public-holdout/selection.js": "sha256:e8049c9c77c21c97bc54f4f118d6990a7ccccf74ac81a672e05ebaebc8ede887",
+    "core/public-holdout/statistics.js": "sha256:7808172b494f0b05ba5285e94be28bb05ddff648c33213c8efdac2f83f676246",
+    "core/public-holdout-pilot/artifacts.js": "sha256:c8c6a0be449fd73caeaf92c6338ab3eff2a01fd78cfdcf48380926217e425dd7",
+    "core/public-holdout-pilot/design.js": "sha256:ed8524454832f3a66929e7c73a6359217090eab5ab7978f46625afa3f1e9924d",
+    "core/public-holdout-pilot/router.js": "sha256:0f656293a281f7ce3d2cd4ac24415ef80cf1e0d6dbc01274d7c0ac0e34c779eb",
+    "core/public-holdout-pilot/statistics.js": "sha256:29973cb6b36d236466d91e9ec3bad5a281d3427acdc91df24be3cd64d75998d8",
+    "scripts/public-holdout-capstone.js": "sha256:6dc552ef0d5637eab37df3535feaeed1e666612c576d35fda8b657db67918002",
+    "scripts/public-holdout-evaluator-summary.js": "sha256:24031b3f1c0b971a24f79e3b5c6193aeacdda51e6147cf92fd436b9ea9b22655",
+    "scripts/public-holdout-matrix.js": "sha256:2a9df25c9053bbf53479066301c379992fbc28c2fa3d457fce56b96cc541e469",
+    "scripts/public-holdout-pilot.js": "sha256:5158da4c8cdd9a1913d46865308d96c5acdfcfa9d1539b4dcd8ebb8339ada7ad",
+    "scripts/test-public-holdout-pilot.js": "sha256:ab0cbfa80dee3dc73da40549264dd5b2bfa438863aa8b99e8aab50ea6413ac03"
+  },
+  "attestation_public_key": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAttWhQcx2y2SU1nrcHD82MM3tDuwS0Lvz9w/mmByC/rQ=\n-----END PUBLIC KEY-----\n",
+  "attestation": {
+    "algorithm": "Ed25519",
+    "payload_digest": "sha256:0eef5494980bbeefe098f0a736c113f4b53182889bf7a02d3930322eba1e4ddb",
+    "signature": "XTVB+neFqaJFq5lHGAMhZABhR3dNwbt3UPryiJQWLV/tsW0lYWkUCdVj1KgQOK1K6JbioQCw7ZLd/8/FJTIPBg=="
+  }
+}

--- a/benchmarks/public-holdout-pilot/visible-tasks.json
+++ b/benchmarks/public-holdout-pilot/visible-tasks.json
@@ -1,0 +1,590 @@
+{
+  "schema": 1,
+  "kind": "citadel_public_holdout_fast_pilot_visible_tasks",
+  "artifact_id": "sha256:184f1ff0ac26379a46587723fb432097f330c091b79383692764f624795662c5",
+  "freeze_id": "sha256:cfe2d091ccd01effd8cacc443986e649a9db442a828fbe20946673a9eff173c8",
+  "assignment_id": "sha256:c5fa3f2a08617b1347fa402964fb91ae422036333a92fc1f551da073e3eb765e",
+  "tasks": [
+    {
+      "schema": 1,
+      "instance_id": "rollup__rollup-6041",
+      "split": "js",
+      "row_index": 24,
+      "repo": "rollup/rollup",
+      "pull_number": "6041",
+      "base_commit": "244dc20bab1cd59221b70cd759e0a0ec15044c2e",
+      "created_at": "2025-07-29T13:29:57Z",
+      "docker_image": "starryzhang/sweb.eval.x86_64.rollup_1776_rollup-6041",
+      "problem_statement": "4.46 breaks `styled-components` with new `in` optimization\n### Rollup Version\n\n4.46.1\n\n### Operating System (or Browser)\n\nall\n\n### Node Version (if applicable)\n\n_No response_\n\n### Link To Reproduction\n\nhttps://rollupjs.org/repl/?version=4.46.1&shareable=JTdCJTIyZXhhbXBsZSUyMiUzQW51bGwlMkMlMjJtb2R1bGVzJTIyJTNBJTVCJTdCJTIyY29kZSUyMiUzQSUyMiUyRiUyRiUyMGltcG9ydCUyMHVuaXRsZXNzJTIwZnJvbSUyMCclNDBlbW90aW9uJTJGdW5pdGxlc3MnJTNCJTVDbmltcG9ydCUyMHVuaXRsZXNzJTIwZnJvbSUyMCcuJTJGdW5pdGxlc3MnJTVDbiU1Q24lMkYlMkYlMjBPcmlnaW5hbCUyMGZ1bmN0aW9uJTIwaW4lMjAlNjBzdHlsZWQtY29tcG9uZW50cyU2MCUyQyUyMHN0cmlwcGVkJTIwZm9yJTIwVHlwZVNjcmlwdCUzQSUyMGh0dHBzJTNBJTJGJTJGZ2l0aHViLmNvbSUyRnN0eWxlZC1jb21wb25lbnRzJTJGc3R5bGVkLWNvbXBvbmVudHMlMkZibG9iJTJGZDBiNzNhY2Q5MzFkYWVmOWVlYmI5N2UzNGZlNDU1MmZmYzU3ZDYzZSUyRnBhY2thZ2VzJTJGc3R5bGVkLWNvbXBvbmVudHMlMkZzcmMlMkZ1dGlscyUyRmFkZFVuaXRJZk5lZWRlZC50cyUyM0wxMCU1Q25leHBvcnQlMjBkZWZhdWx0JTIwZnVuY3Rpb24lMjBhZGRVbml0SWZOZWVkZWQobmFtZSUyQyUyMHZhbHVlKSUyMCU3QiU1Q24lMjAlMjAlMkYlMkYlMjBodHRwcyUzQSUyRiUyRmdpdGh1Yi5jb20lMkZhbWlsYWphY2slMkZlc2xpbnQtcGx1Z2luLWZsb3d0eXBlLWVycm9ycyUyRmlzc3VlcyUyRjEzMyU1Q24lMjAlMjBpZiUyMCh2YWx1ZSUyMCUzRCUzRCUyMG51bGwlMjAlN0MlN0MlMjB0eXBlb2YlMjB2YWx1ZSUyMCUzRCUzRCUzRCUyMCdib29sZWFuJyUyMCU3QyU3QyUyMHZhbHVlJTIwJTNEJTNEJTNEJTIwJycpJTIwJTdCJTVDbiUyMCUyMCUyMCUyMHJldHVybiUyMCcnJTNCJTVDbiUyMCUyMCU3RCU1Q24lNUNuJTIwJTIwaWYlMjAodHlwZW9mJTIwdmFsdWUlMjAlM0QlM0QlM0QlMjAnbnVtYmVyJyUyMCUyNiUyNiUyMHZhbHVlJTIwISUzRCUzRCUyMDAlMjAlMjYlMjYlMjAhKG5hbWUlMjBpbiUyMHVuaXRsZXNzKSUyMCUyNiUyNiUyMCFuYW1lLnN0YXJ0c1dpdGgoJy0tJykpJTIwJTdCJTVDbiUyMCUyMCUyMCUyMHJldHVybiUyMCU2MCUyNCU3QnZhbHVlJTdEcHglNjAlM0IlMjAlMkYlMkYlMjBQcmVzdW1lcyUyMGltcGxpY2l0JTIwJ3B4JyUyMHN1ZmZpeCUyMGZvciUyMHVuaXRsZXNzJTIwbnVtYmVycyUyMGV4Y2VwdCUyMGZvciUyMENTUyUyMHZhcmlhYmxlcyU1Q24lMjAlMjAlN0QlNUNuJTVDbiUyMCUyMHJldHVybiUyMFN0cmluZyh2YWx1ZSkudHJpbSgpJTNCJTVDbiU3RCUyMiUyQyUyMmlzRW50cnklMjIlM0F0cnVlJTJDJTIybmFtZSUyMiUzQSUyMm1haW4uanMlMjIlN0QlMkMlN0IlMjJjb2RlJTIyJTNBJTIyJTJGJTJGJTIwRnJvbSUyMGh0dHBzJTNBJTJGJTJGZ2l0aHViLmNvbSUyRmVtb3Rpb24tanMlMkZlbW90aW9uJTJGYmxvYiUyRjQ5MjI5NTUzOTY3YjYwNTBjOTJkOTYwMmViNTc3YmRjNDgxNjdlOTElMkZwYWNrYWdlcyUyRnVuaXRsZXNzJTJGc3JjJTJGaW5kZXgudHMlMjBzdHJpcHBlZCUyMGZyb20lMjBUUyU1Q24lNUNubGV0JTIwdW5pdGxlc3NLZXlzJTIwJTNEJTIwJTdCJTVDbiUyMCUyMGFuaW1hdGlvbkl0ZXJhdGlvbkNvdW50JTNBJTIwMSUyQyU1Q24lMjAlMjBhc3BlY3RSYXRpbyUzQSUyMDElMkMlNUNuJTIwJTIwYm9yZGVySW1hZ2VPdXRzZXQlM0ElMjAxJTJDJTVDbiUyMCUyMGJvcmRlckltYWdlU2xpY2UlM0ElMjAxJTJDJTVDbiUyMCUyMGJvcmRlckltYWdlV2lkdGglM0ElMjAxJTJDJTVDbiUyMCUyMGJveEZsZXglM0ElMjAxJTJDJTVDbiUyMCUyMGJveEZsZXhHcm91cCUzQSUyMDElMkMlNUNuJTIwJTIwYm94T3JkaW5hbEdyb3VwJTNBJTIwMSUyQyU1Q24lMjAlMjBjb2x1bW5Db3VudCUzQSUyMDElMkMlNUNuJTIwJTIwY29sdW1ucyUzQSUyMDElMkMlNUNuJTIwJTIwZmxleCUzQSUyMDElMkMlNUNuJTIwJTIwZmxleEdyb3clM0ElMjAxJTJDJTVDbiUyMCUyMGZsZXhQb3NpdGl2ZSUzQSUyMDElMkMlNUNuJTIwJTIwZmxleFNocmluayUzQSUyMDElMkMlNUNuJTIwJTIwZmxleE5lZ2F0aXZlJTNBJTIwMSUyQyU1Q24lMjAlMjBmbGV4T3JkZXIlM0ElMjAxJTJDJTVDbiUyMCUyMGdyaWRSb3clM0ElMjAxJTJDJTVDbiUyMCUyMGdyaWRSb3dFbmQlM0ElMjAxJTJDJTVDbiUyMCUyMGdyaWRSb3dTcGFuJTNBJTIwMSUyQyU1Q24lMjAlMjBncmlkUm93U3RhcnQlM0ElMjAxJTJDJTVDbiUyMCUyMGdyaWRDb2x1bW4lM0ElMjAxJTJDJTVDbiUyMCUyMGdyaWRDb2x1bW5FbmQlM0ElMjAxJTJDJTVDbiUyMCUyMGdyaWRDb2x1bW5TcGFuJTNBJTIwMSUyQyU1Q24lMjAlMjBncmlkQ29sdW1uU3RhcnQlM0ElMjAxJTJDJTVDbiUyMCUyMG1zR3JpZFJvdyUzQSUyMDElMkMlNUNuJTIwJTIwbXNHcmlkUm93U3BhbiUzQSUyMDElMkMlNUNuJTIwJTIwbXNHcmlkQ29sdW1uJTNBJTIwMSUyQyU1Q24lMjAlMjBtc0dyaWRDb2x1bW5TcGFuJTNBJTIwMSUyQyU1Q24lMjAlMjBmb250V2VpZ2h0JTNBJTIwMSUyQyU1Q24lMjAlMjBsaW5lSGVpZ2h0JTNBJTIwMSUyQyU1Q24lMjAlMjBvcGFjaXR5JTNBJTIwMSUyQyU1Q24lMjAlMjBvcmRlciUzQSUyMDElMkMlNUNuJTIwJTIwb3JwaGFucyUzQSUyMDElMkMlNUNuJTIwJTIwc2NhbGUlM0ElMjAxJTJDJTVDbiUyMCUyMHRhYlNpemUlM0ElMjAxJTJDJTVDbiUyMCUyMHdpZG93cyUzQSUyMDElMkMlNUNuJTIwJTIwekluZGV4JTNBJTIwMSUyQyU1Q24lMjAlMjB6b29tJTNBJTIwMSUyQyU1Q24lMjAlMjBXZWJraXRMaW5lQ2xhbXAlM0ElMjAxJTJDJTVDbiU1Q24lMjAlMjAlMkYlMkYlMjBTVkctcmVsYXRlZCUyMHByb3BlcnRpZXMlNUNuJTIwJTIwZmlsbE9wYWNpdHklM0ElMjAxJTJDJTVDbiUyMCUyMGZsb29kT3BhY2l0eSUzQSUyMDElMkMlNUNuJTIwJTIwc3RvcE9wYWNpdHklM0ElMjAxJTJDJTVDbiUyMCUyMHN0cm9rZURhc2hhcnJheSUzQSUyMDElMkMlNUNuJTIwJTIwc3Ryb2tlRGFzaG9mZnNldCUzQSUyMDElMkMlNUNuJTIwJTIwc3Ryb2tlTWl0ZXJsaW1pdCUzQSUyMDElMkMlNUNuJTIwJTIwc3Ryb2tlT3BhY2l0eSUzQSUyMDElMkMlNUNuJTIwJTIwc3Ryb2tlV2lkdGglM0ElMjAxJTVDbiU3RCU1Q24lNUNuZXhwb3J0JTIwZGVmYXVsdCUyMHVuaXRsZXNzS2V5cyUyMiUyQyUyMmlzRW50cnklMjIlM0FmYWxzZSUyQyUyMm5hbWUlMjIlM0ElMjJ1bml0bGVzcy5qcyUyMiU3RCU1RCUyQyUyMm9wdGlvbnMlMjIlM0ElN0IlN0QlN0Q=\n\n### Expected Behaviour\n\n[Expected behavior is here](https://rollupjs.org/repl/?version=4.45.3&shareable=JTdCJTIyZXhhbXBsZSUyMiUzQW51bGwlMkMlMjJtb2R1bGVzJTIyJTNBJTVCJTdCJTIyY29kZSUyMiUzQSUyMiUyRiUyRiUyMGltcG9ydCUyMHVuaXRsZXNzJTIwZnJvbSUyMCclNDBlbW90aW9uJTJGdW5pdGxlc3MnJTNCJTVDbmltcG9ydCUyMHVuaXRsZXNzJTIwZnJvbSUyMCcuJTJGdW5pdGxlc3MnJTVDbiU1Q24lMkYlMkYlMjBPcmlnaW5hbCUyMGZ1bmN0aW9uJTIwaW4lMjAlNjBzdHlsZWQtY29tcG9uZW50cyU2MCUyQyUyMHN0cmlwcGVkJTIwZm9yJTIwVHlwZVNjcmlwdCUzQSUyMGh0dHBzJTNBJTJGJTJGZ2l0aHViLmNvbSUyRnN0eWxlZC1jb21wb25lbnRzJTJGc3R5bGVkLWNvbXBvbmVudHMlMkZibG9iJTJGZDBiNzNhY2Q5MzFkYWVmOWVlYmI5N2UzNGZlNDU1MmZmYzU3ZDYzZSUyRnBhY2thZ2VzJTJGc3R5bGVkLWNvbXBvbmVudHMlMkZzcmMlMkZ1dGlscyUyRmFkZFVuaXRJZk5lZWRlZC50cyUyM0wxMCU1Q25leHBvcnQlMjBkZWZhdWx0JTIwZnVuY3Rpb24lMjBhZGRVbml0SWZOZWVkZWQobmFtZSUyQyUyMHZhbHVlKSUyMCU3QiU1Q24lMjAlMjAlMkYlMkYlMjBodHRwcyUzQSUyRiUyRmdpdGh1Yi5jb20lMkZhbWlsYWphY2slMkZlc2xpbnQtcGx1Z2luLWZsb3d0eXBlLWVycm9ycyUyRmlzc3VlcyUyRjEzMyU1Q24lMjAlMjBpZiUyMCh2YWx1ZSUyMCUzRCUzRCUyMG51bGwlMjAlN0MlN0MlMjB0eXBlb2YlMjB2YWx1ZSUyMCUzRCUzRCUzRCUyMCdib29sZWFuJyUyMCU3QyU3QyUyMHZhbHVlJTIwJTNEJTNEJTNEJTIwJycpJTIwJTdCJTVDbiUyMCUyMCUyMCUyMHJldHVybiUyMCcnJTNCJTVDbiUyMCUyMCU3RCU1Q24lNUNuJTIwJTIwaWYlMjAodHlwZW9mJTIwdmFsdWUlMjAlM0QlM0QlM0QlMjAnbnVtYmVyJyUyMCUyNiUyNiUyMHZhbHVlJTIwISUzRCUzRCUyMDAlMjAlMjYlMjYlMjAhKG5hbWUlMjBpbiUyMHVuaXRsZXNzKSUyMCUyNiUyNiUyMCFuYW1lLnN0YXJ0c1dpdGgoJy0tJykpJTIwJTdCJTVDbiUyMCUyMCUyMCUyMHJldHVybiUyMCU2MCUyNCU3QnZhbHVlJTdEcHglNjAlM0IlMjAlMkYlMkYlMjBQcmVzdW1lcyUyMGltcGxpY2l0JTIwJ3B4JyUyMHN1ZmZpeCUyMGZvciUyMHVuaXRsZXNzJTIwbnVtYmVycyUyMGV4Y2VwdCUyMGZvciUyMENTUyUyMHZhcmlhYmxlcyU1Q24lMjAlMjAlN0QlNUNuJTVDbiUyMCUyMHJldHVybiUyMFN0cmluZyh2YWx1ZSkudHJpbSgpJTNCJTVDbiU3RCUyMiUyQyUyMmlzRW50cnklMjIlM0F0cnVlJTJDJTIybmFtZSUyMiUzQSUyMm1haW4uanMlMjIlN0QlMkMlN0IlMjJjb2RlJTIyJTNBJTIyJTJGJTJGJTIwRnJvbSUyMGh0dHBzJTNBJTJGJTJGZ2l0aHViLmNvbSUyRmVtb3Rpb24tanMlMkZlbW90aW9uJTJGYmxvYiUyRjQ5MjI5NTUzOTY3YjYwNTBjOTJkOTYwMmViNTc3YmRjNDgxNjdlOTElMkZwYWNrYWdlcyUyRnVuaXRsZXNzJTJGc3JjJTJGaW5kZXgudHMlMjBzdHJpcHBlZCUyMGZyb20lMjBUUyU1Q24lNUNubGV0JTIwdW5pdGxlc3NLZXlzJTIwJTNEJTIwJTdCJTVDbiUyMCUyMGFuaW1hdGlvbkl0ZXJhdGlvbkNvdW50JTNBJTIwMSUyQyU1Q24lMjAlMjBhc3BlY3RSYXRpbyUzQSUyMDElMkMlNUNuJTIwJTIwYm9yZGVySW1hZ2VPdXRzZXQlM0ElMjAxJTJDJTVDbiUyMCUyMGJvcmRlckltYWdlU2xpY2UlM0ElMjAxJTJDJTVDbiUyMCUyMGJvcmRlckltYWdlV2lkdGglM0ElMjAxJTJDJTVDbiUyMCUyMGJveEZsZXglM0ElMjAxJTJDJTVDbiUyMCUyMGJveEZsZXhHcm91cCUzQSUyMDElMkMlNUNuJTIwJTIwYm94T3JkaW5hbEdyb3VwJTNBJTIwMSUyQyU1Q24lMjAlMjBjb2x1bW5Db3VudCUzQSUyMDElMkMlNUNuJTIwJTIwY29sdW1ucyUzQSUyMDElMkMlNUNuJTIwJTIwZmxleCUzQSUyMDElMkMlNUNuJTIwJTIwZmxleEdyb3clM0ElMjAxJTJDJTVDbiUyMCUyMGZsZXhQb3NpdGl2ZSUzQSUyMDElMkMlNUNuJTIwJTIwZmxleFNocmluayUzQSUyMDElMkMlNUNuJTIwJTIwZmxleE5lZ2F0aXZlJTNBJTIwMSUyQyU1Q24lMjAlMjBmbGV4T3JkZXIlM0ElMjAxJTJDJTVDbiUyMCUyMGdyaWRSb3clM0ElMjAxJTJDJTVDbiUyMCUyMGdyaWRSb3dFbmQlM0ElMjAxJTJDJTVDbiUyMCUyMGdyaWRSb3dTcGFuJTNBJTIwMSUyQyU1Q24lMjAlMjBncmlkUm93U3RhcnQlM0ElMjAxJTJDJTVDbiUyMCUyMGdyaWRDb2x1bW4lM0ElMjAxJTJDJTVDbiUyMCUyMGdyaWRDb2x1bW5FbmQlM0ElMjAxJTJDJTVDbiUyMCUyMGdyaWRDb2x1bW5TcGFuJTNBJTIwMSUyQyU1Q24lMjAlMjBncmlkQ29sdW1uU3RhcnQlM0ElMjAxJTJDJTVDbiUyMCUyMG1zR3JpZFJvdyUzQSUyMDElMkMlNUNuJTIwJTIwbXNHcmlkUm93U3BhbiUzQSUyMDElMkMlNUNuJTIwJTIwbXNHcmlkQ29sdW1uJTNBJTIwMSUyQyU1Q24lMjAlMjBtc0dyaWRDb2x1bW5TcGFuJTNBJTIwMSUyQyU1Q24lMjAlMjBmb250V2VpZ2h0JTNBJTIwMSUyQyU1Q24lMjAlMjBsaW5lSGVpZ2h0JTNBJTIwMSUyQyU1Q24lMjAlMjBvcGFjaXR5JTNBJTIwMSUyQyU1Q24lMjAlMjBvcmRlciUzQSUyMDElMkMlNUNuJTIwJTIwb3JwaGFucyUzQSUyMDElMkMlNUNuJTIwJTIwc2NhbGUlM0ElMjAxJTJDJTVDbiUyMCUyMHRhYlNpemUlM0ElMjAxJTJDJTVDbiUyMCUyMHdpZG93cyUzQSUyMDElMkMlNUNuJTIwJTIwekluZGV4JTNBJTIwMSUyQyU1Q24lMjAlMjB6b29tJTNBJTIwMSUyQyU1Q24lMjAlMjBXZWJraXRMaW5lQ2xhbXAlM0ElMjAxJTJDJTVDbiU1Q24lMjAlMjAlMkYlMkYlMjBTVkctcmVsYXRlZCUyMHByb3BlcnRpZXMlNUNuJTIwJTIwZmlsbE9wYWNpdHklM0ElMjAxJTJDJTVDbiUyMCUyMGZsb29kT3BhY2l0eSUzQSUyMDElMkMlNUNuJTIwJTIwc3RvcE9wYWNpdHklM0ElMjAxJTJDJTVDbiUyMCUyMHN0cm9rZURhc2hhcnJheSUzQSUyMDElMkMlNUNuJTIwJTIwc3Ryb2tlRGFzaG9mZnNldCUzQSUyMDElMkMlNUNuJTIwJTIwc3Ryb2tlTWl0ZXJsaW1pdCUzQSUyMDElMkMlNUNuJTIwJTIwc3Ryb2tlT3BhY2l0eSUzQSUyMDElMkMlNUNuJTIwJTIwc3Ryb2tlV2lkdGglM0ElMjAxJTVDbiU3RCU1Q24lNUNuZXhwb3J0JTIwZGVmYXVsdCUyMHVuaXRsZXNzS2V5cyUyMiUyQyUyMmlzRW50cnklMjIlM0FmYWxzZSUyQyUyMm5hbWUlMjIlM0ElMjJ1bml0bGVzcy5qcyUyMiU3RCU1RCUyQyUyMm9wdGlvbnMlMjIlM0ElN0IlN0QlN0Q=),\n[the `unitlessKeys` object shouldn't be emptied (see the `name in unitless` check), as is the case in 4.45.3 and earlier.\n`styled-components` uses this to determine wether to add `px` units to CSS like `flex: 1`.](https://github.com/styled-components/styled-components/blob/d0b73acd931daef9eebb97e34fe4552ffc57d63e/packages/styled-components/src/utils/addUnitIfNeeded.ts#L10-L12)\n\n### Actual Behaviour\n\n[It removes all properties and this breaks projects that use `styled-components` with `vite`.](https://rollupjs.org/repl/?version=4.46.1&shareable=JTdCJTIyZXhhbXBsZSUyMiUzQW51bGwlMkMlMjJtb2R1bGVzJTIyJTNBJTVCJTdCJTIyY29kZSUyMiUzQSUyMiUyRiUyRiUyMGltcG9ydCUyMHVuaXRsZXNzJTIwZnJvbSUyMCclNDBlbW90aW9uJTJGdW5pdGxlc3MnJTNCJTVDbmltcG9ydCUyMHVuaXRsZXNzJTIwZnJvbSUyMCcuJTJGdW5pdGxlc3MnJTVDbiU1Q24lMkYlMkYlMjBPcmlnaW5hbCUyMGZ1bmN0aW9uJTIwaW4lMjAlNjBzdHlsZWQtY29tcG9uZW50cyU2MCUyQyUyMHN0cmlwcGVkJTIwZm9yJTIwVHlwZVNjcmlwdCUzQSUyMGh0dHBzJTNBJTJGJTJGZ2l0aHViLmNvbSUyRnN0eWxlZC1jb21wb25lbnRzJTJGc3R5bGVkLWNvbXBvbmVudHMlMkZibG9iJTJGZDBiNzNhY2Q5MzFkYWVmOWVlYmI5N2UzNGZlNDU1MmZmYzU3ZDYzZSUyRnBhY2thZ2VzJTJGc3R5bGVkLWNvbXBvbmVudHMlMkZzcmMlMkZ1dGlscyUyRmFkZFVuaXRJZk5lZWRlZC50cyUyM0wxMCU1Q25leHBvcnQlMjBkZWZhdWx0JTIwZnVuY3Rpb24lMjBhZGRVbml0SWZOZWVkZWQobmFtZSUyQyUyMHZhbHVlKSUyMCU3QiU1Q24lMjAlMjAlMkYlMkYlMjBodHRwcyUzQSUyRiUyRmdpdGh1Yi5jb20lMkZhbWlsYWphY2slMkZlc2xpbnQtcGx1Z2luLWZsb3d0eXBlLWVycm9ycyUyRmlzc3VlcyUyRjEzMyU1Q24lMjAlMjBpZiUyMCh2YWx1ZSUyMCUzRCUzRCUyMG51bGwlMjAlN0MlN0MlMjB0eXBlb2YlMjB2YWx1ZSUyMCUzRCUzRCUzRCUyMCdib29sZWFuJyUyMCU3QyU3QyUyMHZhbHVlJTIwJTNEJTNEJTNEJTIwJycpJTIwJTdCJTVDbiUyMCUyMCUyMCUyMHJldHVybiUyMCcnJTNCJTVDbiUyMCUyMCU3RCU1Q24lNUNuJTIwJTIwaWYlMjAodHlwZW9mJTIwdmFsdWUlMjAlM0QlM0QlM0QlMjAnbnVtYmVyJyUyMCUyNiUyNiUyMHZhbHVlJTIwISUzRCUzRCUyMDAlMjAlMjYlMjYlMjAhKG5hbWUlMjBpbiUyMHVuaXRsZXNzKSUyMCUyNiUyNiUyMCFuYW1lLnN0YXJ0c1dpdGgoJy0tJykpJTIwJTdCJTVDbiUyMCUyMCUyMCUyMHJldHVybiUyMCU2MCUyNCU3QnZhbHVlJTdEcHglNjAlM0IlMjAlMkYlMkYlMjBQcmVzdW1lcyUyMGltcGxpY2l0JTIwJ3B4JyUyMHN1ZmZpeCUyMGZvciUyMHVuaXRsZXNzJTIwbnVtYmVycyUyMGV4Y2VwdCUyMGZvciUyMENTUyUyMHZhcmlhYmxlcyU1Q24lMjAlMjAlN0QlNUNuJTVDbiUyMCUyMHJldHVybiUyMFN0cmluZyh2YWx1ZSkudHJpbSgpJTNCJTVDbiU3RCUyMiUyQyUyMmlzRW50cnklMjIlM0F0cnVlJTJDJTIybmFtZSUyMiUzQSUyMm1haW4uanMlMjIlN0QlMkMlN0IlMjJjb2RlJTIyJTNBJTIyJTJGJTJGJTIwRnJvbSUyMGh0dHBzJTNBJTJGJTJGZ2l0aHViLmNvbSUyRmVtb3Rpb24tanMlMkZlbW90aW9uJTJGYmxvYiUyRjQ5MjI5NTUzOTY3YjYwNTBjOTJkOTYwMmViNTc3YmRjNDgxNjdlOTElMkZwYWNrYWdlcyUyRnVuaXRsZXNzJTJGc3JjJTJGaW5kZXgudHMlMjBzdHJpcHBlZCUyMGZyb20lMjBUUyU1Q24lNUNubGV0JTIwdW5pdGxlc3NLZXlzJTIwJTNEJTIwJTdCJTVDbiUyMCUyMGFuaW1hdGlvbkl0ZXJhdGlvbkNvdW50JTNBJTIwMSUyQyU1Q24lMjAlMjBhc3BlY3RSYXRpbyUzQSUyMDElMkMlNUNuJTIwJTIwYm9yZGVySW1hZ2VPdXRzZXQlM0ElMjAxJTJDJTVDbiUyMCUyMGJvcmRlckltYWdlU2xpY2UlM0ElMjAxJTJDJTVDbiUyMCUyMGJvcmRlckltYWdlV2lkdGglM0ElMjAxJTJDJTVDbiUyMCUyMGJveEZsZXglM0ElMjAxJTJDJTVDbiUyMCUyMGJveEZsZXhHcm91cCUzQSUyMDElMkMlNUNuJTIwJTIwYm94T3JkaW5hbEdyb3VwJTNBJTIwMSUyQyU1Q24lMjAlMjBjb2x1bW5Db3VudCUzQSUyMDElMkMlNUNuJTIwJTIwY29sdW1ucyUzQSUyMDElMkMlNUNuJTIwJTIwZmxleCUzQSUyMDElMkMlNUNuJTIwJTIwZmxleEdyb3clM0ElMjAxJTJDJTVDbiUyMCUyMGZsZXhQb3NpdGl2ZSUzQSUyMDElMkMlNUNuJTIwJTIwZmxleFNocmluayUzQSUyMDElMkMlNUNuJTIwJTIwZmxleE5lZ2F0aXZlJTNBJTIwMSUyQyU1Q24lMjAlMjBmbGV4T3JkZXIlM0ElMjAxJTJDJTVDbiUyMCUyMGdyaWRSb3clM0ElMjAxJTJDJTVDbiUyMCUyMGdyaWRSb3dFbmQlM0ElMjAxJTJDJTVDbiUyMCUyMGdyaWRSb3dTcGFuJTNBJTIwMSUyQyU1Q24lMjAlMjBncmlkUm93U3RhcnQlM0ElMjAxJTJDJTVDbiUyMCUyMGdyaWRDb2x1bW4lM0ElMjAxJTJDJTVDbiUyMCUyMGdyaWRDb2x1bW5FbmQlM0ElMjAxJTJDJTVDbiUyMCUyMGdyaWRDb2x1bW5TcGFuJTNBJTIwMSUyQyU1Q24lMjAlMjBncmlkQ29sdW1uU3RhcnQlM0ElMjAxJTJDJTVDbiUyMCUyMG1zR3JpZFJvdyUzQSUyMDElMkMlNUNuJTIwJTIwbXNHcmlkUm93U3BhbiUzQSUyMDElMkMlNUNuJTIwJTIwbXNHcmlkQ29sdW1uJTNBJTIwMSUyQyU1Q24lMjAlMjBtc0dyaWRDb2x1bW5TcGFuJTNBJTIwMSUyQyU1Q24lMjAlMjBmb250V2VpZ2h0JTNBJTIwMSUyQyU1Q24lMjAlMjBsaW5lSGVpZ2h0JTNBJTIwMSUyQyU1Q24lMjAlMjBvcGFjaXR5JTNBJTIwMSUyQyU1Q24lMjAlMjBvcmRlciUzQSUyMDElMkMlNUNuJTIwJTIwb3JwaGFucyUzQSUyMDElMkMlNUNuJTIwJTIwc2NhbGUlM0ElMjAxJTJDJTVDbiUyMCUyMHRhYlNpemUlM0ElMjAxJTJDJTVDbiUyMCUyMHdpZG93cyUzQSUyMDElMkMlNUNuJTIwJTIwekluZGV4JTNBJTIwMSUyQyU1Q24lMjAlMjB6b29tJTNBJTIwMSUyQyU1Q24lMjAlMjBXZWJraXRMaW5lQ2xhbXAlM0ElMjAxJTJDJTVDbiU1Q24lMjAlMjAlMkYlMkYlMjBTVkctcmVsYXRlZCUyMHByb3BlcnRpZXMlNUNuJTIwJTIwZmlsbE9wYWNpdHklM0ElMjAxJTJDJTVDbiUyMCUyMGZsb29kT3BhY2l0eSUzQSUyMDElMkMlNUNuJTIwJTIwc3RvcE9wYWNpdHklM0ElMjAxJTJDJTVDbiUyMCUyMHN0cm9rZURhc2hhcnJheSUzQSUyMDElMkMlNUNuJTIwJTIwc3Ryb2tlRGFzaG9mZnNldCUzQSUyMDElMkMlNUNuJTIwJTIwc3Ryb2tlTWl0ZXJsaW1pdCUzQSUyMDElMkMlNUNuJTIwJTIwc3Ryb2tlT3BhY2l0eSUzQSUyMDElMkMlNUNuJTIwJTIwc3Ryb2tlV2lkdGglM0ElMjAxJTVDbiU3RCU1Q24lNUNuZXhwb3J0JTIwZGVmYXVsdCUyMHVuaXRsZXNzS2V5cyUyMiUyQyUyMmlzRW50cnklMjIlM0FmYWxzZSUyQyUyMm5hbWUlMjIlM0ElMjJ1bml0bGVzcy5qcyUyMiU3RCU1RCUyQyUyMm9wdGlvbnMlMjIlM0ElN0IlN0QlN0Q=) Projects that use `rollup` to build npm libraries are unaffected, since `styled-components` is typically a peer dependency and thus marked as `external` in those cases.\n",
+      "public_features": {
+        "language": "js",
+        "issue_word_count": 112,
+        "issue_size": "short",
+        "feature_key": "js.issue-short"
+      },
+      "source_row_digest": "sha256:2bbc49d8de392038e55c9d930fc2db698e1af8634569d25e1757f4a45f2386b7",
+      "problem_statement_digest": "sha256:de7c58162a7ae4bb7558da7a80b1e5f7b1f696982d6347aaa148028f52c97eb2",
+      "hidden_artifact_digests": {
+        "gold_patch": "sha256:1fd8a2b29542066175c2fdd4b11e16831e9270ab276bc8da97cfa11d746d6380",
+        "test_patch": "sha256:b27d88ff47014afcda68a1544165243a6ccb17eff2861321a90727153a147cc3"
+      }
+    },
+    {
+      "schema": 1,
+      "instance_id": "nodejs__undici-5011",
+      "split": "js",
+      "row_index": 86,
+      "repo": "nodejs/undici",
+      "pull_number": "5011",
+      "base_commit": "0143e1bae27ef6f6eb0225dc0934d69719d55c09",
+      "created_at": "2026-04-09T15:02:43Z",
+      "docker_image": "starryzhang/sweb.eval.x86_64.nodejs_1776_undici-5011",
+      "problem_statement": "Proxies don't accept my timeout and always have a static 10_000 ms.\n```\nconst options = { ... };\noptions.dispatcher = new ProxyAgent({\n\turi: origin,\n\theadersTimeout: 600000,\n\tbodyTimeout: 600000,\n\tconnectTimeout: 600000\n})\nconst response = await fetch(url, options);\n```\n\nProxies don't accept my timeout and always have a static 10_000 ms.\n\nv23.3.0 and 8.0.2\n",
+      "public_features": {
+        "language": "js",
+        "issue_word_count": 54,
+        "issue_size": "short",
+        "feature_key": "js.issue-short"
+      },
+      "source_row_digest": "sha256:01bba553f3f64f1d8c756d52e17b571312d73b9bb11ca53010be67b1c61c1adf",
+      "problem_statement_digest": "sha256:4b5dd32b1f03dd5c51496b5428969bf3b5f3c0ec3a1f31f07e7e31727efbfbf1",
+      "hidden_artifact_digests": {
+        "gold_patch": "sha256:3cfbb94d6d4a61aff4fa3cfcca76c6439e9bf4d822bd7b127f1e4877c9a79e5b",
+        "test_patch": "sha256:351c044e55111e1b7e22af5f21001e4474b891021f9c959b66d951de06f0ccef"
+      }
+    },
+    {
+      "schema": 1,
+      "instance_id": "codeceptjs__CodeceptJS-5072",
+      "split": "js",
+      "row_index": 57,
+      "repo": "codeceptjs/CodeceptJS",
+      "pull_number": "5072",
+      "base_commit": "a27b99eb23d89764b9ec7c79a25a7dc5781f6258",
+      "created_at": "2025-08-19T08:50:21Z",
+      "docker_image": "starryzhang/sweb.eval.x86_64.codeceptjs_1776_codeceptjs-5072",
+      "problem_statement": "unable to inject data between workers because of proxy object\nI am using Codeceptjs with Playwright along with Mochawesome\n\n\nI had my custom parallel runner following the example provided in Codeceptjs website. But with recent changes in 3.7.0 , when I try to inject data between workers, it is coming as proxy object. Can any one tell me if anything that we need to do differently to get the data flowing between workers. Below is my setup in config file and parallel runner.js \n\ncodecept.conf.js\n\nbootstrap() {\n   share({ testData: false})\n}\n\n\n\nInside my custom parallels runner file, I was reading the testData and then assigning values to it , so that I can read the same from any worker\nconst testDataJson = require ('../testDataModel')\n\n\nlet testData = inject()\nif(! testData) {\n testData = testDataJson\n\n\nNow with recent changes from 3.7.0, testData becomes proxy object and unable to assign anything. Any workaround to do this?\n\n\n\n",
+      "public_features": {
+        "language": "js",
+        "issue_word_count": 153,
+        "issue_size": "long",
+        "feature_key": "js.issue-long"
+      },
+      "source_row_digest": "sha256:1af4adfe592817010ea6bc6cde102fa26fb3306edb2fcdf6adec514f056eec02",
+      "problem_statement_digest": "sha256:58cc5f9df6767a11310f1dcdc32b6d9f5930f2ff43b90636a0f9b96d13167075",
+      "hidden_artifact_digests": {
+        "gold_patch": "sha256:4aee0e564ecbdcd6e9cde1ebe9db790bb03f35ab0c9a683c89493245a9335214",
+        "test_patch": "sha256:dca84c4108ce9365dac362da50e5771fd3525dd7c6f9e90673da59a40835adbf"
+      }
+    },
+    {
+      "schema": 1,
+      "instance_id": "siimon__prom-client-679",
+      "split": "js",
+      "row_index": 34,
+      "repo": "siimon/prom-client",
+      "pull_number": "679",
+      "base_commit": "4c6224db43c6cd9c82b4bccfb6b8a8fb09580d44",
+      "created_at": "2025-07-05T13:09:04Z",
+      "docker_image": "starryzhang/sweb.eval.x86_64.siimon_1776_prom-client-679",
+      "problem_statement": "Cluster mode does not handle load shedding properly if timeouts are exceeded.\nWhile looking at #628, I noticed a few other problems with the cluster mode.\n\nThe request is not deleted from the requests map until all responses are returned, which may not happen if a child is restarted.\n\nIt is also processing messages from the workers even if the request is done\n\n```\n\tif (message.error) {\n\t\trequest.done(new Error(message.error));\n\t\treturn;\n\t}\n\n\tmessage.metrics.forEach(registry => request.responses.push(registry));\n\trequest.pending--;\n\n\tif (request.pending === 0) {\n\t\t// finalize\n\t\trequests.delete(message.requestId);\n\t\tclearTimeout(request.errorTimeout);\n```\n\nWhich means all responses from workers are processed regardless of whether another request has already sent.\n\nThe clients also aren't given a deadline, which means they have no way to abort the work if it is not processed in time.\n\nI don't recall if there's a way to avoid the `JSON.parse()` call.  Given the structure of the response that is unlikely.  \n\nPerhaps more importantly: every time a worker fails to deliver a response at all, the responses from its siblings are left in the lookup table in perpetuity, representing a memory leak, and a rather substantial one.\n\nThis also has implications for #645 \n\nAdditionally, cluster mode does not handle benchmarking well. Multiple calls to `new AggregatorRegistry()` leads to `addListeners()` calls if more than one instance of the module is loaded - which is a frequent if unfortunate occurrence in benchmarking code. \n",
+      "public_features": {
+        "language": "js",
+        "issue_word_count": 226,
+        "issue_size": "long",
+        "feature_key": "js.issue-long"
+      },
+      "source_row_digest": "sha256:9e811e293616301ebf9add42bdd4d1f7191f767809069d82669cbd8430359399",
+      "problem_statement_digest": "sha256:b30cd2fea38f18bafc8681e5befc1d18649b7473308bb66ff7a2b0b1830122d1",
+      "hidden_artifact_digests": {
+        "gold_patch": "sha256:8c9946648c4fab3767ca17a36b19d8a09613af7785cc7168c03496cf85acd8c9",
+        "test_patch": "sha256:293ace50ede650b636fe9d091d6fec7cb820df8e8dff883c0de55b980a7fbcde"
+      }
+    },
+    {
+      "schema": 1,
+      "instance_id": "excalidraw__excalidraw-9760",
+      "split": "ts",
+      "row_index": 7,
+      "repo": "excalidraw/excalidraw",
+      "pull_number": "9760",
+      "base_commit": "8492b144b05b56634fa020ec278adc7936fbfc4e",
+      "created_at": "2025-07-18T18:37:52Z",
+      "docker_image": "starryzhang/sweb.eval.x86_64.excalidraw_1776_excalidraw-9760",
+      "problem_statement": "deleting all points from within line editor throws\n1. create line\n2. enter line editor\n3. box-select all points\n4. delete\nBug: [regression in master] Line editor point remains hovered\nSeems to be a regression from #9642. Happens because `handleHoverSelectedLinearElement` was used to handle pointer away and now it doesn't fire when the pointer is away while line-editing.\n\nhttps://github.com/user-attachments/assets/b9297af2-c1a5-4637-9e74-0ad895a3d984\nExcessive re-renders on pointer move during line editing\nThere are two things that cause unnecessary re-renders while moving the pointer while in the line editor:\n- A new `editingLinearElement` is returned each time [here](https://github.com/excalidraw/excalidraw/blob/678dff25eddfc43319299495556ab9f6029bc719/packages/element/src/linearElementEditor.ts#L1043-L1047) even if nothing's changed. The new reference of `editingLinearElement` is then checked against the one in appState [here](https://github.com/excalidraw/excalidraw/blob/678dff25eddfc43319299495556ab9f6029bc719/packages/excalidraw/components/App.tsx#L5860-L5863).\n- Always executing `setState` [here](https://github.com/excalidraw/excalidraw/blob/678dff25eddfc43319299495556ab9f6029bc719/packages/excalidraw/components/App.tsx#L5878-L5883) even if nothing's changed.\nBug: \"suggested bindings box\" shows in line editor (not arrow) while pressing alt to add a point\nThe type of the element is not checked [here](https://github.com/excalidraw/excalidraw/blob/678dff25eddfc43319299495556ab9f6029bc719/packages/excalidraw/components/App.tsx#L5873-L5877)\n\nhttps://github.com/user-attachments/assets/140aa0a0-050c-44f4-8983-3234b33fea78\n",
+      "public_features": {
+        "language": "ts",
+        "issue_word_count": 147,
+        "issue_size": "short",
+        "feature_key": "ts.issue-short"
+      },
+      "source_row_digest": "sha256:f763f41930a3992f30c726375bb5da28d0fcb592afdac0c4b84a897647954b73",
+      "problem_statement_digest": "sha256:93996120247488ce02fdfcd367cd17b881de8388e465902fbb00f1f2fdd0173d",
+      "hidden_artifact_digests": {
+        "gold_patch": "sha256:d23353959e0ae3ddcb9da87443699904e9d5beb410f435d3db04dbf80cf0df3c",
+        "test_patch": "sha256:51792ded38c4bc48bb993e8a66d706a5ca133ed57328ffa5d3dc273607a8fade"
+      }
+    },
+    {
+      "schema": 1,
+      "instance_id": "mui__base-ui-2493",
+      "split": "ts",
+      "row_index": 79,
+      "repo": "mui/base-ui",
+      "pull_number": "2493",
+      "base_commit": "3ce0fe2e9ed56513f02f2c8660ada9413ccca3db",
+      "created_at": "2025-08-14T11:25:48Z",
+      "docker_image": "starryzhang/sweb.eval.x86_64.mui_1776_base-ui-2493",
+      "problem_statement": "[menu] Focus is lost when `closeParentOnEsc: false`\n# Bug report\n\n## Current behavior\n\nCurrently, when `closeParentOnEsc: false` is set on Menu.Submenu, pressing the ESC key causes the Submenu to disappear and the focus to be lost as well.\n\nhttps://github.com/user-attachments/assets/49c7d86f-e4b5-439a-baf8-f7f10c5bfa90\n\n## Expected behavior\n\nAccording to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/menu_role#escape), when the focus is on a submenu, pressing the ESC key should close the submenu and move focus to the submenu trigger.\n\n## Reproducible example\n\nhttps://codesandbox.io/p/sandbox/silent-sound-x4fghr?file=%2Fsrc%2FApp.tsx%3A23%2C37\n\n## Base UI version\n\nv1.0.0-beta.2\n\n## Which browser are you using?\n\nChrome\n\n## Which OS are you using?\n\nMac OS\n\n## Which assistive tech are you using (if applicable)?\n\nX\n\n## Additional context\n\n",
+      "public_features": {
+        "language": "ts",
+        "issue_word_count": 106,
+        "issue_size": "short",
+        "feature_key": "ts.issue-short"
+      },
+      "source_row_digest": "sha256:95302db7a9ee1ea9c257fbdc3e19b90852db5c3fc294b26037a4b66253b35e4a",
+      "problem_statement_digest": "sha256:f0303fe25e6f891f7f1afc14e211b7e92c7e704d57016c3a60a3282610079027",
+      "hidden_artifact_digests": {
+        "gold_patch": "sha256:e6191aba32ddfeef5c77a03dede8991aff2309bc68bc355dbaeee4508ef1b67d",
+        "test_patch": "sha256:4e42268abdadfce9b75cd81bdfcd274cae665fb34b75204cb44e81c7dd3b68fa"
+      }
+    },
+    {
+      "schema": 1,
+      "instance_id": "QwenLM__qwen-code-349",
+      "split": "ts",
+      "row_index": 52,
+      "repo": "QwenLM/qwen-code",
+      "pull_number": "349",
+      "base_commit": "df1479f8644efd20bfe58548d74363631fd0d95a",
+      "created_at": "2025-08-16T00:40:01Z",
+      "docker_image": "starryzhang/sweb.eval.x86_64.qwenlm_1776_qwen-code-349",
+      "problem_statement": "Unexpectedly scanned entire `.venv` directory, sending ~100M tokens from 5,000 files\n### What happened?\n\nWhile using Qwen Code, I noticed that it automatically scanned the entire `.venv` directory—even though I didn’t instruct it to do so. This resulted in nearly 100 million tokens being sent from approximately 5,000 files. These files are mostly irrelevant to the task and should not have been included.\n\n```\nSuccessfully read and concatenated content from **5472 file(s)**.\n\n**Processed Files (first 10 shown):**\n- `scripts/.gitignore`\n- `scripts/.venv/.gitignore`\n- `scripts/.venv/CACHEDIR.TAG`\n- `scripts/.venv/bin/activate`\n- `scripts/.venv/bin/activate.bat`\n- `scripts/.venv/bin/activate.csh`\n- `scripts/.venv/bin/activate.fish`\n- `scripts/.venv/bin/activate.nu`\n- ...and 5462 more.\n```\n\nI canceled the operation when I noticed something was wrong, but the final screen revealed that nearly 100 million tokens had already been processed.\n\n```\n╭────────────────────────────────────────────────────────────────────────────────────────────────╮\n│                                                                                                │\n│  Agent powering down. Goodbye!                                                                 │\n│                                                                                                │\n│  Performance                                                                                   │\n│  Wall Time:                  14m 18s                                                           │\n│  Agent Active:               3m 2s                                                             │\n│    » API Time:               3m 2s (100.0%)                                                    │\n│    » Tool Time:              0s (0.0%)                                                         │\n│                                                                                                │\n│                                                                                                │\n│  Model Usage                  Reqs   Input Tokens  Output Tokens                               │\n│  ───────────────────────────────────────────────────────────────                               │\n│  qwen3-coder-plus               11    102,939,617            113                               │\n│                                                                                                │\n│  Savings Highlight: 11,008 (0.0%) of input tokens were served from the cache, reducing costs.  │\n│                                                                                                │\n│  » Tip: For a full token breakdown, run `/stats model`.                                        │\n│                                                                                                │\n╰────────────────────────────────────────────────────────────────────────────────────────────────╯\n```\n\n\n### What did you expect to happen?\n\nI expected Qwen Code to ignore large directories like `.venv` by default, or at least prompt the user before scanning and sending such a massive number of files. Ideally, it should have safeguards to avoid reading directories with excessive file counts or known irrelevant content (e.g., virtual environments, build artifacts).\n\n### Client information\n\n\n* **CLI Version:** 0.0.5\n* **Git Commit:** c09abb81 (local modifications)\n* **Operating System:** linux v24.4.1\n* **Sandbox Environment:** no sandbox\n* **Model Version:** qwen3-coder-plus\n* **Memory Usage:** 257.0 MB\n\n\n### Login information\n\n_No response_\n\n### Anything else we need to know?\n\n_No response_\n",
+      "public_features": {
+        "language": "ts",
+        "issue_word_count": 325,
+        "issue_size": "long",
+        "feature_key": "ts.issue-long"
+      },
+      "source_row_digest": "sha256:4041190eb817d1cff7cac6e0a2ccca0886709c8f62ef9bfd21daed468f6f2d7b",
+      "problem_statement_digest": "sha256:4bfe963e1cda82563da2fa4877f1be825843c5f142c340a79f3a6f4f6466e464",
+      "hidden_artifact_digests": {
+        "gold_patch": "sha256:41caa3bd2666801ad79c181f2c210772f587c859a38be047eb67176c9d73b22d",
+        "test_patch": "sha256:e51dcd3fb63c73f6d41b96617b60b703193795cc5e4fc15e127b454cd25309fa"
+      }
+    },
+    {
+      "schema": 1,
+      "instance_id": "TypeCellOS__BlockNote-2629",
+      "split": "ts",
+      "row_index": 108,
+      "repo": "TypeCellOS/BlockNote",
+      "pull_number": "2629",
+      "base_commit": "38be5fd2ddab06977a663ac8b5077042a0a5eac7",
+      "created_at": "2026-04-07T08:35:41Z",
+      "docker_image": "starryzhang/sweb.eval.x86_64.typecellos_1776_blocknote-2629",
+      "problem_statement": "RangeError: Position out of range when deleting after multi-column block\n### What’s broken?\n\nWhen using the multi-column feature, continuously pressing Backspace after typing in a block following a multi-column layout causes a runtime error:\n\n```RangeError: Position X out of range```\n\nThis crashes the editor and breaks further interaction.\n\n<img width=\"1225\" height=\"838\" alt=\"Image\" src=\"https://github.com/user-attachments/assets/de3d5796-0967-40e8-bbd3-98c4147efaec\" />\n\n<img width=\"592\" height=\"174\" alt=\"Image\" src=\"https://github.com/user-attachments/assets/3ccd0b6d-4eed-46c0-8193-34692e7e225f\" />\n\n### What did you expect to happen?\n\n- Text should be deleted normally\n- Editor should remain stable\n- No runtime errors should occur\n\n\n### Steps to reproduce\n\n1. Insert a multi-column block (e.g., 3 columns)\n2. Move cursor to the next block (below the columns)\n3. Type some text (e.g., aaa)\n4. Press and hold Backspace to delete continuously\n\n### BlockNote version\n\n\"@blocknote/xl-multi-column\": \"0.47.1\"\n\n### Environment\n\nChrome\n\n### Additional context\n\n- This issue appears to be related to how the multi-column structure interacts with deletion logic.\n- Likely caused by an invalid ProseMirror transaction when deleting across structural boundaries.\n- Happens more frequently when holding down Backspace (rapid consecutive deletes).\n\n### Contribution\n\n- [ ] I'd be interested in contributing a fix for this issue\n\n### Sponsor\n\n- [ ] I'm a [sponsor](https://www.blocknotejs.org/pricing) and would appreciate if you could look into this sooner than later 💖\n",
+      "public_features": {
+        "language": "ts",
+        "issue_word_count": 207,
+        "issue_size": "long",
+        "feature_key": "ts.issue-long"
+      },
+      "source_row_digest": "sha256:ee816b8ac36a3dbbd4ea1e7c5b85e7126a69befb60ebe3410dbb9bf35c2149a3",
+      "problem_statement_digest": "sha256:868347f9b4fed9ccfb7ae1d65b99bbd2b33bf3f5250bfc9b78774742bd3b8b35",
+      "hidden_artifact_digests": {
+        "gold_patch": "sha256:0bbab6e962054f392ebe25602101f7e3ab9eabe66009933dd7b724ffe18816d0",
+        "test_patch": "sha256:a8641bcf4cb0d87cc50cc3bf2c19c74b21039300c5841fb6e75fa163330f95f1"
+      }
+    },
+    {
+      "schema": 1,
+      "instance_id": "preactjs__preact-4880",
+      "split": "js",
+      "row_index": 29,
+      "repo": "preactjs/preact",
+      "pull_number": "4880",
+      "base_commit": "aeb59e0cbb90fb1baf976cd29cd2d99d9faa9870",
+      "created_at": "2025-08-08T15:17:31Z",
+      "docker_image": "starryzhang/sweb.eval.x86_64.preactjs_1776_preact-4880",
+      "problem_statement": "the child component of ErrorBoundary, wrapped by memo function failed to recover from the last error\n- [x] Check if updating to the latest Preact version resolves the issue\r\n\r\n**Describe the bug**\r\nthe child componet wrapped by memo function caused an error in the first render, then it's parent component caught the error and solved the error, but this child component disappears in the next render.\r\n\r\n**To Reproduce**\r\n\r\nThe second Test component disappeared.\r\n[https://codesandbox.io/s/charming-curie-to3te?file=/src/index.js](https://codesandbox.io/s/charming-curie-to3te?file=/src/index.js)\r\n\r\nSteps to reproduce the behavior:\r\n\r\nPlease see the demo above. It's not difficult to reproduce.\r\n\r\n**Expected behavior**\r\n\r\nall Test component should be rendered.\r\n\n",
+      "public_features": {
+        "language": "js",
+        "issue_word_count": 97,
+        "issue_size": "short",
+        "feature_key": "js.issue-short"
+      },
+      "source_row_digest": "sha256:ab0908830d9216b571d9bd9c3db8edb6bced60427d9dd34151490cfa30fcba55",
+      "problem_statement_digest": "sha256:a15e5664d8852cc552c1c07d9b5ef36905565f6dfe87264a86a2d906590d4668",
+      "hidden_artifact_digests": {
+        "gold_patch": "sha256:cf10443e7ea31c39c3baaf214e32903df18520ed2723a4631a6bdc2aefe85541",
+        "test_patch": "sha256:62cc05d8803198c60639ef49eae9d50089dd211f97a27e08cf0eff91619da9b2"
+      }
+    },
+    {
+      "schema": 1,
+      "instance_id": "GladysAssistant__Gladys-2504",
+      "split": "js",
+      "row_index": 88,
+      "repo": "GladysAssistant/Gladys",
+      "pull_number": "2504",
+      "base_commit": "b32900c920e000491c817d33e748f6b57ffa2569",
+      "created_at": "2026-03-23T14:32:01Z",
+      "docker_image": "starryzhang/sweb.eval.x86_64.gladysassistant_1776_gladys-2504",
+      "problem_statement": "Zigbee2mqtt : Error on discover page when energy monitoring has a missing energy meter id\n<img width=\"2912\" height=\"770\" alt=\"Image\" src=\"https://github.com/user-attachments/assets/c7bc2939-f76d-44ac-b6db-8cd072e56632\" />\n",
+      "public_features": {
+        "language": "js",
+        "issue_word_count": 21,
+        "issue_size": "short",
+        "feature_key": "js.issue-short"
+      },
+      "source_row_digest": "sha256:1d5c54e1a15bc74ce6f775bc1d73c40abe9783ec7b5cb05ff041743f2d91ad08",
+      "problem_statement_digest": "sha256:2c905fcec19df8c8538eb69796a5abd4d41694fdf68bb65ac5fb83b48ce9d09b",
+      "hidden_artifact_digests": {
+        "gold_patch": "sha256:9ac59e7429e5a8dc6f0767fcf04e2810c13620bacaa360dd80523515e318865e",
+        "test_patch": "sha256:a9df344f7b7e90ee96318142a770c8c31755f5ed5388e0db42a98f9bd88602a0"
+      }
+    },
+    {
+      "schema": 1,
+      "instance_id": "simple-icons__simple-icons-13659",
+      "split": "js",
+      "row_index": 61,
+      "repo": "simple-icons/simple-icons",
+      "pull_number": "13659",
+      "base_commit": "6c8f4377578ea1a4d6f22a35da31a279a0b9f7fe",
+      "created_at": "2025-07-25T02:02:39Z",
+      "docker_image": "starryzhang/sweb.eval.x86_64.simple-icons_1776_simple-icons-13659",
+      "problem_statement": "Request: Suitest\n### Brand Name\n\nSuitest\n\n### Website\n\nhttps://www.suite.st/\n\n### Popularity Metric\n\nhttps://www.similarweb.com/website/suite.st/\n\n### Forbidden Brands\n\n- [x] I have reviewed the list of [forbidden brands](https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md#forbidden-brands) and can confirm the brand I am requesting is not one of them, nor is it a subsidiary of one of them.\n\n### Terms of Service\n\n_No response_\n\n### Official Resources for Icon and Color\n\nSVG: https://suite.st/img/suitest-logo-mobile.svg\nColor: #f06060\n\n### Additional Comments\n\n_No response_\n",
+      "public_features": {
+        "language": "js",
+        "issue_word_count": 70,
+        "issue_size": "short",
+        "feature_key": "js.issue-short"
+      },
+      "source_row_digest": "sha256:9bfc894da9127fe59c0ef80a2616d60f650180b5d95e7380ca24760075b73327",
+      "problem_statement_digest": "sha256:55f8a48d933f1c59779137ef905405512ddd40c017a293d1f53ac0416f5f8772",
+      "hidden_artifact_digests": {
+        "gold_patch": "sha256:d5fb73838347a45e46889157557d23456ece7e60024603fbb68d9f845bf322b4",
+        "test_patch": "sha256:24eea23377437b8879fb9b40a36f132dc79e0914b04d7773be6fcac1e8802e2e"
+      }
+    },
+    {
+      "schema": 1,
+      "instance_id": "moment__luxon-1720",
+      "split": "js",
+      "row_index": 14,
+      "repo": "moment/luxon",
+      "pull_number": "1720",
+      "base_commit": "4cc03e5b71240ece26ba1424cabcf35b8a939c56",
+      "created_at": "2025-07-29T21:55:04Z",
+      "docker_image": "starryzhang/sweb.eval.x86_64.moment_1776_luxon-1720",
+      "problem_statement": "Interval.fromISO not following standard for start/end notation\nActual behavior:\r\n`Interval.fromISO(\"1988-04-15T09/15\").toString()`\r\n> '[1988-04-15T09:00:00.000+01:00 – 2021-03-23T15:00:00.000+01:00)'\r\n\r\nExpected behavior:\r\n`Interval.fromISO(\"1988-04-15T09/15\").toString()`\r\n> '[1988-04-15T09:00:00.000+01:00 – 1988-04-15T15:00:00.000+01:00)'\r\n\r\nas described in:\r\nhttps://en.wikipedia.org/wiki/ISO_8601#Time_intervals\r\n> For <start>/<end> expressions, if any elements are missing from the end value, they are assumed to be the same as for the start value including the time zone.\r\n\r\nIn node 12.21.0 with luxon 1.25.0, 1.26.0.\n",
+      "public_features": {
+        "language": "js",
+        "issue_word_count": 61,
+        "issue_size": "short",
+        "feature_key": "js.issue-short"
+      },
+      "source_row_digest": "sha256:756f8706beaa3f192b59d7fe1739c184829e5e2fe070bf65aeaac957ea7bf63e",
+      "problem_statement_digest": "sha256:ab7a5ad55c98e0753a0cf0a699bd1e6900140bb2c8b4ec05e6e211f33ec6d3f0",
+      "hidden_artifact_digests": {
+        "gold_patch": "sha256:2e12a8caaed93c95e40a1a85501c5e78001f5a9d4e834976f96cc38b339715e6",
+        "test_patch": "sha256:8352a5a9a4f777a5b70f53672647931404e2b0b762b0238c129aa6ab83029621"
+      }
+    },
+    {
+      "schema": 1,
+      "instance_id": "gsd-build__get-shit-done-2186",
+      "split": "js",
+      "row_index": 78,
+      "repo": "gsd-build/get-shit-done",
+      "pull_number": "2186",
+      "base_commit": "c11ec0555451338c3ef666753ec2b24731d7a2c7",
+      "created_at": "2026-04-13T11:48:41Z",
+      "docker_image": "starryzhang/sweb.eval.x86_64.gsd-build_1776_get-shit-done-2186",
+      "problem_statement": "init plan-phase / execute-phase return archived phase when current milestone reuses the same phase number\n## GSD Version\n1.34.2 (reproduced on `main` at 1.35.0-dev)\n\n## Runtime\nClaude Code\n\n## OS / Node / Shell\nmacOS, Node v22.22.1, zsh\n\n## Installation Method\nLocal (`~/.claude/get-shit-done/`)\n\n## Summary\n\n`node gsd-tools.cjs init plan-phase <N>` returns the wrong phase when the current milestone reuses a phase number that also exists in an archived milestone's `.planning/milestones/v*-phases/` directory.\n\n`phase_dir`, `phase_slug`, `phase_name`, `has_context`, `has_research`, `context_path`, `research_path` all point at the archived phase from the prior milestone, while `phase_req_ids` correctly comes from the current ROADMAP. The mismatch silently steers downstream agents (gsd-planner, gsd-phase-researcher) at shipped work from a previous milestone.\n\n## Reproduction\n\nDirectory layout (a project on v2.0 where v1.0 shipped and was archived):\n\n```\n.planning/\n  ROADMAP.md                         # current v2.0 roadmap, has \"Phase 2: New Feature\"\n  phases/                            # (empty — Phase 2 not started yet)\n  milestones/\n    v1.0-phases/\n      02-old-feature/\n        2-CONTEXT.md                 # old v1.0 artifacts\n        2-RESEARCH.md\n```\n\nRunning:\n\n```\nnode gsd-tools.cjs init plan-phase 2\n```\n\nreturns:\n\n```json\n{\n  \"phase_found\": true,\n  \"phase_dir\": \".planning/milestones/v1.0-phases/02-old-feature\",\n  \"phase_name\": \"old-feature\",\n  \"phase_slug\": \"old-feature\",\n  \"has_context\": true,\n  \"has_research\": true,\n  \"context_path\": \".planning/milestones/v1.0-phases/02-old-feature/2-CONTEXT.md\",\n  \"research_path\": \".planning/milestones/v1.0-phases/02-old-feature/2-RESEARCH.md\",\n  \"phase_req_ids\": \"NEW-01, NEW-02\"\n}\n```\n\n`phase_req_ids` is correctly scoped to the current milestone (via `getRoadmapPhaseInternal`'s `extractCurrentMilestone`), but everything coming from `findPhaseInternal` points at the archived phase. The result is internally inconsistent.\n\n## Expected\n\nSince `ROADMAP.md` has Phase 2 in the current milestone and `.planning/phases/` has no Phase 2 directory yet, init should return the ROADMAP fallback (no directory, clean slate) — same behavior `cmdInitPhaseOp` already implements for discuss-phase.\n\n```json\n{\n  \"phase_found\": true,\n  \"phase_dir\": null,\n  \"phase_name\": \"New Feature\",\n  \"phase_slug\": \"new-feature\",\n  \"has_context\": false,\n  \"has_research\": false,\n  \"phase_req_ids\": \"NEW-01, NEW-02\"\n}\n```\n\n## Root Cause\n\n`findPhaseInternal` (in `get-shit-done/bin/lib/core.cjs`) falls through to archived milestone directories when nothing is found in `.planning/phases/`. The archived match's `archived: version` flag is set but never checked by `cmdInitPlanPhase` / `cmdInitExecutePhase` / `cmdInitVerifyWork`, so an archived phase silently masquerades as the current one.\n\n`cmdInitPhaseOp` already guards against this (lines 621–642 in `get-shit-done/bin/lib/init.cjs` on current main). The three other init entry points do not.\n\n## Impact\n\nHit in real use while running `/gsd-plan-phase 2` on a project where v1.0 was archived and v2.0's Phase 2 started — the orchestrator was routed at `.planning/milestones/v1.0-phases/02-session-context-pool/` artifacts (a shipped browser-service phase) instead of the current milestone's UI theming phase. Had to manually override `phase_dir`.\n\n## Fix\n\nPR: #TBD (linked once opened from fork).\n",
+      "public_features": {
+        "language": "js",
+        "issue_word_count": 392,
+        "issue_size": "long",
+        "feature_key": "js.issue-long"
+      },
+      "source_row_digest": "sha256:fe9f40b5b110f96fdba78d538b7640464927fa063c6ae9ca95f93f43262225f4",
+      "problem_statement_digest": "sha256:b5904919950ec093134ce3f747a4bf2fee8c9b63223f0bc31abb60f77d003e26",
+      "hidden_artifact_digests": {
+        "gold_patch": "sha256:aaa5a440f43192d086370a328a2892df11ae6e758f65c3e07703ebfba471ad3f",
+        "test_patch": "sha256:1d8e3aa444697cc28c6a0a31fdc44d8bc1f5217aafb9ecf729b82dc55357595d"
+      }
+    },
+    {
+      "schema": 1,
+      "instance_id": "docsifyjs__docsify-2595",
+      "split": "js",
+      "row_index": 67,
+      "repo": "docsifyjs/docsify",
+      "pull_number": "2595",
+      "base_commit": "32aa74e0d2fcd89705e5c30fc8b8e2562e7b774e",
+      "created_at": "2025-08-08T04:51:56Z",
+      "docker_image": "starryzhang/sweb.eval.x86_64.docsifyjs_1776_docsify-2595",
+      "problem_statement": "Use of Coverpage H1 (Title) as link to start of content not working as expected in v5 Preview\n### Description\n\nAs mentioned in #2593 , the use of a Coverpage Title as a link to the main content of a Docsify site can be problematic due to the repeated use of the same id, however in v5 RC-1 this seemed to be supported (as expected).\n\n### Expected behavior\n\nWhen there is  H1 (title) in the Coverpage, this link when clicked should go to the first matching id in the main content area of Docsify, and not on the matching id within the Coverpage itself. The coverpage will always be displayed as the landing page for a Docsify site, so navigating to an id within the one screen long Coverpage is highly unlikely.\n\n### Actual behavior\n\nCurrently, clicking on the H1 (title) of the Coverpage scrolls the Coverpage halfway up to where the H1 link is.\n\nDocsify v5 preview codsandbox, click on coverpage title:\nhttps://codesandbox.io/p/sandbox/docsify-v5-preview-coverpage-2d82hj\n\nHowever, in Docsify v5 RC-1 this issue did not seem to be present, and works as expected:\n\nDocsify v5 RC 1 codsandbox, click on coverpage title:\nhttps://codesandbox.io/p/sandbox/docsify-v5-rc-1-coverpage-jx2rl3\n\nThe same logic seems to hold true when using a direct URL with the id which results in targeting the main content (which has the same id on the Coverpage):\nhttps://paulhibbitts.github.io/docsify-v5-rc-1-coverpage/#/?id=docsify-template\n\n### Steps to reproduce\n\n1. Create Coverpage with H1 (title) such as \"Quick start\"\n2. Create a main content Markdown file, with # Quick start as the content title\n3. View the site, and click on the Coverpage H1 (title) link\n\nHappy to help test/try possible approaches to this issue, thank you!\n\n### Environment\n\nDocsify v5 Preview\n\n### Additional Information\n\n- [x] Bug still occurs when all/other plugins are disabled?\n",
+      "public_features": {
+        "language": "js",
+        "issue_word_count": 292,
+        "issue_size": "long",
+        "feature_key": "js.issue-long"
+      },
+      "source_row_digest": "sha256:bbf7ac7d78c2b875a46fba81a5884bb7785a954e8756a21ea13cde7c7ed8e507",
+      "problem_statement_digest": "sha256:a34338f7164ffe6bb708bd034f21bd839e60a4c019b5073e1cf3421c7ca41759",
+      "hidden_artifact_digests": {
+        "gold_patch": "sha256:8bb536ffd7490e1e5d21341b415ec9412f05129e1215a0dc52709d9d7737ff62",
+        "test_patch": "sha256:481c04593a542f143a8850bf3212c55ab684cc66ed5dafd2df1fbb063feb779f"
+      }
+    },
+    {
+      "schema": 1,
+      "instance_id": "openai__codex-plugin-cc-83",
+      "split": "js",
+      "row_index": 87,
+      "repo": "openai/codex-plugin-cc",
+      "pull_number": "83",
+      "base_commit": "8e403f9d4b496b0b0aff50fa3673f889f6a22cb1",
+      "created_at": "2026-04-01T08:09:41Z",
+      "docker_image": "starryzhang/sweb.eval.x86_64.openai_1776_codex-plugin-cc-83",
+      "problem_statement": "task --resume-last ignores current-session scoping and can resume another Claude session's task\n## Summary\n\n`task-resume-candidate --json` is scoped to the current Claude session, but `task --resume-last` is not. In a multi-session workspace, the CLI can report that there is no resumable task for the current session and then still resume a different session's persisted Codex thread.\n\nThe same helper also lets an active task from another Claude session block `--resume-last`, even when `/codex:status` for the current session shows no running jobs.\n\n## Reproduction\n\n1. Start a repository with the plugin state directory available.\n2. Run one successful `task` command under Claude session `sess-other` so it persists a completed task thread.\n3. In a separate Claude session `sess-current`, run:\n   - `node scripts/codex-companion.mjs task-resume-candidate --json`\n   - `node scripts/codex-companion.mjs task --resume-last \"follow up\"`\n4. Observe that `task-resume-candidate` reports `available: false`, but `--resume-last` still resumes the older thread from `sess-other`.\n5. Alternatively, leave a `running` task owned by `sess-other` in state and run `task --resume-last` from `sess-current`.\n\n## Expected\n\n- Implicit resume selection should use the same current-session visibility rules as `task-resume-candidate`.\n- If `CODEX_COMPANION_SESSION_ID` is set and the current session has no resumable task, `task --resume-last` should fail with \"No previous Codex task thread was found for this repository.\".\n- A running task from another session should not block `--resume-last` for the current session.\n\n## Actual\n\n- `task-resume-candidate` says there is no resumable task in the current session.\n- `task --resume-last` still resumes another session's completed thread.\n- A running task from another session can also block `--resume-last` with `Task ... is still running. Use /codex:status before continuing it.` even though `/codex:status` for the current session shows no running jobs.\n\n## Suspected Cause\n\n`resolveLatestTrackedTaskThread(...)` scans all persisted task jobs in the workspace and only excludes the current job id. It does not apply current-session filtering before choosing a completed thread or before checking for active tasks.\n\n## Suggested Fix\n\nThread the same session-aware filtering used by `task-resume-candidate` into the implicit `--resume-last` path, and only fall back to `findLatestTaskThread(...)` when there is no Claude session id in scope.\n\n",
+      "public_features": {
+        "language": "js",
+        "issue_word_count": 344,
+        "issue_size": "long",
+        "feature_key": "js.issue-long"
+      },
+      "source_row_digest": "sha256:54f3454ab284e822e55a39d47c0e3f6b8f1ee75dcfd33c31f59da03cb1f51e86",
+      "problem_statement_digest": "sha256:4abb1b12fd8fe85e030ac12737bc02d91f1c166c09332e21819faf1a2912e9d0",
+      "hidden_artifact_digests": {
+        "gold_patch": "sha256:463728ac65b14c90ad622973139ddbedb9d8a6af45e1bfe6c7e534676d6adce8",
+        "test_patch": "sha256:06524c6ffea8de5dc0efca91e7da14c285cc6155de24951da904369847503c24"
+      }
+    },
+    {
+      "schema": 1,
+      "instance_id": "aralroca__next-translate-1259",
+      "split": "js",
+      "row_index": 89,
+      "repo": "aralroca/next-translate",
+      "pull_number": "1259",
+      "base_commit": "f1fbf473b42cf795ae8eb996003222625bfc58ac",
+      "created_at": "2026-03-22T06:21:20Z",
+      "docker_image": "starryzhang/sweb.eval.x86_64.aralroca_1776_next-translate-1259",
+      "problem_statement": "I18nProvider ignores lang after upgrade from 3.0.0 to 3.0.2\nAfter upgrading next-translate from 3.0.0 to 3.0.2 I can no longer change my app's language. Regardless of which language I pass to I18nProvider, the app always renders using the default language. Rolling back to 3.0.0 restores expected behavior.\n\nEnvironment:\nnext: 16.1.6 (webpack)\nreact: 19.2.4\nnext-translate-plugin: 2.6.2 (also tried 3.0.2)\nnext-translate: 3.0.2 (next-translate-plugin peer dependecy)\n\nReproduction:\n\n```ts\nexport default function App({ Component, pageProps }: AppProps) {\n  const [lang, setLang] = useState('en')\n\n  return (\n    <I18nProvider key={lang} lang={lang}>\n      <DynamicNamespaces namespaces={['common']}>\n        <Component {...pageProps} onLanguageChange={setLang} />\n      </DynamicNamespaces>\n    </I18nProvider>\n  )\n}\n```\n\n```ts\nexport default function Home({ onLanguageChange }: HomeProps) {\n  const { t, lang } = useTranslation('common')\n  return (\n    <div className=\"h-svh flex flex-col items-center justify-center\">\n      <LanguageSelector onLanguageChange={onLanguageChange} />\n      <strong className=\"mt-4 text-2xl\">Current Language:</strong>{' '}\n      {t('languageName')} ({lang})\n    </div>\n  )\n}\n```\n```ts\nexport const LanguageSelector: React.FC<LanguageSelectorProps> = ({\n  onLanguageChange,\n}) => {\n  const { t, lang } = useTranslation('common')\n\n  const LANGUAGES = [\n  { code: 'en', name: 'English' },\n  { code: 'es', name: 'Español' },\n  { code: 'fr', name: 'Français' },\n  { code: 'pt', name: 'Português' },\n]\n\n  const handleLanguageChange = (e: React.ChangeEvent<HTMLSelectElement>) => {\n    const newLang = e.target.value\n    if (onLanguageChange) {\n      onLanguageChange(newLang)\n    }\n  }\n\n  return (\n    <div>\n      <label htmlFor=\"language-select\">\n        {t('selectLabel')}\n      </label>\n      <select\n        id=\"language-select\"\n        value={lang}\n        onChange={handleLanguageChange}\n      >\n        {LANGUAGES.map((language) => (\n          <option key={language.code} value={language.code}>\n            {language.name}\n          </option>\n        ))}\n      </select>\n    </div>\n  )\n}\n```\nOr clone this project: https://github.com/dmg-vicente/next-language-bug (uses 3.0.0 by default)\n\n",
+      "public_features": {
+        "language": "js",
+        "issue_word_count": 232,
+        "issue_size": "long",
+        "feature_key": "js.issue-long"
+      },
+      "source_row_digest": "sha256:545dba140b1864794974499042571d905660c5bf93b8e8043b03f7b468ee899f",
+      "problem_statement_digest": "sha256:8191eb84398517ae59a1dc73bf41c789099db2b81dadabe52ce7d3c6f2b1dbe8",
+      "hidden_artifact_digests": {
+        "gold_patch": "sha256:edfc197b29fddfa60f332966043b69fc387e8e32e6b1f5d6e1db5aa742dd7f22",
+        "test_patch": "sha256:f43ce8c65d6bd38403ef7e02c897351438d3683456bb79c432a429616cdd6e9d"
+      }
+    },
+    {
+      "schema": 1,
+      "instance_id": "MetaMask__metamask-mobile-17294",
+      "split": "ts",
+      "row_index": 44,
+      "repo": "MetaMask/metamask-mobile",
+      "pull_number": "17294",
+      "base_commit": "67e871cc994621f15dac7a662275ae3cc5af594e",
+      "created_at": "2025-07-16T17:30:19Z",
+      "docker_image": "starryzhang/sweb.eval.x86_64.metamask_1776_metamask-mobile-17294",
+      "problem_statement": "[Bug]: Request Payment button for Solana should be disabled and hidden\n### Describe the bug\n\nRequest Payment button for Solana should be disabled and hidden\n\n### Expected behavior\n\n_No response_\n\n### Screenshots/Recordings\n\nhttps://github.com/user-attachments/assets/698242d2-b727-4b22-a843-e1b7c925cc5f\n\n### Steps to reproduce\n\n1. Switch to Solana network\n2. Click receive\n3. See request payment button is displayed and enabled \n\n### Error messages or log output\n\n```shell\n\n```\n\n### Detection stage\n\nDuring release testing\n\n### Version\n\n7.51.0\n\n### Build type\n\nNone\n\n### Device\n\nIphone 16\n\n### Operating system\n\niOS\n\n### Additional context\n\n_No response_\n\n### Severity\n\n_No response_\n",
+      "public_features": {
+        "language": "ts",
+        "issue_word_count": 92,
+        "issue_size": "short",
+        "feature_key": "ts.issue-short"
+      },
+      "source_row_digest": "sha256:8cb7b11f2e449de71a65276343620a13fd779d5c113e1a771129b00ca1d5142f",
+      "problem_statement_digest": "sha256:40a80b29eae2aa4b8504a8d81c3012bfd5e6aefa6be6a848bd99689a5ef5fd67",
+      "hidden_artifact_digests": {
+        "gold_patch": "sha256:edabe2bf9071f006dbfffd32ddbb304df6395f1f84ccda99ebbe4189b6e70794",
+        "test_patch": "sha256:41e70b24b89f9d64e8370f5363360d455fe308d809c85d4eef3c5dcb117291a1"
+      }
+    },
+    {
+      "schema": 1,
+      "instance_id": "denoland__std-6775",
+      "split": "ts",
+      "row_index": 67,
+      "repo": "denoland/std",
+      "pull_number": "6775",
+      "base_commit": "5aa2bf1280b24e921e1b7cc610bbc3196311d95a",
+      "created_at": "2025-07-27T09:20:49Z",
+      "docker_image": "starryzhang/sweb.eval.x86_64.denoland_1776_std-6775",
+      "problem_statement": "`@std/async` `delay(Infinity)` or `delay(0x80000000)` resolve immediately\n**Describe the bug**\n\n`@std/async` `delay(Infinity)` or `delay(0x80000000)` resolve immediately. This is due to the value passed to `setTimeout` being coerced to an i32, with a [max value of `0x7fffffff`](https://developer.mozilla.org/en-US/docs/Web/API/Window/setTimeout#maximum_delay_value).\n\n**Steps to Reproduce**\n\n```ts\nimport { delay } from '@std/async'\ndelay(0x80000000).then(() => console.log('done')) // logs immediately\n\nawait Promise.race([1, Infinity].map((n) => delay(n).then(() => n)))\n// returns Infinity\n```\n\n**Expected behavior**\n\n`delay` not to resolve until the time specified has elapsed (never resolve if `Infinity`).\n\nThis probably isn't important for most use cases, as `Deno.cron` is a much better solution for scheduling tasks etc, but `delay(Infinity)` (maybe also passing an abort signal etc) would be a handy shorthand for \"never resolve\" for cases like long-polling to implement simple dev server watch/reload logic.\n\n**Environment**\n\n- OS: WSL\n- deno version: 2.4.0\n- std version: @std/async@1.0.13\n\n",
+      "public_features": {
+        "language": "ts",
+        "issue_word_count": 137,
+        "issue_size": "short",
+        "feature_key": "ts.issue-short"
+      },
+      "source_row_digest": "sha256:9f4cbce1242e7d0bd766ddc80dfe91d36d9100363cf832f2867615b28cdc63bf",
+      "problem_statement_digest": "sha256:924ce0cc1020957af42c8a324a69150a96e6b3694b653ed07e28d9cc5baa4446",
+      "hidden_artifact_digests": {
+        "gold_patch": "sha256:7b9ccf3d37c88d7a6d814d19eebf0f94dd574e5b1c138e966425fce370b2d6af",
+        "test_patch": "sha256:331db371a952a2be280e0c0710cb71154392a7181c04f3f3221f2db20798977d"
+      }
+    },
+    {
+      "schema": 1,
+      "instance_id": "RocketChat__Rocket.Chat.ReactNative-6382",
+      "split": "ts",
+      "row_index": 40,
+      "repo": "RocketChat/Rocket.Chat.ReactNative",
+      "pull_number": "6382",
+      "base_commit": "05a0b498e88de4a10ca0a22d8049de0740e8bfb0",
+      "created_at": "2025-05-25T12:32:44Z",
+      "docker_image": "starryzhang/sweb.eval.x86_64.rocketchat_1776_rocket.chat.reactnative-6382",
+      "problem_statement": "Mobile apps show colons around the emoji when sent by webhook\n```bash\ncurl -H 'Content-Type: application/json' \\\n                                                      --data '{\n                                                      \"emoji\": \":smirk:\",\n                                                      \"text\": \"Example message\"}' https://<server>/hooks/***/***\n```\nRenders as \"\\:😏\\:\" on mobile apps, but correctly (\"😏\") in desktop.\n\nRemoving the colons from the message renders as \"😏\" on mobile, but blank on desktop\n\niOS: 4.60.79286\nAndroid: 4.60.79290\nDesktop: 4.4.0\nServer : 7.3.1\n\nMobile:\n![Image](https://github.com/user-attachments/assets/545ef7dc-3f55-4162-b6fa-e42f937fe838)\n\nDesktop:\n![Image](https://github.com/user-attachments/assets/5a0c5d22-04ea-426c-887b-922f4d598890)\n\n\n\n",
+      "public_features": {
+        "language": "ts",
+        "issue_word_count": 65,
+        "issue_size": "short",
+        "feature_key": "ts.issue-short"
+      },
+      "source_row_digest": "sha256:cc24cda86233229539f5ac2dc810a88dbef0cf8920d7e5d4f472eb74a6f7ef1a",
+      "problem_statement_digest": "sha256:bf4e4d3b96108085ca60a886404c7a86f458da9711a322c4e69c78d36325f0c2",
+      "hidden_artifact_digests": {
+        "gold_patch": "sha256:33193468659cdd84b6b3a9c3d5264e72e2c7724f6ac53d48f14280b3ae4a5534",
+        "test_patch": "sha256:e16825488204faa59e8fef818b30489292fc5e1bda82cd8922c1ebcab708cc39"
+      }
+    },
+    {
+      "schema": 1,
+      "instance_id": "jhlywa__chess.js-546",
+      "split": "ts",
+      "row_index": 15,
+      "repo": "jhlywa/chess.js",
+      "pull_number": "546",
+      "base_commit": "c57231d6416ed3e1aaf94ddb90cfbb914889263f",
+      "created_at": "2025-07-08T19:34:02Z",
+      "docker_image": "starryzhang/sweb.eval.x86_64.jhlywa_1776_chess.js-546",
+      "problem_statement": ".fen({ forceEnpassantSquare = true)) not working\n```typescript\nimport {Chess} from 'chess.js'\n\nconst chess = new Chess()\n\n\nchess.move(\"h2h4\");\n\nconsole.log(chess.fen({forceEnpassantSquare: true}));\n// returns:\n// rnbqkbnr/pppppppp/8/8/7P/8/PPPPPPP1/RNBQKBNR b KQkq - 0 1\n// expected\n// rnbqkbnr/pppppppp/8/8/7P/8/PPPPPPP1/RNBQKBNR b KQkq h3 0 1\n```\n",
+      "public_features": {
+        "language": "ts",
+        "issue_word_count": 38,
+        "issue_size": "short",
+        "feature_key": "ts.issue-short"
+      },
+      "source_row_digest": "sha256:466f53871e767fc7c1baaa860295d36bc2c460a9e6f1aee0485fb39abc28ceb3",
+      "problem_statement_digest": "sha256:892ece94abee3c7b911ec4a67e6ec5fdf5ab913838748909a1137c0404511f70",
+      "hidden_artifact_digests": {
+        "gold_patch": "sha256:803ca27d8a33e43ee9b6b6b9930d9bd10ea99c73d3da27463c382b292093941e",
+        "test_patch": "sha256:80414c35f3829ebb313fd000cf47f8995d0a7fed6154d52d2a0d7536dccf1cb6"
+      }
+    },
+    {
+      "schema": 1,
+      "instance_id": "code-yeongyu__oh-my-openagent-3013",
+      "split": "ts",
+      "row_index": 102,
+      "repo": "code-yeongyu/oh-my-openagent",
+      "pull_number": "3013",
+      "base_commit": "941e265aa15281445ee2953aa435a1c4010214a6",
+      "created_at": "2026-04-02T01:40:24Z",
+      "docker_image": "starryzhang/sweb.eval.x86_64.code-yeongyu_1776_oh-my-openagent-3013",
+      "problem_statement": "[Bug]: Skill short names are exposed but not resolvable by the skill resolver\n## Prerequisites\n- [x] I will write this issue in English (see the Language Policy)\n- [x] I have searched existing issues to avoid duplicates\n- [x] I am using the latest version of oh-my-opencode\n- [x] I have read the documentation or asked an AI coding agent with this project's GitHub URL loaded and couldn't find the answer\n\n## Bug Description\nIn an OpenCode environment with oh-my-opencode installed, some superpowers skills are surfaced to the user by their short names (for example `systematic-debugging`), but the `skill` resolver does not actually accept those short names.\n\nCalling the visible short name fails with a `not found` error, and the error message then suggests using the fully qualified name such as `superpowers/systematic-debugging` or the slash-command form `/superpowers:systematic-debugging`.\n\nFrom a user perspective, this looks like a product bug rather than user error, because the visible skill name is not the same as the executable identifier.\n\n## Steps to Reproduce\n1. In the current environment, invoke the skill using the visible short name:\n   ```text\n   systematic-debugging\n   ```\n   or call the skill resolver/tool with that same short name.\n2. Observe the error:\n   ```text\n   Skill or command \"systematic-debugging\" not found. Did you mean: superpowers/systematic-debugging, /superpowers:systematic-debugging?\n   ```\n3. Retry with the fully qualified name:\n   ```text\n   superpowers/systematic-debugging\n   ```\n4. The invocation succeeds.\n\n## Expected Behavior\nIf a skill is exposed in the available-skills list / UI / context as `systematic-debugging`, that short name should be directly resolvable by the `skill` mechanism.\n\nIf short names are intentionally unsupported, then the system should consistently expose only the fully qualified name, so users are not guided toward an invalid invocation.\n\n## Actual Behavior\n- The skill is surfaced to the user as a short name like `systematic-debugging`\n- The resolver rejects that short name\n- The resolver only accepts the fully qualified form such as `superpowers/systematic-debugging`\n- The error message teaches the workaround only after the failure happens\n\n## Doctor Output\n```shell\n$ bunx oh-my-opencode doctor\n\n oMoMoMoMo Doctor \n\n ⚠ 3 issues found:\n\n1. Model override uses unavailable provider\n   Provider(s) not found in OpenCode model cache: axonhub, Custom:Nvidia Nim\n   Affects: model resolution\n\n2. Comment checker unavailable\n   Comment checker binary is not installed.\n   Fix: Install @code-yeongyu/comment-checker\n   Affects: comment-checker hook\n\n3. Configured models rely on compatibility fallback\n   multimodal-looker=google/antigravity-gemini-3-flash (heuristic-backed)\n   Affects: multimodal-looker\n```\n\n## Error Logs\n```shell\nSkill or command \"systematic-debugging\" not found. Did you mean: superpowers/systematic-debugging, /superpowers:systematic-debugging?\n```\n\n## Configuration\n```json\n{\n  \"note\": \"No minimal config snippet isolated yet. The issue appears to be in skill name exposure vs resolver namespace handling rather than a user-specific config mistake.\"\n}\n```\n\n## Additional Context\nMy current guess is that the short-name alias is being displayed but not registered in the runtime resolver, or that the resolver is not expanding short names back to the canonical `superpowers/...` identifier.\n\nIn other words, the presentation layer and the execution layer seem to disagree about the valid skill identifier.\n\nCurrent workaround:\n- `superpowers/systematic-debugging`\n- `/superpowers:systematic-debugging`\n\n## Operating System\nmacOS\n\n## OpenCode Version\n1.3.9\n\n",
+      "public_features": {
+        "language": "ts",
+        "issue_word_count": 506,
+        "issue_size": "long",
+        "feature_key": "ts.issue-long"
+      },
+      "source_row_digest": "sha256:75b857583d29be2e29cb841a38d2ce998d236248c779cb83aa400ca507ec8148",
+      "problem_statement_digest": "sha256:8c3827b7454520c6609238a13028cb3b40ba11955847ca23c9a28bef179f4be0",
+      "hidden_artifact_digests": {
+        "gold_patch": "sha256:ecd483f8e8125a12212265c2359dbf9e0b39200b88c12a820a70b17b31b742ed",
+        "test_patch": "sha256:cd399df9ecd4bf3d0a266fdf87bd3018bdea0a8d56bad96e1ed68abf1cdfe34c"
+      }
+    },
+    {
+      "schema": 1,
+      "instance_id": "honojs__hono-4269",
+      "split": "ts",
+      "row_index": 23,
+      "repo": "honojs/hono",
+      "pull_number": "4269",
+      "base_commit": "0432f81c376a3854d5a00da350b6f8f74a6ad9f2",
+      "created_at": "2025-07-03T14:03:12Z",
+      "docker_image": "starryzhang/sweb.eval.x86_64.honojs_1776_hono-4269",
+      "problem_statement": "TypeError: Body is unusable\n### What version of Hono are you using?\n\n4.8.3\n\n### What runtime/platform is your app running on? (with version if possible)\n\nNode\n\n### What steps can reproduce the bug?\n\nAdd 2x `zValidators` for path/middleware for json, header and try to access raw body text in route handler.\n\nFrom my investigations, [this](https://github.com/honojs/hono/blob/main/src/validator/validator.ts#L78) is causing the error. If we clone the json using `await c.req.raw.clone().json()`, it works fine.\n\nExample using create hono app:\n```\nimport { serve } from \"@hono/node-server\";\nimport { Hono } from \"hono\";\nimport { z } from \"zod\";\nimport { zValidator } from \"@hono/zod-validator\";\n\nconst schema = z.object({  mock: z.string() });\n\nconst app = new Hono();\n\napp\n  .get(\"/\", (c) => {\n    return c.text(\"Hello Hono!\");\n  })\n  .post(\n    \"/\",\n    zValidator(\"header\", schema),\n    zValidator(\"json\", schema),\n    async (c) => {\n      // causes error\n      console.log(await c.req.raw.clone().text());\n\n      return c.text(\"Hello Hono!\");\n    }\n  );\n\nserve(\n  {\n    fetch: app.fetch,\n    port: 3000,\n  },\n  (info) => {\n    console.log(`Server is running on http://localhost:${info.port}`);\n  }\n);\n```\n\n### What is the expected behavior?\n\nI'm able to use multiple zValidators - especially for json & header - and still access the raw body.\n\n### What do you see instead?\n\n```\nTypeError: unusable\n    at Request.clone (node:internal/deps/undici/undici:9942:17)\n    at Request.value (file:///Users/pete/Development/poc/hono-bug/node_modules/.pnpm/@hono+node-server@1.14.4_hono@4.8.3/node_modules/@hono/node-server/dist/index.mjs:122:40)\n    at <anonymous> (/Users/pete/Development/poc/hono-bug/src/index.ts:21:35)\n    at dispatch (file:///Users/pete/Development/poc/hono-bug/node_modules/.pnpm/hono@4.8.3/node_modules/hono/dist/compose.js:22:23)\n    at file:///Users/pete/Development/poc/hono-bug/node_modules/.pnpm/hono@4.8.3/node_modules/hono/dist/compose.js:22:46\n    at file:///Users/pete/Development/poc/hono-bug/node_modules/.pnpm/hono@4.8.3/node_modules/hono/dist/validator/validator.js:81:11\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at async dispatch (file:///Users/pete/Development/poc/hono-bug/node_modules/.pnpm/hono@4.8.3/node_modules/hono/dist/compose.js:22:17)\n    at async file:///Users/pete/Development/poc/hono-bug/node_modules/.pnpm/hono@4.8.3/node_modules/hono/dist/validator/validator.js:81:5\n    at async dispatch (file:///Users/pete/Development/poc/hono-bug/node_modules/.pnpm/hono@4.8.3/node_modules/hono/dist/compose.js:22:17)\n```\n\n### Additional information\n\n_No response_\n",
+      "public_features": {
+        "language": "ts",
+        "issue_word_count": 229,
+        "issue_size": "long",
+        "feature_key": "ts.issue-long"
+      },
+      "source_row_digest": "sha256:382cbb786226847b5316f8064b72ede5e885c4982d2fc99c6300782c1638a90b",
+      "problem_statement_digest": "sha256:0cfe71d26328d5b1110377d4a21a4dfa92630d9838e4ca62538ea899541e847b",
+      "hidden_artifact_digests": {
+        "gold_patch": "sha256:c8875f7ba4f4e75fd40c1cdf7103d585ac86ef3f7672f55ed5adc8bd927f6f47",
+        "test_patch": "sha256:fa581aac9609d1ce29d6cf085c0f6c376bba649f93598450434786eebc7a89a9"
+      }
+    },
+    {
+      "schema": 1,
+      "instance_id": "TanStack__router-4611",
+      "split": "ts",
+      "row_index": 82,
+      "repo": "TanStack/router",
+      "pull_number": "4611",
+      "base_commit": "4124583bce47cd19a2f57439f939c0ad736cacb1",
+      "created_at": "2025-07-10T02:23:20Z",
+      "docker_image": "starryzhang/sweb.eval.x86_64.tanstack_1776_router-4611",
+      "problem_statement": "[Start] Pages with non-Latin characters in the route path are not rendered in TanStack Start\n### Which project does this relate to?\n\nStart\n\n### Describe the bug\n\nI’m building a project in Persian, which is a non-English language that uses a non-Latin alphabet. Today I noticed that pages with non-Latin characters in their route paths — like the example below:\n\n```tsx\nimport { createFileRoute } from '@tanstack/react-router'\n\nexport const Route = createFileRoute('/تست')({\n  component: RouteComponent,\n})\n\nfunction RouteComponent() {\n  return <div>Hello \"/تست\"!</div>\n}\n\n```\nare not being rendered.\n\nAnd in the browser console, only this code/message is shown:\n\n```html\n<html><head></head><body></body></html>\n```\n\n### Your Example Website or App\n\nhttps://github.com/Mrahmani71/test-tanstack-start\n\n### Steps to Reproduce the Bug or Issue\n\nAfter installing the packages and running the project, go to the following link — you’ll see that the page doesn’t render.\n\n[http://localhost:3000/%D8%AA%D8%B3%D8%AA](http://localhost:3000/تست)\n\n### Expected behavior\n\nI expected this page to render just like other pages with Latin characters and display its content correctly.\n\n### Screenshots or Videos\n\n_No response_\n\n### Platform\n\n- Start Version: 1.125.6\n- OS: Windows\n- Browser: Brave \n- Browser Version: 1.80.120 / Chromium: 138.0.7204.101\n- Bundler: Vite\n- Bundler Version: 6.3.5\n\n\n### Additional context\n\nI didn’t have this issue with tanstack-router — the page was displayed correctly.\n",
+      "public_features": {
+        "language": "ts",
+        "issue_word_count": 206,
+        "issue_size": "long",
+        "feature_key": "ts.issue-long"
+      },
+      "source_row_digest": "sha256:491d4627ed058e44307bb542b4b8fe64b7073fada027045731df21e47d3bba32",
+      "problem_statement_digest": "sha256:af0578f90448fde91edfd737773eced91d3ddf791795628f8d2c206dda4f99e7",
+      "hidden_artifact_digests": {
+        "gold_patch": "sha256:cc76945838f1ace1e7b690d65cf79dbbebfcecbbfe4bae3365073febe70146cf",
+        "test_patch": "sha256:222e1c03b8e0f5bb7c5fd08635b88468344d9549cce35bc241abae738f2274fb"
+      }
+    },
+    {
+      "schema": 1,
+      "instance_id": "openai__openai-agents-js-156",
+      "split": "ts",
+      "row_index": 74,
+      "repo": "openai/openai-agents-js",
+      "pull_number": "156",
+      "base_commit": "07939c0f7fb5b6d7a6da819931d052fc0d5177d5",
+      "created_at": "2025-06-25T09:47:16Z",
+      "docker_image": "starryzhang/sweb.eval.x86_64.openai_1776_openai-agents-js-156",
+      "problem_statement": "Human in the Loop MCP approval fails\n### Please read this first\n\n- **Have you read the docs?** [Agents SDK docs](https://openai.github.io/openai-agents-js/) ✅ \n- **Have you searched for related issues?** Others may have faced similar issues. ✅ \n\n### Describe the bug\n\nThere is a bug in the serialization logic for `RunState` that causes data loss for MCP approval items when an agent run is interrupted and resumed. Specifically, the Zod schema for `lastProcessedResponse.mcpApprovalRequests` is incomplete, causing essential properties like `id` and `providerData` to be stripped from the rawItem during serialization.\nThis leads to a corrupted state upon deserialization, where subsequent logic that relies on these properties fails, making it impossible to correctly handle MCP tool approvals across agent turns.\n\nThis results to an `400 The following MCP approval requests do not have an approval: mcpr_...` error.\n\n[This](https://github.com/openai/openai-agents-js/blob/main/packages/agents-core/src/runImplementation.ts#L330) filter returns an empty array, because `providerData` is not there.\n\nSolution:\nAdd `id` and `providerData` to [rawItem](https://github.com/openai/openai-agents-js/blob/main/packages/agents-core/src/runState.ts#L162)\n\n### Debug information\n\n- Agents SDK version: (e.g. `v0.0.8`)\n- Runtime environment (e.g. `Node.js 22.16.0`)\n\n### Repro steps\n\n```ts\nexport const agent = new Agent({\n  name: \"Assistant\",\n  model: \"gpt-4.1-2025-04-14\",\n  instructions: \"You are a helpful assistant.\",\n  tools: [\n    hostedMcpTool({\n      serverLabel: \"deepwiki\",\n      serverUrl: \"https://mcp.deepwiki.com/mcp\",\n      requireApproval: \"always\",\n    }),\n  ],\n});\n\n// Serialization:\nlet result = await run(agent, [\n    { role: \"system\", content: systemContent },\n    { role: \"user\", content: prompt },\n  ]);\n\n  const hasInterruptions = result.interruptions?.length > 0;\n\n  if (hasInterruptions) {\n    const uuid = crypto.randomUUID();\n    const statePath = path.join(\"./agent_states\", `${uuid}.json`);\n    await fs.mkdir(path.dirname(statePath), { recursive: true });\n    await fs.writeFile(statePath, JSON.stringify(result.state, null, 2), \"utf-8\");\n}\n\n // Deserealization:\n    const stored = await fs.readFile(statePath, \"utf-8\");\n\n    const state = await RunState.fromString(agent, stored); // rawItem providerData is no longer there\n    const interruptions = state.getInterruptions();\n\n    for (const interruption of interruptions) {\n      if (approve) {\n        console.log(\"Approving interruption:\", interruption);\n        state.approve(interruption, { alwaysApprove: true });\n      } else {\n        state.reject(interruption);\n      }\n    }\n\n   let result = await run(agent, state); // error\n```\n\n### Expected behavior\n\nNo approval error.\n\n\nI'm happy to open a PR, if it's verified by your side.\n\n",
+      "public_features": {
+        "language": "ts",
+        "issue_word_count": 327,
+        "issue_size": "long",
+        "feature_key": "ts.issue-long"
+      },
+      "source_row_digest": "sha256:8832a7354625150f1a7e62d49506079c8a6ab19e176f0d46baae0be86249a7eb",
+      "problem_statement_digest": "sha256:1c589b5db8b3b9534f693a174740d7c6e2a502a39307064431ae1f70757fd026",
+      "hidden_artifact_digests": {
+        "gold_patch": "sha256:719bf81ff5db42eb6dd28075335a1a2bad8caf6043a113e8c748e5e9160d991c",
+        "test_patch": "sha256:7538ef9457f25af61f3c4dee3eb3310ac633f2d4ad61ea6d4b3d6f347e566817"
+      }
+    }
+  ],
+  "attestation": {
+    "algorithm": "Ed25519",
+    "payload_digest": "sha256:f85a9abab520395568f8e139f2c694d9c24e58f35bc9ad57e56b4844d6bc9862",
+    "signature": "wG/T0cSkJ4grT6dOV/GuPSjHD8pR2C1NdyM26PVUZzTHCZeI/Et8pstqR/YIITYn60QXYg97fSN7hTPdOqJ7CA=="
+  }
+}

--- a/core/public-holdout-pilot/artifacts.js
+++ b/core/public-holdout-pilot/artifacts.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const { digest } = require('../operation-control/contracts');
+const { attest, calibrationHistory } = require('../public-holdout/artifacts');
+const { buildPilotAssignment, PILOT_DESIGN } = require('./design');
+const { PILOT_PLAN_IDS, routePilotTask } = require('./router');
+const { analyzePilot } = require('./statistics');
+
+function buildPilotFreeze({ parentRequest, parentSelection, parentPreflight, parentAssignment, sourceDigests, privateKey, frozenAt = new Date().toISOString() }) {
+  const unsigned = {
+    schema: 1,
+    kind: 'citadel_public_holdout_fast_pilot_freeze',
+    freeze_id: null,
+    frozen_at: frozenAt,
+    parent_request_id: parentRequest.request_id,
+    parent_selection_id: parentSelection.selection_id,
+    parent_preflight_id: parentPreflight.preflight_id,
+    parent_terminal_assignment_id: parentAssignment.assignment_id,
+    parent_terminal_status: parentAssignment.status,
+    design: PILOT_DESIGN,
+    source_digests: sourceDigests,
+    attestation_public_key: parentRequest.attestation_public_key,
+  };
+  return attest({ ...unsigned, freeze_id: digest(unsigned) }, privateKey);
+}
+
+function buildSignedPilotAssignment({ freeze, selection, preflight, privateKey }) {
+  return attest(buildPilotAssignment({ freezeId: freeze.freeze_id, selection, preflight }), privateKey);
+}
+
+function buildPilotVisible({ freeze, assignment, tasks, privateKey }) {
+  const assigned = [...assignment.assignments.calibration, ...assignment.assignments.evaluation];
+  const byId = new Map(tasks.map((task) => [task.instance_id, task]));
+  const visible = assigned.map((instanceId) => {
+    const task = byId.get(instanceId);
+    if (!task) throw new Error(`pilot visible task missing: ${instanceId}`);
+    return task;
+  });
+  const unsigned = { schema: 1, kind: 'citadel_public_holdout_fast_pilot_visible_tasks', artifact_id: null, freeze_id: freeze.freeze_id, assignment_id: assignment.assignment_id, tasks: visible };
+  return attest({ ...unsigned, artifact_id: digest(unsigned) }, privateKey);
+}
+
+function buildPilotRouteLedger({ freeze, assignment, visibleTasks, calibrationAttemptSets, calibrationVerdictBundles, privateKey }) {
+  const evaluationIds = new Set(assignment.assignments.evaluation);
+  const history = calibrationHistory(calibrationAttemptSets, calibrationVerdictBundles, visibleTasks);
+  const routes = visibleTasks.filter((task) => evaluationIds.has(task.instance_id)).map((task) => routePilotTask(task, history));
+  const unsigned = { schema: 1, kind: 'citadel_public_holdout_fast_pilot_route_ledger', ledger_id: null, freeze_id: freeze.freeze_id, assignment_id: assignment.assignment_id, calibration_history_digest: digest(history), calibration_records: history.length, routes };
+  return attest({ ...unsigned, ledger_id: digest(unsigned) }, privateKey);
+}
+
+function policyOutcome(path, attemptsByPlan, verdictsByPlan) {
+  const visited = [];
+  let status = 'failed';
+  for (const planId of path) {
+    const attempt = attemptsByPlan.get(planId);
+    const verdict = verdictsByPlan.get(planId);
+    if (!attempt || !verdict) throw new Error(`pilot attempt or verdict missing for ${planId}`);
+    visited.push({ plan_id: planId, attempt_id: attempt.attempt_id, verification_status: verdict.verification_status, comparison_cost_usd: attempt.economics.comparison_cost.amount_usd });
+    if (verdict.verification_status === 'passed') { status = 'passed'; break; }
+    if (verdict.verification_status === 'unknown') { status = 'unknown'; break; }
+  }
+  const costs = visited.map((attempt) => attempt.comparison_cost_usd);
+  return { status, visited_attempts: visited, comparison_cost_usd: costs.every(Number.isFinite) ? Number(costs.reduce((sum, value) => sum + value, 0).toFixed(9)) : null };
+}
+
+function buildPilotAnalysis({ freeze, assignment, visibleTasks, routeLedger, evaluationAttemptSets, evaluationVerdictBundles, privateKey }) {
+  const evaluationIds = new Set(assignment.assignments.evaluation);
+  const attemptsByTask = new Map();
+  for (const attempt of evaluationAttemptSets.flat()) {
+    if (!attemptsByTask.has(attempt.instance_id)) attemptsByTask.set(attempt.instance_id, new Map());
+    attemptsByTask.get(attempt.instance_id).set(attempt.plan_id, attempt);
+  }
+  const verdictsByTask = new Map();
+  for (const bundle of evaluationVerdictBundles) for (const verdict of bundle.verdicts) {
+    if (!verdictsByTask.has(verdict.instance_id)) verdictsByTask.set(verdict.instance_id, new Map());
+    verdictsByTask.get(verdict.instance_id).set(bundle.plan_id, verdict);
+  }
+  const routeById = new Map(routeLedger.routes.map((route) => [route.instance_id, route]));
+  const rows = visibleTasks.filter((task) => evaluationIds.has(task.instance_id)).map((task) => {
+    const attempts = attemptsByTask.get(task.instance_id);
+    const verdicts = verdictsByTask.get(task.instance_id);
+    const route = routeById.get(task.instance_id);
+    if (!attempts || !verdicts || !route) throw new Error(`pilot evaluation evidence incomplete: ${task.instance_id}`);
+    return { instance_id: task.instance_id, repo: task.repo, feature_key: task.public_features.feature_key, outcomes: { 'always-claude': policyOutcome([PILOT_PLAN_IDS.cloud], attempts, verdicts), 'static-local-first': policyOutcome([PILOT_PLAN_IDS.local, PILOT_PLAN_IDS.cloud], attempts, verdicts), 'citadel-controller': policyOutcome(route.decision.selected.plan_ids, attempts, verdicts) } };
+  });
+  const executed = evaluationAttemptSets.flat();
+  const unsigned = {
+    schema: 1,
+    kind: 'citadel_public_holdout_fast_pilot_final_analysis',
+    analysis_id: null,
+    freeze_id: freeze.freeze_id,
+    assignment_id: assignment.assignment_id,
+    route_ledger_id: routeLedger.ledger_id,
+    rows,
+    primary: analyzePilot(rows),
+    counterfactual_execution_disclosure: { generated_attempts: executed.length, policy_cost_excludes_unvisited_generated_tiers: true, total_observed_generation_comparison_usd: executed.every((attempt) => Number.isFinite(attempt.economics.comparison_cost.amount_usd)) ? Number(executed.reduce((sum, attempt) => sum + attempt.economics.comparison_cost.amount_usd, 0).toFixed(9)) : null },
+    actual_subscription_cash_status: 'unknown',
+  };
+  return attest({ ...unsigned, analysis_id: digest(unsigned) }, privateKey);
+}
+
+module.exports = Object.freeze({ buildPilotAnalysis, buildPilotFreeze, buildPilotRouteLedger, buildPilotVisible, buildSignedPilotAssignment, policyOutcome });

--- a/core/public-holdout-pilot/design.js
+++ b/core/public-holdout-pilot/design.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const { digest } = require('../operation-control/contracts');
+
+const PILOT_DESIGN = Object.freeze({
+  design_id: 'public-holdout-fast-pilot-v1',
+  parent_protocol: 'public-holdout-capstone-v1-terminal-setup-unknown',
+  feature_strata: Object.freeze(['js.issue-short', 'js.issue-long', 'ts.issue-short', 'ts.issue-long']),
+  calibration_per_feature_stratum: 2,
+  evaluation_per_feature_stratum: 4,
+  calibration_total: 8,
+  evaluation_total: 16,
+  maximum_tasks_per_repo: 1,
+  required_gold_passes: 3,
+  gold_attempts: 3,
+  plan_ids: Object.freeze(['qwen-3b', 'claude-sonnet']),
+  assignment_rule: 'within each frozen feature-stratum order, take the first two gold-valid tasks from unique repositories for calibration and the next four for untouched evaluation',
+  stopping_rule: 'if any stratum cannot fill two calibration and four evaluation tasks under the one-task-per-repository cap, stop setup-unknown before model inference',
+  inference_scope: 'bounded paired descriptive pilot; no population-wide noninferiority or universal savings claim',
+});
+
+function goldDisposition(result) {
+  if (!result) return 'not-preflighted';
+  if (result.attempts === PILOT_DESIGN.gold_attempts && result.passes === PILOT_DESIGN.required_gold_passes) return 'gold-valid';
+  if (result.failures > 0) return 'gold-invalid';
+  return 'setup-unknown';
+}
+
+function buildPilotAssignment({ freezeId, selection, preflight }) {
+  if (!freezeId || selection.selection_id !== preflight.selection_id) throw new Error('pilot parent evidence identity invalid');
+  const assignments = { calibration: [], evaluation: [] };
+  const decisions = [];
+  const usedRepos = new Set();
+  const byId = new Map(preflight.tasks.map((task) => [task.instance_id, task]));
+
+  for (const featureKey of PILOT_DESIGN.feature_strata) {
+    const split = featureKey.slice(0, 2);
+    let calibration = 0;
+    let evaluation = 0;
+    for (const ordered of selection.ordered_candidates[split].filter((candidate) => candidate.feature_key === featureKey)) {
+      const result = byId.get(ordered.instance_id);
+      const repo = result?.repo || ordered.repo;
+      const gold = goldDisposition(result);
+      let disposition = gold;
+      if (gold === 'gold-valid' && usedRepos.has(repo)) disposition = 'repo-cap';
+      else if (gold === 'gold-valid' && calibration < PILOT_DESIGN.calibration_per_feature_stratum) {
+        disposition = 'calibration';
+        calibration += 1;
+        usedRepos.add(repo);
+        assignments.calibration.push(ordered.instance_id);
+      } else if (gold === 'gold-valid' && evaluation < PILOT_DESIGN.evaluation_per_feature_stratum) {
+        disposition = 'evaluation';
+        evaluation += 1;
+        usedRepos.add(repo);
+        assignments.evaluation.push(ordered.instance_id);
+      } else if (gold === 'gold-valid') disposition = 'unused-valid-reserve';
+      decisions.push({ split, feature_key: featureKey, rank: ordered.rank, instance_id: ordered.instance_id, repo, gold_disposition: gold, disposition });
+      if (calibration === PILOT_DESIGN.calibration_per_feature_stratum && evaluation === PILOT_DESIGN.evaluation_per_feature_stratum) break;
+    }
+  }
+
+  const ready = assignments.calibration.length === PILOT_DESIGN.calibration_total
+    && assignments.evaluation.length === PILOT_DESIGN.evaluation_total
+    && usedRepos.size === PILOT_DESIGN.calibration_total + PILOT_DESIGN.evaluation_total;
+  const unsigned = {
+    schema: 1,
+    kind: 'citadel_public_holdout_fast_pilot_assignment',
+    assignment_id: null,
+    freeze_id: freezeId,
+    parent_selection_id: selection.selection_id,
+    parent_preflight_id: preflight.preflight_id,
+    status: ready ? 'ready' : 'setup-unknown',
+    assignments,
+    decisions,
+    unique_repository_count: usedRepos.size,
+  };
+  return Object.freeze({ ...unsigned, assignment_id: digest(unsigned) });
+}
+
+module.exports = Object.freeze({ PILOT_DESIGN, buildPilotAssignment, goldDisposition });

--- a/core/public-holdout-pilot/router.js
+++ b/core/public-holdout-pilot/router.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const { digest } = require('../operation-control/contracts');
+const { calibratedPrediction, routeOperation } = require('../operation-controller/controller');
+
+const PILOT_PLAN_IDS = Object.freeze({ local: 'qwen-3b', cloud: 'claude-sonnet' });
+const PILOT_ROUTING = Object.freeze({
+  prior: Object.freeze({ success_probability: 0.5, strength: 1, source: 'symmetric-beta-half-neutral-prior' }),
+  quality_rule: 'direct-Claude conservative probability in the same frozen feature stratum, floored at 0.10',
+  candidate_rule: 'choose the lower expected comparison-cost path meeting the direct-Claude quality target; otherwise choose highest conservative quality',
+  recovery_rule: 'the local-first path advances to Claude only after an official hidden-test failure and stops on pass or unknown',
+});
+
+function known(amount, source, basis = 'estimate') { return { status: 'known', amount_usd: amount, basis, source }; }
+function unknown(source, basis = 'estimate') { return { status: 'unknown', amount_usd: null, basis, source }; }
+
+function plan({ planId, label, adapterId, model, fallbackPlanIds, expectedDurationMs, estimatedMarginalUsd }) {
+  return {
+    plan_id: planId,
+    label,
+    adapter_id: adapterId,
+    topology: 'direct',
+    model,
+    tools: [],
+    privacy: fallbackPlanIds.length ? 'allow-remote' : (adapterId === 'ollama' ? 'local-only' : 'allow-remote'),
+    feature_keys: [],
+    prior: PILOT_ROUTING.prior,
+    expected_duration_ms: expectedDurationMs,
+    costs: {
+      actual_cash: adapterId === 'ollama' ? known(0, 'self-hosted-existing-hardware', 'not-applicable') : unknown('subscription-not-allocated-per-operation', 'subscription'),
+      marginal: known(estimatedMarginalUsd, 'frozen-preflight-estimate'),
+      market_equivalent: adapterId === 'ollama' ? unknown('no-frozen-market-equivalent') : known(estimatedMarginalUsd, 'provider-reported-equivalent-estimate'),
+    },
+    retry_on: [],
+    max_retries: 0,
+    fallback_plan_ids: fallbackPlanIds,
+  };
+}
+
+function pilotCatalog() {
+  return Object.freeze({
+    schema: 1,
+    catalog_id: 'public-holdout-fast-pilot-v1',
+    adapters: {
+      ollama: { protocol: 'citadel-operation-adapter-v1', executable: 'ollama', args: [], timeout_ms: 600000, environment_allowlist: [] },
+      claude: { protocol: 'citadel-operation-adapter-v1', executable: 'claude', args: [], timeout_ms: 600000, environment_allowlist: [] },
+    },
+    plans: [
+      plan({ planId: PILOT_PLAN_IDS.local, label: 'Qwen 2.5 Coder 3B, then Claude after verifier rejection', adapterId: 'ollama', model: 'qwen2.5-coder:3b', fallbackPlanIds: [PILOT_PLAN_IDS.cloud], expectedDurationMs: 45000, estimatedMarginalUsd: 0.0002 }),
+      plan({ planId: PILOT_PLAN_IDS.cloud, label: 'Claude Sonnet direct', adapterId: 'claude', model: 'claude-sonnet-5', fallbackPlanIds: [], expectedDurationMs: 90000, estimatedMarginalUsd: 0.08 }),
+    ],
+  });
+}
+
+function controllerHistory(calibrationAttempts) {
+  return calibrationAttempts.map((attempt) => ({ schema: 1, feature_key: attempt.feature_key, plan_id: attempt.plan_id, verification_status: attempt.verification_status, duration_ms: attempt.duration_ms, costs: attempt.costs, observed_tools: [] }));
+}
+
+function directClaudeTarget(featureKey, history, catalog = pilotCatalog()) {
+  const cloud = catalog.plans.find((entry) => entry.plan_id === PILOT_PLAN_IDS.cloud);
+  const prediction = calibratedPrediction(cloud, { feature_key: featureKey }, history);
+  return Number(Math.max(0.10, prediction.conservative_probability).toFixed(6));
+}
+
+function requestFor(task, qualityTarget) {
+  return Object.freeze({
+    schema: 2,
+    operation_id: `swe-pilot-${digest(task.instance_id).slice(7, 27)}`,
+    objective: task.problem_statement,
+    feature_key: task.public_features.feature_key,
+    quality_target: qualityTarget,
+    constraints: { privacy: 'allow-remote', allowed_tools: [], required_tools: [], max_duration_ms: 900000, budgets: { actual_cash: null, marginal: null, market_equivalent: null }, unknown_cost_policy: 'allow' },
+    verifier: { kind: 'adapter-result' },
+  });
+}
+
+function routePilotTask(task, calibrationAttempts, catalog = pilotCatalog()) {
+  const history = controllerHistory(calibrationAttempts);
+  const qualityTarget = directClaudeTarget(task.public_features.feature_key, history, catalog);
+  const request = requestFor(task, qualityTarget);
+  const decision = routeOperation({ request, catalog, history });
+  return Object.freeze({ schema: 1, kind: 'citadel_public_holdout_fast_pilot_route', instance_id: task.instance_id, feature_key: task.public_features.feature_key, quality_target_source: PILOT_ROUTING.quality_rule, decision });
+}
+
+module.exports = Object.freeze({ PILOT_PLAN_IDS, PILOT_ROUTING, controllerHistory, directClaudeTarget, pilotCatalog, requestFor, routePilotTask });

--- a/core/public-holdout-pilot/statistics.js
+++ b/core/public-holdout-pilot/statistics.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const { analyzePaired } = require('../public-holdout/statistics');
+
+function analyzePilot(rows) {
+  const bootstrap = analyzePaired(rows, { seed: 'citadel-public-holdout-fast-pilot-v1' });
+  const point = bootstrap.point_estimate;
+  const sampleQualityPreserved = point.candidate_verified_rate >= point.baseline_verified_rate;
+  const sampleCostReduced = sampleQualityPreserved && Number.isFinite(point.comparison_cost_reduction) && point.comparison_cost_reduction > 0;
+  return Object.freeze({
+    schema: 1,
+    kind: 'citadel_public_holdout_fast_pilot_analysis',
+    task_count: rows.length,
+    point_estimate: point,
+    sample_gates: { quality_preserved_in_observed_sample: sampleQualityPreserved, comparison_cost_reduced_after_sample_quality: sampleCostReduced, overall_preliminary_signal: sampleQualityPreserved && sampleCostReduced },
+    exploratory_bootstrap: { confidence_method: bootstrap.confidence_method, quality_difference_interval: bootstrap.quality_difference_interval, comparison_cost_reduction_interval: bootstrap.comparison_cost_reduction_interval, by_feature_stratum: bootstrap.by_feature_stratum },
+    inference_scope: 'Secondary bounded pilot. The sample gates describe these sixteen prospectively assigned tasks and are not a population noninferiority test.',
+    claim_boundary: 'Comparison USD is not actual subscription cash. This pilot cannot establish universal model performance, production savings, or best-in-class status.',
+  });
+}
+
+module.exports = Object.freeze({ analyzePilot });

--- a/scripts/public-holdout-pilot.js
+++ b/scripts/public-holdout-pilot.js
@@ -1,0 +1,306 @@
+'use strict';
+
+const childProcess = require('child_process');
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { digest } = require('../core/operation-control/contracts');
+const { DATASET, validatePool, visibleTask } = require('../core/public-holdout/dataset');
+const { buildPredictionEvidence, buildVerdictBundle, signAttempt, verifyAttestation } = require('../core/public-holdout/artifacts');
+const { CLAUDE_BIN, MODELS, OLLAMA_ENDPOINT, generateAttempt } = require('../core/public-holdout/runner');
+const { validateSelectionRecord } = require('../core/public-holdout/selection');
+const { buildPilotAssignment } = require('../core/public-holdout-pilot/design');
+const { buildPilotAnalysis, buildPilotFreeze, buildPilotRouteLedger, buildPilotVisible, buildSignedPilotAssignment } = require('../core/public-holdout-pilot/artifacts');
+const { PILOT_PLAN_IDS } = require('../core/public-holdout-pilot/router');
+const capstone = require('./public-holdout-capstone');
+
+const ROOT = path.resolve(__dirname, '..');
+const BENCHMARK = path.join(ROOT, 'benchmarks', 'public-holdout-pilot');
+const PARENT = path.join(ROOT, 'benchmarks', 'public-holdout-capstone');
+const PARENT_REQUEST_FILE = path.join(PARENT, 'selection-request.json');
+const PARENT_SELECTION_FILE = path.join(PARENT, 'selection.json');
+const PARENT_POOL_FILE = path.join(PARENT, 'candidate-pool.json');
+const PARENT_PREFLIGHT_FILE = path.join(PARENT, 'gold-preflight.json');
+const PARENT_ASSIGNMENT_FILE = path.join(PARENT, 'assignment.json');
+const FREEZE_FILE = path.join(BENCHMARK, 'freeze.json');
+const ASSIGNMENT_FILE = path.join(BENCHMARK, 'assignment.json');
+const VISIBLE_FILE = path.join(BENCHMARK, 'visible-tasks.json');
+const ROUTE_LEDGER_FILE = path.join(BENCHMARK, 'route-ledger.json');
+const ANALYSIS_FILE = path.join(BENCHMARK, 'final-analysis.json');
+const KEY_FILE = process.env.CITADEL_HOLDOUT_KEY || path.join('C:\\tmp', 'citadel-public-holdout-ed25519.pem');
+const PHASES = Object.freeze(['calibration', 'evaluation']);
+const PLANS = Object.freeze(Object.values(PILOT_PLAN_IDS));
+const SOURCE_FILES = Object.freeze([
+  '.github/workflows/public-holdout-pilot-evaluation.yml',
+  'benchmarks/public-holdout-pilot/METHOD.md',
+  'core/operation-control/contracts.js',
+  'core/operation-control/receipt.js',
+  'core/operation-controller/contracts.js',
+  'core/operation-controller/controller.js',
+  'core/public-holdout/artifacts.js',
+  'core/public-holdout/dataset.js',
+  'core/public-holdout/retrieval.js',
+  'core/public-holdout/runner.js',
+  'core/public-holdout/selection.js',
+  'core/public-holdout/statistics.js',
+  'core/public-holdout-pilot/artifacts.js',
+  'core/public-holdout-pilot/design.js',
+  'core/public-holdout-pilot/router.js',
+  'core/public-holdout-pilot/statistics.js',
+  'scripts/public-holdout-capstone.js',
+  'scripts/public-holdout-evaluator-summary.js',
+  'scripts/public-holdout-matrix.js',
+  'scripts/public-holdout-pilot.js',
+  'scripts/test-public-holdout-pilot.js',
+]);
+
+function readJson(file) { return JSON.parse(fs.readFileSync(file, 'utf8')); }
+function writeJson(file, value) { fs.mkdirSync(path.dirname(file), { recursive: true }); fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, 'utf8'); }
+function normalizedSource(relative) { return fs.readFileSync(path.join(ROOT, relative), 'utf8').replace(/\r\n/g, '\n'); }
+function sourceDigests() { return Object.fromEntries(SOURCE_FILES.map((relative) => [relative, digest(normalizedSource(relative))])); }
+function privateKey() { return fs.readFileSync(KEY_FILE, 'utf8'); }
+function publicKey() { return crypto.createPublicKey(privateKey()).export({ type: 'spki', format: 'pem' }); }
+function attemptFile(phase, planId, instanceId) { return path.join(BENCHMARK, 'attempts', phase, planId, `${instanceId}.json`); }
+function contextFile(instanceId) { return path.join(BENCHMARK, 'contexts', `${instanceId}.json`); }
+function predictionFile(phase, planId) { return path.join(BENCHMARK, 'predictions', `${phase}--${planId}.json`); }
+function predictionEvidenceFile(phase, planId) { return path.join(BENCHMARK, 'predictions', `${phase}--${planId}.evidence.json`); }
+function verdictFile(phase, planId) { return path.join(BENCHMARK, 'verdicts', `${phase}--${planId}.json`); }
+function directoryHasJson(directory) { return fs.existsSync(directory) && fs.readdirSync(directory, { recursive: true }).some((entry) => String(entry).endsWith('.json')); }
+
+function parentEvidence() {
+  const pool = validatePool(readJson(PARENT_POOL_FILE));
+  const request = readJson(PARENT_REQUEST_FILE);
+  const selection = validateSelectionRecord(readJson(PARENT_SELECTION_FILE), request, pool);
+  const preflight = verifyAttestation(readJson(PARENT_PREFLIGHT_FILE), request.attestation_public_key);
+  const assignment = verifyAttestation(readJson(PARENT_ASSIGNMENT_FILE), request.attestation_public_key);
+  if (preflight.selection_id !== selection.selection_id || assignment.preflight_id !== preflight.preflight_id) throw new Error('parent evidence chain invalid');
+  return { pool, request, selection, preflight, assignment };
+}
+
+function freeze() {
+  if (fs.existsSync(FREEZE_FILE) || fs.existsSync(ASSIGNMENT_FILE)) throw new Error('pilot freeze already exists');
+  const priorAttempts = path.join(BENCHMARK, 'attempts');
+  if (fs.existsSync(priorAttempts) && fs.readdirSync(priorAttempts).length) throw new Error('pilot model attempts already exist before freeze');
+  capstone.verify();
+  const parent = parentEvidence();
+  if (parent.assignment.status !== 'setup-unknown') throw new Error('pilot requires the preserved terminal parent assignment');
+  const signedFreeze = buildPilotFreeze({ parentRequest: parent.request, parentSelection: parent.selection, parentPreflight: parent.preflight, parentAssignment: parent.assignment, sourceDigests: sourceDigests(), privateKey: privateKey() });
+  const assignment = buildSignedPilotAssignment({ freeze: signedFreeze, selection: parent.selection, preflight: parent.preflight, privateKey: privateKey() });
+  verifyAttestation(signedFreeze, parent.request.attestation_public_key);
+  verifyAttestation(assignment, parent.request.attestation_public_key);
+  writeJson(FREEZE_FILE, signedFreeze);
+  writeJson(ASSIGNMENT_FILE, assignment);
+  return { freeze_id: signedFreeze.freeze_id, assignment_id: assignment.assignment_id, status: assignment.status, calibration: assignment.assignments.calibration.length, evaluation: assignment.assignments.evaluation.length, unique_repositories: assignment.unique_repository_count };
+}
+
+async function fetchRow(candidate) {
+  const query = new URLSearchParams({ dataset: DATASET.id, config: DATASET.config, split: candidate.split, offset: String(candidate.row_index), length: '1' });
+  const response = await fetch(`${DATASET.rows_api}?${query}`, { headers: { 'user-agent': 'citadel-public-holdout-fast-pilot/1' } });
+  if (!response.ok) throw new Error(`HTTP ${response.status} hydrating ${candidate.instance_id}`);
+  const page = await response.json();
+  if (!Array.isArray(page.rows) || page.rows.length !== 1) throw new Error(`source row missing for ${candidate.instance_id}`);
+  const task = visibleTask(page.rows[0], candidate.split);
+  if (task.instance_id !== candidate.instance_id || task.source_row_digest !== candidate.source_row_digest) throw new Error(`source row drifted for ${candidate.instance_id}`);
+  return task;
+}
+
+async function hydrate() {
+  const parent = parentEvidence();
+  const signedFreeze = verifyAttestation(readJson(FREEZE_FILE), parent.request.attestation_public_key);
+  const assignment = verifyAttestation(readJson(ASSIGNMENT_FILE), parent.request.attestation_public_key);
+  if (assignment.status !== 'ready') throw new Error(`pilot assignment is ${assignment.status}`);
+  const byId = new Map(parent.pool.candidates.map((candidate) => [candidate.instance_id, candidate]));
+  const ids = [...assignment.assignments.calibration, ...assignment.assignments.evaluation];
+  const tasks = [];
+  for (const instanceId of ids) {
+    const candidate = byId.get(instanceId);
+    if (!candidate) throw new Error(`assigned pilot candidate missing: ${instanceId}`);
+    tasks.push(await fetchRow(candidate));
+    process.stdout.write(`[${tasks.length}/${ids.length}] ${instanceId}\n`);
+  }
+  const visible = buildPilotVisible({ freeze: signedFreeze, assignment, tasks, privateKey: privateKey() });
+  writeJson(VISIBLE_FILE, visible);
+  return { artifact_id: visible.artifact_id, tasks: visible.tasks.length };
+}
+
+async function doctor() {
+  const response = await fetch(`${OLLAMA_ENDPOINT}/api/tags`);
+  if (!response.ok) throw new Error(`Ollama doctor HTTP ${response.status}`);
+  const tags = await response.json();
+  const installed = new Map((tags.models || []).map((model) => [model.name, model]));
+  const expected = MODELS[PILOT_PLAN_IDS.local];
+  const observed = installed.get(expected.requested_model);
+  const local = { plan_id: PILOT_PLAN_IDS.local, requested_model: expected.requested_model, expected_digest: expected.model_digest, observed_digest: observed ? `sha256:${observed.digest}` : null, status: observed && `sha256:${observed.digest}` === expected.model_digest ? 'passed' : 'failed' };
+  const claude = childProcess.spawnSync(CLAUDE_BIN, ['--version'], { encoding: 'utf8', shell: false, windowsHide: true, timeout: 30000 });
+  const cloudExpected = MODELS[PILOT_PLAN_IDS.cloud];
+  const cloud = { plan_id: PILOT_PLAN_IDS.cloud, expected_cli_version: cloudExpected.cli_version, observed_cli_version: claude.status === 0 ? String(claude.stdout).trim() : null, status: claude.status === 0 && String(claude.stdout).startsWith(cloudExpected.cli_version) ? 'passed' : 'failed' };
+  const gpu = childProcess.spawnSync('nvidia-smi', ['--query-gpu=name,memory.total,driver_version', '--format=csv,noheader'], { encoding: 'utf8', shell: false, windowsHide: true, timeout: 30000 });
+  return Object.freeze({ schema: 1, kind: 'citadel_public_holdout_fast_pilot_environment_doctor', status: local.status === 'passed' && cloud.status === 'passed' && gpu.status === 0 ? 'passed' : 'failed', models: [local, cloud], gpu: gpu.status === 0 ? String(gpu.stdout).trim() : null, platform: process.platform, arch: process.arch, cpu_count: os.cpus().length, total_memory_bytes: os.totalmem(), node: process.version });
+}
+
+function pilotArtifacts() {
+  const parent = parentEvidence();
+  const signedFreeze = verifyAttestation(readJson(FREEZE_FILE), parent.request.attestation_public_key);
+  const assignment = verifyAttestation(readJson(ASSIGNMENT_FILE), parent.request.attestation_public_key);
+  const visible = fs.existsSync(VISIBLE_FILE) ? verifyAttestation(readJson(VISIBLE_FILE), parent.request.attestation_public_key) : null;
+  return { parent, freeze: signedFreeze, assignment, visible };
+}
+
+function tasksForPhase(phase) {
+  if (!PHASES.includes(phase)) throw new Error(`unsupported pilot phase: ${phase}`);
+  const { assignment, visible } = pilotArtifacts();
+  if (!visible) throw new Error('pilot visible task artifact missing');
+  const ids = new Set(assignment.assignments[phase]);
+  return visible.tasks.filter((task) => ids.has(task.instance_id));
+}
+
+function bindAttempt(attempt, freezeId, assignmentId) {
+  const unsigned = { ...attempt, attempt_id: null, pilot_freeze_id: freezeId, pilot_assignment_id: assignmentId };
+  return Object.freeze({ ...unsigned, attempt_id: digest(unsigned) });
+}
+
+function readAttempts(phase, planId) {
+  const { parent, freeze: signedFreeze, assignment } = pilotArtifacts();
+  return tasksForPhase(phase).map((task) => {
+    const file = attemptFile(phase, planId, task.instance_id);
+    if (!fs.existsSync(file)) throw new Error(`pilot attempt missing: ${file}`);
+    const attempt = verifyAttestation(readJson(file), parent.request.attestation_public_key);
+    if (attempt.pilot_freeze_id !== signedFreeze.freeze_id || attempt.pilot_assignment_id !== assignment.assignment_id) throw new Error(`pilot attempt binding invalid: ${task.instance_id}`);
+    return attempt;
+  });
+}
+
+async function generate(phase, planId) {
+  if (!PHASES.includes(phase) || !PLANS.includes(planId)) throw new Error('pilot generate requires a valid phase and plan');
+  const health = await doctor();
+  if (health.status !== 'passed') throw new Error(`pilot environment doctor failed: ${JSON.stringify(health)}`);
+  const { parent, freeze: signedFreeze, assignment } = pilotArtifacts();
+  if (phase === 'evaluation') {
+    if (!fs.existsSync(ROUTE_LEDGER_FILE)) throw new Error('pilot route ledger must be sealed before evaluation generation');
+    const ledger = verifyAttestation(readJson(ROUTE_LEDGER_FILE), parent.request.attestation_public_key);
+    if (ledger.freeze_id !== signedFreeze.freeze_id || ledger.assignment_id !== assignment.assignment_id || ledger.routes.length !== assignment.assignments.evaluation.length) throw new Error('pilot route ledger binding invalid');
+  }
+  const tasks = tasksForPhase(phase);
+  let completed = 0;
+  for (const task of tasks) {
+    const file = attemptFile(phase, planId, task.instance_id);
+    if (fs.existsSync(file)) {
+      const existing = verifyAttestation(readJson(file), parent.request.attestation_public_key);
+      if (existing.pilot_freeze_id !== signedFreeze.freeze_id || existing.pilot_assignment_id !== assignment.assignment_id) throw new Error(`existing pilot attempt binding invalid: ${task.instance_id}`);
+    }
+    else {
+      const frozenContext = fs.existsSync(contextFile(task.instance_id)) ? readJson(contextFile(task.instance_id)) : null;
+      const generated = await generateAttempt({ task, planId, retrievalArtifact: frozenContext });
+      const attempt = signAttempt(bindAttempt(generated, signedFreeze.freeze_id, assignment.assignment_id), parent.request, privateKey());
+      writeJson(file, attempt);
+      if (!frozenContext) writeJson(contextFile(task.instance_id), attempt.retrieval);
+    }
+    completed += 1;
+    process.stdout.write(`[${completed}/${tasks.length}] ${phase}/${planId}/${task.instance_id}\n`);
+  }
+  return { status: 'complete', phase, plan_id: planId, attempts: completed };
+}
+
+function buildPredictions(phase, planId) {
+  const attempts = readAttempts(phase, planId);
+  const predictions = Object.fromEntries(attempts.map((attempt) => [attempt.instance_id, { model_patch: attempt.generated_patch }]));
+  const file = predictionFile(phase, planId);
+  writeJson(file, predictions);
+  const evidence = buildPredictionEvidence({ phase: `pilot-${phase}`, planId, attempts, predictionDigest: digest(predictions), privateKey: privateKey() });
+  writeJson(predictionEvidenceFile(phase, planId), evidence);
+  return { prediction_file: path.relative(ROOT, file).replace(/\\/g, '/'), evidence_id: evidence.evidence_id, predictions: attempts.length };
+}
+
+function findNamedFiles(directory, filename) {
+  if (!fs.existsSync(directory)) throw new Error(`pilot evidence directory missing: ${directory}`);
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const absolute = path.join(directory, entry.name);
+    if (entry.isDirectory()) return findNamedFiles(absolute, filename);
+    return entry.isFile() && entry.name === filename ? [absolute] : [];
+  });
+}
+
+function ingestVerdicts(phase, planId, directory) {
+  const attempts = readAttempts(phase, planId);
+  const expectedIds = new Set(attempts.map((attempt) => attempt.instance_id));
+  const summaries = findNamedFiles(path.resolve(directory), 'summary.json').map(readJson).filter((summary) => expectedIds.has(summary.instance_id));
+  if (summaries.length !== attempts.length || new Set(summaries.map((summary) => summary.instance_id)).size !== attempts.length) throw new Error(`pilot verdict summary set incomplete for ${phase}/${planId}`);
+  const bundle = buildVerdictBundle({ phase: `pilot-${phase}`, planId, attempts, summaries, privateKey: privateKey() });
+  writeJson(verdictFile(phase, planId), bundle);
+  return { bundle_id: bundle.bundle_id, verdicts: bundle.verdicts.length, passed: bundle.verdicts.filter((verdict) => verdict.verification_status === 'passed').length, failed: bundle.verdicts.filter((verdict) => verdict.verification_status === 'failed').length, unknown: bundle.verdicts.filter((verdict) => verdict.verification_status === 'unknown').length };
+}
+
+function routes() {
+  const { parent, freeze: signedFreeze, assignment, visible } = pilotArtifacts();
+  if (directoryHasJson(path.join(BENCHMARK, 'attempts', 'evaluation'))) throw new Error('cannot seal pilot routes after evaluation attempts exist');
+  const attemptSets = PLANS.map((planId) => readAttempts('calibration', planId));
+  const verdictBundles = PLANS.map((planId) => verifyAttestation(readJson(verdictFile('calibration', planId)), parent.request.attestation_public_key));
+  const ledger = buildPilotRouteLedger({ freeze: signedFreeze, assignment, visibleTasks: visible.tasks, calibrationAttemptSets: attemptSets, calibrationVerdictBundles: verdictBundles, privateKey: privateKey() });
+  writeJson(ROUTE_LEDGER_FILE, ledger);
+  return { ledger_id: ledger.ledger_id, routes: ledger.routes.length, calibration_records: ledger.calibration_records };
+}
+
+function analyze() {
+  const { parent, freeze: signedFreeze, assignment, visible } = pilotArtifacts();
+  const routeLedger = verifyAttestation(readJson(ROUTE_LEDGER_FILE), parent.request.attestation_public_key);
+  const attemptSets = PLANS.map((planId) => readAttempts('evaluation', planId));
+  const verdictBundles = PLANS.map((planId) => verifyAttestation(readJson(verdictFile('evaluation', planId)), parent.request.attestation_public_key));
+  const analysis = buildPilotAnalysis({ freeze: signedFreeze, assignment, visibleTasks: visible.tasks, routeLedger, evaluationAttemptSets: attemptSets, evaluationVerdictBundles: verdictBundles, privateKey: privateKey() });
+  writeJson(ANALYSIS_FILE, analysis);
+  return { analysis_id: analysis.analysis_id, primary: analysis.primary };
+}
+
+function unsignedArtifact(value, idField) {
+  const payload = { ...value };
+  delete payload.attestation;
+  payload[idField] = null;
+  return payload;
+}
+
+function verify() {
+  const parentStatus = capstone.verify();
+  const parent = parentEvidence();
+  const signedFreeze = verifyAttestation(readJson(FREEZE_FILE), parent.request.attestation_public_key);
+  if (signedFreeze.freeze_id !== digest(unsignedArtifact(signedFreeze, 'freeze_id'))) throw new Error('pilot freeze digest invalid');
+  if (JSON.stringify(signedFreeze.source_digests) !== JSON.stringify(sourceDigests())) throw new Error('frozen pilot sources drifted');
+  const assignment = verifyAttestation(readJson(ASSIGNMENT_FILE), parent.request.attestation_public_key);
+  const expected = buildPilotAssignment({ freezeId: signedFreeze.freeze_id, selection: parent.selection, preflight: parent.preflight });
+  const observedAssignment = { ...assignment };
+  delete observedAssignment.attestation;
+  if (JSON.stringify(observedAssignment) !== JSON.stringify(expected)) throw new Error('pilot assignment drifted');
+  for (const file of [VISIBLE_FILE, ROUTE_LEDGER_FILE, ANALYSIS_FILE]) if (fs.existsSync(file)) verifyAttestation(readJson(file), parent.request.attestation_public_key);
+  if (fs.existsSync(VISIBLE_FILE)) {
+    const visible = readJson(VISIBLE_FILE);
+    const assignedIds = [...assignment.assignments.calibration, ...assignment.assignments.evaluation];
+    if (visible.freeze_id !== signedFreeze.freeze_id || visible.assignment_id !== assignment.assignment_id || JSON.stringify(visible.tasks.map((task) => task.instance_id)) !== JSON.stringify(assignedIds)) throw new Error('pilot visible task artifact drifted');
+  }
+  for (const phase of PHASES) for (const planId of PLANS) {
+    const evidence = predictionEvidenceFile(phase, planId);
+    const verdict = verdictFile(phase, planId);
+    if (fs.existsSync(evidence)) verifyAttestation(readJson(evidence), parent.request.attestation_public_key);
+    if (fs.existsSync(verdict)) verifyAttestation(readJson(verdict), parent.request.attestation_public_key);
+    if (fs.existsSync(path.dirname(attemptFile(phase, planId, 'placeholder')))) readAttempts(phase, planId);
+  }
+  return { status: 'pilot-passed', parent_status: parentStatus.status, freeze_id: signedFreeze.freeze_id, assignment_id: assignment.assignment_id, assignment_status: assignment.status, visible_tasks: fs.existsSync(VISIBLE_FILE) ? readJson(VISIBLE_FILE).tasks.length : 0, route_ledger: fs.existsSync(ROUTE_LEDGER_FILE), final_analysis: fs.existsSync(ANALYSIS_FILE) };
+}
+
+async function main() {
+  const [command, ...args] = process.argv.slice(2);
+  let result;
+  if (command === 'freeze') result = freeze();
+  else if (command === 'hydrate') result = await hydrate();
+  else if (command === 'doctor') result = await doctor();
+  else if (command === 'generate') result = await generate(args[0], args[1]);
+  else if (command === 'predictions') result = buildPredictions(args[0], args[1]);
+  else if (command === 'ingest-verdicts') result = ingestVerdicts(args[0], args[1], args[2]);
+  else if (command === 'routes') result = routes();
+  else if (command === 'analyze') result = analyze();
+  else if (command === 'verify') result = verify();
+  else throw new Error('usage: public-holdout-pilot.js <freeze|hydrate|doctor|generate PHASE PLAN|predictions PHASE PLAN|ingest-verdicts PHASE PLAN DIR|routes|analyze|verify>');
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+if (require.main === module) main().catch((error) => { process.stderr.write(`${error.stack || error.message}\n`); process.exitCode = 1; });
+
+module.exports = Object.freeze({ ANALYSIS_FILE, ASSIGNMENT_FILE, BENCHMARK, FREEZE_FILE, PLANS, ROUTE_LEDGER_FILE, SOURCE_FILES, VISIBLE_FILE, analyze, buildPredictions, doctor, freeze, generate, hydrate, ingestVerdicts, parentEvidence, routes, sourceDigests, verify });

--- a/scripts/test-public-holdout-pilot.js
+++ b/scripts/test-public-holdout-pilot.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { generateAttestationKeyPair } = require('../core/operation-control/receipt');
+const { verifyAttestation } = require('../core/public-holdout/artifacts');
+const { buildPilotFreeze, buildSignedPilotAssignment } = require('../core/public-holdout-pilot/artifacts');
+const { buildPilotAssignment, PILOT_DESIGN } = require('../core/public-holdout-pilot/design');
+const { PILOT_PLAN_IDS, pilotCatalog, routePilotTask } = require('../core/public-holdout-pilot/router');
+const { analyzePilot } = require('../core/public-holdout-pilot/statistics');
+
+const ROOT = path.resolve(__dirname, '..');
+function readJson(relative) { return JSON.parse(fs.readFileSync(path.join(ROOT, relative), 'utf8')); }
+function costs(amount) { return { actual_cash: { status: 'unknown', amount_usd: null, basis: 'subscription', source: 'test' }, marginal: { status: 'known', amount_usd: amount, basis: 'observed', source: 'test' }, market_equivalent: { status: 'known', amount_usd: amount, basis: 'observed', source: 'test' } }; }
+
+function main() {
+  const request = readJson('benchmarks/public-holdout-capstone/selection-request.json');
+  const selection = readJson('benchmarks/public-holdout-capstone/selection.json');
+  const preflight = readJson('benchmarks/public-holdout-capstone/gold-preflight.json');
+  const parentAssignment = readJson('benchmarks/public-holdout-capstone/assignment.json');
+  const assignment = buildPilotAssignment({ freezeId: 'sha256:test-freeze', selection, preflight });
+  assert.strictEqual(assignment.status, 'ready');
+  assert.strictEqual(assignment.assignments.calibration.length, PILOT_DESIGN.calibration_total);
+  assert.strictEqual(assignment.assignments.evaluation.length, PILOT_DESIGN.evaluation_total);
+  assert.strictEqual(assignment.unique_repository_count, 24);
+  const repos = assignment.decisions.filter((decision) => ['calibration', 'evaluation'].includes(decision.disposition)).map((decision) => decision.repo);
+  assert.strictEqual(new Set(repos).size, 24);
+  const featureCounts = assignment.decisions.filter((decision) => ['calibration', 'evaluation'].includes(decision.disposition)).reduce((counts, decision) => { counts[decision.feature_key] = (counts[decision.feature_key] || 0) + 1; return counts; }, {});
+  for (const featureKey of PILOT_DESIGN.feature_strata) assert.strictEqual(featureCounts[featureKey], 6);
+
+  const history = PILOT_DESIGN.feature_strata.flatMap((featureKey) => [
+    { feature_key: featureKey, plan_id: PILOT_PLAN_IDS.local, verification_status: 'failed', duration_ms: 100, costs: costs(0.01) },
+    { feature_key: featureKey, plan_id: PILOT_PLAN_IDS.local, verification_status: 'passed', duration_ms: 100, costs: costs(0.01) },
+    { feature_key: featureKey, plan_id: PILOT_PLAN_IDS.cloud, verification_status: 'passed', duration_ms: 100, costs: costs(1) },
+    { feature_key: featureKey, plan_id: PILOT_PLAN_IDS.cloud, verification_status: 'passed', duration_ms: 100, costs: costs(1) },
+  ]);
+  const routed = routePilotTask({ instance_id: 'fixture', problem_statement: 'repair', public_features: { feature_key: 'js.issue-short' } }, history, pilotCatalog());
+  assert.ok(Object.values(PILOT_PLAN_IDS).includes(routed.decision.selected.root_plan_id));
+  assert.deepStrictEqual(routed.decision.candidates.map((candidate) => candidate.root_plan_id).sort(), Object.values(PILOT_PLAN_IDS).sort());
+
+  const rows = Array.from({ length: 16 }, (_, index) => ({ instance_id: `task-${index}`, feature_key: PILOT_DESIGN.feature_strata[index % 4], outcomes: { 'always-claude': { status: 'passed', comparison_cost_usd: 1 }, 'citadel-controller': { status: 'passed', comparison_cost_usd: 0.5 } } }));
+  const analysis = analyzePilot(rows);
+  assert.strictEqual(analysis.sample_gates.overall_preliminary_signal, true);
+  assert.strictEqual(analysis.point_estimate.comparison_cost_reduction, 0.5);
+
+  const pair = generateAttestationKeyPair();
+  const signedFreeze = buildPilotFreeze({ parentRequest: request, parentSelection: selection, parentPreflight: preflight, parentAssignment, sourceDigests: { fixture: 'sha256:test' }, privateKey: pair.private_key, frozenAt: '2026-08-03T00:00:00.000Z' });
+  const signedAssignment = buildSignedPilotAssignment({ freeze: signedFreeze, selection, preflight, privateKey: pair.private_key });
+  assert.strictEqual(verifyAttestation(signedFreeze, pair.public_key).design.evaluation_total, 16);
+  assert.strictEqual(verifyAttestation(signedAssignment, pair.public_key).status, 'ready');
+  process.stdout.write('public holdout fast pilot tests passed\n');
+}
+
+main();


### PR DESCRIPTION
## What changed

- adds a separate secondary public-holdout pilot without modifying the terminal primary capstone;
- deterministically assigns 8 calibration and 16 untouched evaluation tasks from the existing signed preflight;
- enforces one task per repository, yielding 24 distinct repositories across four frozen strata;
- reduces the comparison to Qwen 3B local-first versus Claude direct, requiring 48 model outputs rather than 240;
- adds signed freeze, assignment, visible-task artifacts and a graceful 60-minute prediction evaluator deadline;
- blocks evaluation generation until the signed route ledger exists.

## Why

The primary 20/60 capstone correctly terminated setup-unknown before inference. This bounded secondary pilot uses only setup-yield information, no model outcomes, to obtain preliminary outside-authored evidence quickly while preserving the primary negative result.

## Claim boundary

This is a 16-task descriptive pilot, not a population noninferiority study. Comparison USD remains separate from actual subscription cash, which is unknown.

## Verification

- `node scripts/test-public-holdout-pilot.js`
- `node scripts/test-public-holdout-capstone.js`
- `npm run holdout:verify`
- `node scripts/public-holdout-pilot.js verify`
- `node scripts/test-all.js` — all tests passed
- environment doctor passed pinned Qwen 3B, Claude Code 2.1.219, and GTX 1070 checks
