### PR TITLE
Finalize Citadel site and Sentient application package

### DIFF
--- a/.planning/active/site-experience-final-audit.md
+++ b/.planning/active/site-experience-final-audit.md
@@ -1,0 +1,71 @@
+# Citadel final site experience decisions
+
+Observed 2026-08-03 against the local release candidate. This is a refinement
+pass, not a rebrand. The public evidence and claim boundaries remain frozen.
+
+## Experience contract
+
+- **Purpose:** let a new visitor understand `/do` first, then progressively
+  reveal durable operation control, evidence, economics, and the grant thesis.
+- **Emotional target:** calm, credible, technically alive, and candid. The site
+  may feel ambitious; it must never feel evasive, frantic, or sales-led.
+- **Primary hierarchy:** each viewport should answer one dominant question.
+  Supporting cards, metrics, and links must remain subordinate to that answer.
+- **Information density:** low-to-medium on the product path; medium-to-high on
+  evidence surfaces where the density is meaningful and visibly structured.
+- **Motion:** short entrance and interaction feedback only. No perpetual motion
+  may compete with reading. Reduced-motion must leave every item visible.
+- **Typography:** large editorial headings, readable blue-white body text, and
+  mono only for labels, commands, receipts, and measurement details.
+- **Color and depth:** retain the current ink, ocean, cyan, blue, green, amber,
+  and violet system. Cards need hierarchy from border, tint, and shadow rather
+  than a wall of identical gray panels.
+- **Responsive behavior:** preserve the same narrative order at every width;
+  change layout before copy becomes cramped; never clip links, hover movement,
+  focus rings, tables, or proof identifiers.
+- **Accessibility:** visible keyboard focus, a functional skip link and mobile
+  menu, captioned media, downloadable transcripts, and zero content hidden by
+  reduced-motion preferences.
+- **Performance:** static-first HTML/CSS with lightweight progressive
+  enhancement. Decorative effects must not gate content or navigation.
+
+## Contextual composition
+
+- **Homepage:** one clear entry point, then four levels of increasing power.
+  Product demonstration precedes proof and installation detail.
+- **Evidence:** evaluator index. Dense comparison material is acceptable when
+  each result carries a method, outcome, and claim boundary.
+- **Operation Control:** explain the contract, then show the proof and the
+  novelty boundary. Evidence must remain more prominent than aspiration.
+- **Optimizer:** show why cheap failure is not savings, then reveal the policy
+  contract, existing proof, open gates, and funded thesis.
+- **Research:** present current implementation in descending claim strength,
+  then funded milestones and the exact boundary of demonstrated work.
+- **Walkthrough:** media first; the full transcript is an accessible secondary
+  path that unfolds on request instead of becoming a wall of prose.
+- **404:** one explanation and two recovery actions, with no additional noise.
+
+## Anti-defaults
+
+- No equal-weight card wallpaper without a leading editorial statement.
+- No metric wall without a nearby explanation of what the numbers permit.
+- No duplicate calls to action with indistinguishable intent.
+- No perpetual animation, hidden scrollbar, or clipped hover transform.
+- No run-on link cluster or inline CTA styling that breaks below 390 pixels.
+- No full transcript wall when the same information can be disclosed on demand.
+
+## Verification matrix
+
+Every public page is reviewed at 1440x900, 1280x720, 768x1024, 390x844, and
+320x568. The catalog contains 373 overlapping viewport screenshots across:
+
+1. Homepage
+2. Evidence
+3. Operation Control
+4. Optimizer
+5. Research
+6. Walkthrough
+7. 404
+
+The release gate additionally checks overflow, navigation behavior, focus,
+normal and reduced motion, console errors, and claim-sensitive site tests.

--- a/.planning/active/visual-qa-triage.md
+++ b/.planning/active/visual-qa-triage.md
@@ -1,5 +1,112 @@
 # Citadel application-readiness visual QA triage
 
+## Final whole-site pass - 2026-08-03
+
+### Summary
+
+- 373 overlapping viewport screenshots reviewed across 7 public pages and 5
+  viewport classes.
+- 5 actionable findings: 1 broken, 1 ugly, 3 polish; all resolved.
+- All other page and viewport combinations retained their current composition.
+
+### BROKEN
+
+#### [SITE-B1] Research hero metrics overflow at 320px
+
+- **Screenshots:** `output/playwright/site-visual-audit/before/research/small-mobile/`
+- **Expected:** the two-column proof strip remains inside the 320px viewport.
+- **Actual:** the right-hand metrics reach 361px inside a 320px viewport.
+- **Root cause:** shared proof-page components inherited content-box sizing, so
+  column padding expanded each nominal grid track beyond its allocation.
+- **Resolution:** border-box sizing and minimum-width containment are now an
+  explicit shared site-page contract. The 320px document is exactly 320px wide.
+
+### UGLY
+
+#### [SITE-U1] Walkthrough transcript becomes a long wall of prose
+
+- **Screenshots:** `walkthrough--tablet.png`, `walkthrough--mobile.png`, and
+  `walkthrough--small-mobile.png` contact sheets.
+- **Expected:** the media remains primary and the complete accessible transcript
+  unfolds when a visitor asks for it.
+- **Actual:** four long paragraphs occupy the final two to five screenfuls; at
+  768px the two-column layout also leaves an unnecessarily narrow reading rail.
+- **Root cause:** the full transcript is permanently expanded and the layout
+  does not collapse until 760px.
+- **Resolution:** retained a visible plain-language introduction and download,
+  then place the complete transcript in a styled native disclosure. Collapse
+  the grid before tablet reading becomes cramped.
+
+### POLISH
+
+#### [SITE-P1] Homepage suppresses the shared custom scrollbar
+
+- **Screenshot:** all Homepage captures.
+- **Expected:** long-form product storytelling uses the same thin cyan-to-blue
+  scrollbar as the rest of the public site.
+- **Actual:** legacy homepage CSS hides scrollbars in Firefox and Chromium.
+- **Root cause:** the original single-screen prototype used an intentionally
+  hidden scrollbar before the page became a native long-form story.
+- **Resolution:** removed the legacy hide rule and let the shared site system
+  own scrollbar appearance.
+
+#### [SITE-P2] Homepage ambient motion persists beyond its purpose
+
+- **Expected:** the interactive field adds life to the product entry, respects
+  reduced motion, and recedes while the visitor reads later proof sections.
+- **Actual:** the canvas requests frames at 60fps and autonomous pulses continue
+  throughout the entire long-form page.
+- **Root cause:** animation behavior remained tuned for the original single
+  viewport prototype.
+- **Resolution:** capped the canvas at 30fps, rendered only once for reduced-motion
+  visitors, confine autonomous pulses to the hero viewport, and run the five
+  routing animations only while their explanatory section is visible.
+
+#### [SITE-P3] Research closing actions read as one run-on link cluster
+
+- **Expected:** the four next steps are distinct, touch-safe actions with a
+  clear primary choice.
+- **Actual:** incomplete `.button` styling leaves inline anchors touching and
+  wrapping like prose at tablet and mobile widths.
+- **Root cause:** the proof-page button skin supplied colors without supplying
+  a complete layout and spacing contract.
+- **Resolution:** completed the button component and gave the action group a
+  wrapping gap, switching to full-width actions on the narrowest viewport.
+
+### Reviewed screenshot matrix
+
+- [x] Homepage: desktop, laptop, tablet, mobile, small mobile
+- [x] Evidence: desktop, laptop, tablet, mobile, small mobile
+- [x] Operation Control: desktop, laptop, tablet, mobile, small mobile
+- [x] Optimizer: desktop, laptop, tablet, mobile, small mobile
+- [x] Research: desktop, laptop, tablet, mobile, small mobile
+- [x] Walkthrough: desktop, laptop, tablet, mobile, small mobile
+- [x] 404: desktop, laptop, tablet, mobile, small mobile
+
+### Preserved strengths
+
+- `/do` remains the dominant first-use story and the four levels remain clear.
+- Evidence-heavy pages are dense but structured, readable, and candid.
+- Sticky navigation does not cover section starts or clip transformed controls.
+- The palette, typography roles, card depth, and proof hierarchy remain coherent.
+- Reduced-motion captures report zero active animations on every tested page.
+
+### Final verification
+
+- [x] 361 fresh after-state viewport screenshots across the same 7 pages and 5
+  viewport classes; the count fell from 373 because the transcript now unfolds
+  on request rather than consuming twelve extra overlapping captures.
+- [x] 35/35 runtime combinations: zero overflow, local console errors, missing
+  focus outlines, or failed mobile-menu/disclosure interactions.
+- [x] 14/14 reduced-motion combinations: zero active animations and zero hidden
+  reveal content.
+- [x] Public story contract: 44/44.
+- [x] Grant verification: 17/17.
+- [x] Full repository test suite: all tests passed.
+- [ ] Hosted post-merge smoke and deployment digest verification.
+
+---
+
 Initial findings were observed against the deployed GitHub Pages site on
 2026-08-01 before application-readiness edits. This file now records their
 local release-candidate disposition; hosted verification remains post-merge.

--- a/docs/404.html
+++ b/docs/404.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="robots" content="noindex" />
   <title>Page not found | Citadel</title>
-  <link rel="stylesheet" href="site-system.css?v=20260801-1" />
+  <link rel="stylesheet" href="site-system.css?v=20260803-1" />
 </head>
 <body class="site-page">
   <main class="site-shell" style="min-height:100vh;display:grid;place-items:center;padding:48px 0;">

--- a/docs/evidence.html
+++ b/docs/evidence.html
@@ -113,7 +113,7 @@
       .reproduce, .funded-target { padding: 24px; }
     }
   </style>
-<link rel="stylesheet" href="site-system.css?v=20260801-1" />
+<link rel="stylesheet" href="site-system.css?v=20260803-1" />
 </head>
 <body class="site-page site-evidence">
   <a class="site-skip-link" href="#main-content">Skip to content</a>
@@ -351,6 +351,6 @@
   </main>
 
   <footer class="evidence-shell evidence-footer">Citadel public evidence · observed 2026-08-03 · outside-authored baseline invalid · zero adversarial false passes · generalization remains open.</footer>
-  <script src="site-system.js"></script>
+  <script src="site-system.js?v=20260803-1"></script>
 </body>
 </html>

--- a/docs/grants/APPLICANT_AND_ADOPTION.md
+++ b/docs/grants/APPLICANT_AND_ADOPTION.md
@@ -12,9 +12,9 @@ Observed 2026-08-03:
 - Current maintainer model: one maintainer and release authority, disclosed as
   a bus-factor risk rather than presented as a team.
 - License: MIT.
-- Public repository metrics: **809 stars, 80 forks, and 538 commits** reachable
-  from `main`. Of those commits, 514 are attributed to Seth's Git identity and
-  374 are non-merge commits attributed to that identity. These are delivery and
+- Public repository metrics: **809 stars, 80 forks, and 542 commits** reachable
+  from `main`. Of those commits, 518 are attributed to Seth's Git identity and
+  377 are non-merge commits attributed to that identity. These are delivery and
   repository-history signals, not manually typed code, active users, successful
   installations, retention, or revenue.
 - Owner-visible GitHub traffic for 2026-07-18 through 2026-07-31 reported 1,237
@@ -25,6 +25,12 @@ Observed 2026-08-03:
   on 2026-03-20. The current evidence package includes frozen methods, signed
   raw cells, negative reports, adapters, hosted verification, and an evaluator
   index rather than screenshots alone.
+- Applicant contact is `seth@softwareshaped.com`. Public DNS exposes Cloudflare
+  inbound routing plus SPF and DMARC records; a private delivery ledger retains
+  the 2026-08-03 inbound, sender-verification, and outbound-delivery receipts.
+- `https://softwareshaped.com/` is live as Seth's independent research and
+  software lab and publishes Citadel among its evidence-bounded case studies.
+  It is founder-context evidence, not Citadel adoption or optimizer evidence.
 
 Do not reuse an earlier claim of weekly installs unless a dated source and
 measurement definition are attached. GitHub stars must never be converted into
@@ -61,7 +67,9 @@ performance gate.
 
 ## Applicant facts and later due diligence
 
-- The live application requires applicant email and city/country.
+- The live application requires applicant email and city/country. The current
+  values are resolved in the private final payload; the public pack masks the
+  location while using the public business email.
 - Legal recipient type, tax status, and payment details were not requested on
   the observed Typeform path, but may be required during later due diligence.
 - Nine-month availability should be confirmed before accepting any award.

--- a/docs/grants/APPLICATION_CHECKLIST.md
+++ b/docs/grants/APPLICATION_CHECKLIST.md
@@ -63,8 +63,8 @@ page titles, images, and application media.
 
 ## Submission authority
 
-- [ ] Seth approves the final `$150,000` amount.
-- [ ] Seth approves the final application wording.
+- [x] Seth approved the final `$150,000` amount.
+- [ ] Seth approves the refreshed application wording and regenerated PDF.
 - [ ] Seth explicitly approves submitting the external form.
 
 No outside reviewer, pre-submission outreach campaign, sponsor, recruited

--- a/docs/grants/DEMO_SCRIPT.md
+++ b/docs/grants/DEMO_SCRIPT.md
@@ -37,7 +37,7 @@ compress the research story into fast terminal noise.
 
 ## 1:40-1:50 — Delivery record
 
-- Show the dated repository evidence: 520 main-branch commits, 496 attributed
+- Show the dated repository evidence: 542 main-branch commits, 518 attributed
   to Seth's Git identity, 809 stars, 80 forks, and 524 unique cloners in the
   latest owner-visible 14-day window.
 - Caption: **Funding scales a shipped public substrate, not a first prototype.**

--- a/docs/grants/GITHUB_DELIVERY_EVIDENCE.md
+++ b/docs/grants/GITHUB_DELIVERY_EVIDENCE.md
@@ -1,6 +1,6 @@
 # GitHub delivery and interest evidence
 
-Observed on 2026-08-03 after pull request 244 merged to `main`. This record
+Observed on 2026-08-03 after pull request 245 merged to `main`. This record
 separates public repository history, maintainer attribution, and owner-visible
 traffic. None of these measures is a user, installation, retention, revenue, or
 economic-impact count.
@@ -13,9 +13,9 @@ economic-impact count.
 | Public age at observation | 136 days | Calendar difference through 2026-08-03 |
 | Stars | 809 | GitHub repository API |
 | Forks | 80 | GitHub repository API |
-| Commits reachable from `main` | 538 | `git rev-list --count origin/main` |
-| Commits attributed to Seth's Git identity | 514 | `git rev-list --count --author=gammon.seth@gmail.com origin/main` |
-| Non-merge commits attributed to Seth's Git identity | 374 | `git rev-list --count --no-merges --author=gammon.seth@gmail.com origin/main` |
+| Commits reachable from `main` | 542 | `git rev-list --count origin/main` |
+| Commits attributed to Seth's Git identity | 518 | `git rev-list --count --author=gammon.seth@gmail.com origin/main` |
+| Non-merge commits attributed to Seth's Git identity | 377 | `git rev-list --count --no-merges --author=gammon.seth@gmail.com origin/main` |
 
 Git author attribution establishes repository history and delivery ownership;
 it does not prove that every line was typed manually or without AI assistance.

--- a/docs/grants/SENTIENT_OPTIMIZER_APPLICATION_DRAFT.md
+++ b/docs/grants/SENTIENT_OPTIMIZER_APPLICATION_DRAFT.md
@@ -608,8 +608,8 @@ Those are the exact uncertainties the funded milestones address.
 ## Applicant and adoption evidence
 
 SethGammon owns and maintains the public MIT repository. On 2026-08-03 it had
-809 stars, 80 forks, and 538 commits reachable from `main`; 514 were attributed
-to Seth's Git identity and 374 were non-merge commits attributed to that
+809 stars, 80 forks, and 542 commits reachable from `main`; 518 were attributed
+to Seth's Git identity and 377 were non-merge commits attributed to that
 identity. GitHub's owner-visible 14-day traffic reported 524 unique cloners and
 380 unique visitors. Those are delivery and interest signals, not manually
 typed code, users, installations, adoption, or economic impact. The adoption

--- a/docs/grants/SUBMISSION_READINESS.md
+++ b/docs/grants/SUBMISSION_READINESS.md
@@ -50,8 +50,8 @@ The mandatory supporting document is ready at:
 
 - format: PDF, 16:9 landscape;
 - pages: 8;
-- size: 537,507 bytes;
-- SHA-256: `2f81f966bee724325e68fa068cabcdc02826378cbddf34e2319797e8c3240e44`;
+- size: 537,550 bytes;
+- SHA-256: `27af2246100eab7e3ab13db6f6c7c32f9192c55936ab67c868fc821e534cee3f`;
 - source renderer: `scripts/render-sentient-grant-packet.py`;
 - visual QA: all eight pages rendered to PNG and inspected at 96 DPI, the
   normal-viewer scale that exposed the original legibility problem;
@@ -121,8 +121,8 @@ dollar-for-dollar and unused funds remain unspent.
   controller verified 3/16 at 1.26% lower comparison cost. Direct Claude passed
   only 12.5% overall and 0% in three strata, so no general quality-preservation
   or savings claim is allowed.
-- GitHub showed 809 stars, 80 forks, and 538 commits reachable from `main` on
-  2026-08-03. Of those, 514 were attributed to Seth's Git identity and 374 were
+- GitHub showed 809 stars, 80 forks, and 542 commits reachable from `main` on
+  2026-08-03. Of those, 518 were attributed to Seth's Git identity and 377 were
   non-merge commits attributed to that identity. Owner-visible traffic for
   2026-07-18 through 2026-07-31 reported 524 unique cloners and 380 unique
   visitors. These are dated delivery and interest signals, not manually typed
@@ -153,15 +153,25 @@ frontier baseline higher priorities. Free-GPU work is useful only if obtained
 at zero cost and published under a frozen method. It is not a submission blocker
 and cannot establish savings or generalization by itself.
 
-## Human-owned final values
+## Founder and contact refresh
 
-Only four factual or authority inputs remain outside the repository:
+- Applicant email is `seth@softwareshaped.com`, with inbound routing,
+  authenticated outbound sending, and an end-to-end delivered test retained in
+  the private Opportunity OS receipt ledger on 2026-08-03.
+- City and country are resolved in the private final payload and remain masked
+  in this public repository.
+- `Engineer / Builder` and the $150,000 over nine months request remain the
+  approved selections.
+- Software Shaped is live at `https://softwareshaped.com/` with a public
+  partnership route and `hello@softwareshaped.com`. It supports founder and
+  communication credibility; it is not used as Citadel technical or adoption
+  evidence.
+- Career OS and Opportunity OS are current private delivery systems. They are
+  intentionally excluded from the public technical case because no public
+  evaluator surface supports them and they do not prove Citadel's optimizer.
 
-- [ ] applicant email;
-- [ ] city and country;
-- [ ] confirmation that `Engineer / Builder` is the correct role selection;
-- [ ] Seth's explicit approval of the amount, wording, upload, and external
-  submission.
+The remaining human authority gates are approval of the refreshed exact wording
+and PDF, followed by explicit authorization of the external submission.
 
 No outside reviewer, sponsor, operator outreach, external task selector, or
 recruited cohort is required or promised. Funded onboarding proof uses clean
@@ -170,7 +180,7 @@ a written scope and budget amendment.
 
 ## Final submission sequence
 
-1. Confirm the two applicant facts and role selection above.
+1. Review and approve the refreshed answer pack and rendered PDF.
 2. Run `npm run application:form:check` to reject live field, option, or branch
    drift.
 3. Refresh the dated GitHub counts or remove them if they cannot be verified.

--- a/docs/grants/TYPEFORM_ANSWER_PACK.md
+++ b/docs/grants/TYPEFORM_ANSWER_PACK.md
@@ -11,20 +11,20 @@ from applicant facts that Seth must confirm before submission.
 
 | Live field | Paste-ready value | Status |
 |---|---|---|
-| Email | `[SETH EMAIL]` | Seth confirmation required |
-| Role | `Engineer / Builder` | Recommended selection |
-| City, country | `[CITY, COUNTRY]` | Seth confirmation required |
+| Email | `seth@softwareshaped.com` | Verified business sender and inbound route on 2026-08-03 |
+| Role | `Engineer / Builder` | Approved selection |
+| City, country | `[CITY, COUNTRY]` | Resolved in the private final payload; intentionally masked here |
 
 ## Project fields
 
 ### What problem are you solving, and why now?
 
-AI-agent optimization is usually measured at the model-call level even though
-cost and failure happen across the whole operation: decomposition, models,
-tools, retries, context, verification, recovery, and human intervention. That
-creates two failures. A system can look cheap while wasting work elsewhere, and
-it can claim success without proving that the declared route ran or that a
-verifier outside the routed model accepted the artifact.
+Sentient's request names the target: a layer that finds the cheapest path
+through models, tools, and calls on any agent stack. The unsolved problem is
+that model-call optimization can look cheaper while the operation fails or
+shifts cost into decomposition, retries, tools, context, verification,
+recovery, and human intervention. Citadel treats the externally verified
+operation, not the isolated call, as the economic unit.
 
 This matters now because coding agents are becoming persistent, multi-model,
 and recursive. Open stacks such as Sentient ROMA make whole-operation control
@@ -64,17 +64,17 @@ the funded evaluation reach the published gates.
 
 ### In one line, what are you building?
 
-`An open control layer that proves whether AI agents finished and what it cost.`
+`An open layer that finds the cheapest verified path through any agent stack.`
 
-Character count: 78 of 80.
+Character count: 76 of 80.
 
 ### Who is building this, and why is the team right?
 
 Seth Gammon is Citadel's solo builder and maintainer. He has taken it from a
 working Claude Code harness into an MIT-licensed operating and evidence layer
 for Claude Code, Codex, local Ollama models, and a pinned Sentient ROMA binding.
-In 136 public days it reached 809 stars and 80 forks; 514 of 538 main-branch
-commits are attributed to Seth's Git identity, including 374 non-merge commits.
+In 136 public days it reached 809 stars and 80 forks; 518 of 542 main-branch
+commits are attributed to Seth's Git identity, including 377 non-merge commits.
 GitHub's latest owner-visible 14-day window reported 524 unique cloners. Those
 are delivery and continuing-interest signals, not users or installations. The
 stronger qualification is what shipped: preregistered methods, signed actual-run
@@ -83,7 +83,9 @@ and negative findings preserved instead of marketed away. The latest public
 holdout published 32 official verdicts across 16 untouched evaluation tasks and
 then rejected its own positive sample rule because the direct-Claude baseline
 passed only 2/16. Funding scales a working, self-falsifying substrate; it does
-not fund the first prototype or conceal the hardest result.
+not fund the first prototype or conceal the hardest result. Seth also publishes
+the method, case studies, and limits through his live independent lab at
+`https://softwareshaped.com/`.
 
 Observation boundary: GitHub counts checked on 2026-08-03. Refresh immediately
 before submission.
@@ -160,11 +162,11 @@ failure analysis, and unused-funds accounting remain public deliverables.
 
 ## Final human confirmations
 
-- [ ] Confirm applicant email.
-- [ ] Confirm city and country.
-- [ ] Confirm `Engineer / Builder` as the role selection.
-- [ ] Approve the final $150,000 amount.
-- [ ] Approve this wording and the rendered PDF.
+- [x] Applicant email verified and refreshed.
+- [x] City and country resolved in the private final payload.
+- [x] `Engineer / Builder` confirmed as the role selection.
+- [x] Final $150,000 amount approved.
+- [ ] Approve this refreshed wording and rendered PDF after the final audit.
 - [ ] Explicitly authorize submission of the external Typeform.
 
 No form has been submitted by preparing this file.

--- a/docs/index.html
+++ b/docs/index.html
@@ -43,9 +43,7 @@
       -webkit-tap-highlight-color: transparent;
     }
 
-    /* Hide scrollbar everywhere */
-    html { scrollbar-width: none; background: var(--bg); }
-    ::-webkit-scrollbar { display: none; }
+    html { background: var(--bg); }
 
     #bg-dots { position: fixed; inset: 0; z-index: -1; pointer-events: none; width: 100%; height: 100%; }
 
@@ -1431,6 +1429,12 @@
     .cascade-connector:last-of-type .cascade-connector-line { animation-delay: 1.4s; }
     .cascade-connector-chevron { animation: conn-flow 2.8s ease-in-out infinite; }
     .cascade-connector:last-of-type .cascade-connector-chevron { animation-delay: 1.4s; }
+    .cascade-section .t0-word,
+    .cascade-section .cascade-connector-line,
+    .cascade-section .cascade-connector-chevron { animation-play-state: paused; }
+    .cascade-section.is-motion-active .t0-word,
+    .cascade-section.is-motion-active .cascade-connector-line,
+    .cascade-section.is-motion-active .cascade-connector-chevron { animation-play-state: running; }
 
     /* ─── prefers-reduced-motion ─── */
     @media (prefers-reduced-motion: reduce) {
@@ -1471,7 +1475,7 @@
       .scroll-cue svg:last-child { display: none; }
     }
   </style>
-  <link rel="stylesheet" href="site-system.css?v=20260801-1" />
+  <link rel="stylesheet" href="site-system.css?v=20260803-1" />
 </head>
 <body class="site-page site-home">
   <a class="site-skip-link" href="#main-content">Skip to content</a>
@@ -3087,10 +3091,24 @@
       // Retained for the router's state transitions; native scroll has no cue state.
     }
 
+    (function initCascadeMotion() {
+      const section = document.querySelector('.cascade-section');
+      if (!section || window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+      if (!('IntersectionObserver' in window)) {
+        section.classList.add('is-motion-active');
+        return;
+      }
+      const observer = new IntersectionObserver(([entry]) => {
+        section.classList.toggle('is-motion-active', entry.isIntersecting);
+      }, { threshold: 0.04 });
+      observer.observe(section);
+    })();
+
     // ─── Dot grid background (physics: liquid repulsion + spring) ─────────────
     (function () {
       const canvas = document.getElementById('bg-dots');
       const ctx = canvas.getContext('2d');
+      const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
       const SPACING = 36, BASE_R = 1.2, MAX_R = 2.8;
       const REPEL_DIST = 90, REPEL_STRENGTH = 6;
       const SPRING = 0.045, DAMPING = 0.88;
@@ -3099,7 +3117,7 @@
       const STRIDE = 7;
       let mx = -9999, my = -9999, raf = null, lastTime = 0;
       const pulses = []; // { x, y, r, maxR, speed, type: 'burst'|'ripple', age }
-      const FRAME_MS = 1000 / 60;
+      const FRAME_MS = 1000 / 30;
 
       function resize() {
         W = canvas.width = window.innerWidth;
@@ -3117,7 +3135,7 @@
       }
 
       function draw(now) {
-        raf = requestAnimationFrame(draw);
+        raf = reduceMotion ? null : requestAnimationFrame(draw);
         if (now - lastTime < FRAME_MS) return;
         const dt = Math.min(now - lastTime, 32) / 16;
         lastTime = now;
@@ -3233,6 +3251,7 @@
 
     // ─── Idle placeholder cycling ─────────────────────────────────────────
     (function initPlaceholder() {
+      if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
       const hints = [
         'Type any engineering task…',
         'try: fix the typo on line 42',
@@ -3302,10 +3321,11 @@
 
     // ─── Autonomous background pulses (background agent activity) ─────────
     (function autoPulse() {
+      if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
       let _W = window.innerWidth, _H = window.innerHeight;
       window.addEventListener('resize', () => { _W = window.innerWidth; _H = window.innerHeight; });
       function fire() {
-        if (!document.hidden && window.fireAmbientPulse) {
+        if (!document.hidden && window.scrollY < window.innerHeight * 1.1 && window.fireAmbientPulse) {
           const x = _W * (0.1 + Math.random() * 0.8);
           const y = _H * (0.1 + Math.random() * 0.8);
           window.fireAmbientPulse(x, y);
@@ -3362,6 +3382,6 @@
         .catch(() => {});
     })();
   </script>
-  <script src="site-system.js"></script>
+  <script src="site-system.js?v=20260803-1"></script>
 </body>
 </html>

--- a/docs/operation-control.html
+++ b/docs/operation-control.html
@@ -423,7 +423,7 @@
       .button:hover { transform: none; }
     }
   </style>
-  <link rel="stylesheet" href="site-system.css?v=20260801-1" />
+  <link rel="stylesheet" href="site-system.css?v=20260803-1" />
 </head>
 <body class="site-page site-proof site-operation">
   <a class="site-skip-link" href="#main-content">Skip to content</a>
@@ -664,6 +664,6 @@
   <footer>
     <div class="shell">Citadel operation-control proof · observed 2026-07-31 · signed actual run · evidence passed · performance hypothesis failed.</div>
   </footer>
-  <script src="site-system.js"></script>
+  <script src="site-system.js?v=20260803-1"></script>
 </body>
 </html>

--- a/docs/optimizer.html
+++ b/docs/optimizer.html
@@ -463,7 +463,7 @@
       html { scroll-behavior: auto; }
     }
   </style>
-  <link rel="stylesheet" href="site-system.css?v=20260801-1" />
+  <link rel="stylesheet" href="site-system.css?v=20260803-1" />
 </head>
 <body class="site-page site-proof site-optimizer">
   <a class="site-skip-link" href="#main-content">Skip to content</a>
@@ -834,6 +834,6 @@
       tabs[next].click();
     });
   </script>
-  <script src="site-system.js"></script>
+  <script src="site-system.js?v=20260803-1"></script>
 </body>
 </html>

--- a/docs/research.html
+++ b/docs/research.html
@@ -17,7 +17,7 @@
   <meta name="twitter:image" content="https://sethgammon.github.io/Citadel/assets/citadel-social-preview.png" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 32 32%22><rect width=%2232%22 height=%2232%22 rx=%227%22 fill=%22%23070b12%22/><path d=%22M8 8h16v5H13v6h11v5H8z%22 fill=%22%2345ddff%22/></svg>" />
   <title>Citadel Research Program | Proof before optimization claims</title>
-  <link rel="stylesheet" href="site-system.css?v=20260801-1" />
+<link rel="stylesheet" href="site-system.css?v=20260803-1" />
 </head>
 <body class="site-page site-proof site-research">
   <a class="site-skip-link" href="#main-content">Skip to content</a>
@@ -302,6 +302,6 @@
   <footer>
     <div class="shell">Citadel research program · operation control, model-external verification, and honest agent economics · bounded performance gate passed; generalization gate open.</div>
   </footer>
-  <script src="site-system.js"></script>
+  <script src="site-system.js?v=20260803-1"></script>
 </body>
 </html>

--- a/docs/site-release-manifest.json
+++ b/docs/site-release-manifest.json
@@ -74,13 +74,13 @@
     },
     {
       "path": "grants/APPLICANT_AND_ADOPTION.md",
-      "bytes": 3800,
-      "digest": "sha256:e839269a11381058ca1347afdab79d96d94f8141db7135bda8893a8506c74453"
+      "bytes": 4410,
+      "digest": "sha256:a02ef04e3e43e6170e4424b1dddff7bb5952540c8987feddd57042d48d40db84"
     },
     {
       "path": "grants/APPLICATION_CHECKLIST.md",
-      "bytes": 4682,
-      "digest": "sha256:bc21efc55fe11262e074e4977145405f9fb51ce16504c4fc69a60164193c09d3"
+      "bytes": 4706,
+      "digest": "sha256:e97628a986ad72fbc6bff2b494e147e350197b8b3dd15577a41abbae56400693"
     },
     {
       "path": "grants/APPLICATION_MEDIA.md",
@@ -95,7 +95,7 @@
     {
       "path": "grants/DEMO_SCRIPT.md",
       "bytes": 2396,
-      "digest": "sha256:54a866fa7903ad6e990bdecf3ec0c59b45c181131671baa4f5133195d51a2399"
+      "digest": "sha256:3b35dbf279a197ba82f75429e4bfd17fd71eca7362e5764fc15e6b5174f30c2f"
     },
     {
       "path": "grants/EVALUATOR_START_HERE.md",
@@ -105,7 +105,7 @@
     {
       "path": "grants/GITHUB_DELIVERY_EVIDENCE.md",
       "bytes": 2738,
-      "digest": "sha256:5fe69371bcd5dde1afb7e57eeb082305d5b3b93ea0b0c74f837f1522859ae70a"
+      "digest": "sha256:58a94902fd8d9a8978fec6ee320013516a1e36ed53341b301c43f4f21e7f4657"
     },
     {
       "path": "grants/MILESTONES_AND_BUDGET.md",
@@ -135,12 +135,12 @@
     {
       "path": "grants/SENTIENT_OPTIMIZER_APPLICATION_DRAFT.md",
       "bytes": 32670,
-      "digest": "sha256:7b48c499aac6c3460b3acdb36503850cec8a2f18e1ef6edde658e89aa11fd297"
+      "digest": "sha256:1b70440b0e08720cb6f48e2e38f4620c7b03b9dc428466802a0a6213b9c629cc"
     },
     {
       "path": "grants/SUBMISSION_READINESS.md",
-      "bytes": 9014,
-      "digest": "sha256:cfa55b72a229eb872c11eb1d44092b8888fa8e8d6396bfc532ee03032cf0045a"
+      "bytes": 9774,
+      "digest": "sha256:c10354c648e745a9285e189b238d7f9eea4030ee44cc291061062b6322e21fa3"
     },
     {
       "path": "grants/TECHNICAL_COMPARISON.md",
@@ -149,8 +149,8 @@
     },
     {
       "path": "grants/TYPEFORM_ANSWER_PACK.md",
-      "bytes": 8909,
-      "digest": "sha256:e694d059a8d17d4ce1e69e76221f568322ef45bd8993d83edf708ba40161e8ce"
+      "bytes": 9162,
+      "digest": "sha256:c0efa3a4ea5bb25b732ad533094bef67dd1e4217b38c88690e8473fc2ffbe53c"
     },
     {
       "path": "index.html",
@@ -203,5 +203,5 @@
       "digest": "sha256:4ade6149f757c62ab3c60a0cce5c72214093bf3f3b214c553c5c44bb48e16495"
     }
   ],
-  "source_digest": "sha256:47265b4d055d0f2a07322d225c3bc5919de976d26436c167293a7968530b73a4"
+  "source_digest": "sha256:045fd6f58d6f35c24529f580470d427be162d8ee03672b54ac90973516b003de"
 }

--- a/docs/site-release-manifest.json
+++ b/docs/site-release-manifest.json
@@ -5,7 +5,7 @@
     {
       "path": "404.html",
       "bytes": 1078,
-      "digest": "sha256:dba7effef32735c0a31a549de8f98bdbb6840652bdf4a3ed7b5b34edb62e1063"
+      "digest": "sha256:31b2f1c98da9bb12ba3e41c65b62b913570edb5086574cd2621d967941561252"
     },
     {
       "path": "EVIDENCE_MANIFEST.md",
@@ -69,8 +69,8 @@
     },
     {
       "path": "evidence.html",
-      "bytes": 30047,
-      "digest": "sha256:e7cf6b038fa7af09ff8e3ccac549b0c45ade16e68186c08a179334edc560fabf"
+      "bytes": 30060,
+      "digest": "sha256:46796e7a6b8dbb7dfa2ec41d07fbc9834173e704cccffb5483133a1f3cac6d03"
     },
     {
       "path": "grants/APPLICANT_AND_ADOPTION.md",
@@ -154,23 +154,23 @@
     },
     {
       "path": "index.html",
-      "bytes": 201647,
-      "digest": "sha256:522eddab43be3a811ebd9ba2c32bbb2d159263306842ac7c758c42045d8f6114"
+      "bytes": 202780,
+      "digest": "sha256:a18c3ad5a14f02c07a657e4d86900bc7ce925651dc57c21c2b0d2eb81c5f9627"
     },
     {
       "path": "operation-control.html",
-      "bytes": 26460,
-      "digest": "sha256:e007b5b194ed9fb52ec442366577141b0d02f15c6f987a7380d6879c0d0c6eb2"
+      "bytes": 26473,
+      "digest": "sha256:dd16b178123c8ba738663a657699395a890b44d3b8f22a7f16dc85df895dd782"
     },
     {
       "path": "optimizer.html",
-      "bytes": 33901,
-      "digest": "sha256:5b4aca3deefe108a9dc5459c5fa4deef0a6f0536646382686a2bc000098d0820"
+      "bytes": 33914,
+      "digest": "sha256:2c63cd1f477e967e6686734a673eed51ebee6cc7e63b27ea377599b926603b8b"
     },
     {
       "path": "research.html",
-      "bytes": 19263,
-      "digest": "sha256:01ef1253df0736ea1a9a0463b38c44bdae9fdfa34078e92cdbad57cd9091711c"
+      "bytes": 19274,
+      "digest": "sha256:a7413d7bb98ec76d07b1f5cd7e838e910955d9440f2f9f01f5f78215b0c007e7"
     },
     {
       "path": "robots.txt",
@@ -179,13 +179,13 @@
     },
     {
       "path": "site-system.css",
-      "bytes": 37888,
-      "digest": "sha256:0325358cb2cf243e7aa74d547a779760be07856e63354062eec8e55bcde2b88c"
+      "bytes": 39099,
+      "digest": "sha256:2f7baebf44ac5fdb843b70192a50707cbd35aeba2d37f20d4d6aaf0665aa5a84"
     },
     {
       "path": "site-system.js",
-      "bytes": 1981,
-      "digest": "sha256:bdf7c7ee8e326e3420a53e904fc3c17dc4a7417dd3c4702e0f7d3fd7ce70884a"
+      "bytes": 2400,
+      "digest": "sha256:6a682b2d105cf7d086b10bed63ad24a4405ad2f93c187402dc7cafc368b631bc"
     },
     {
       "path": "site.webmanifest",
@@ -199,9 +199,9 @@
     },
     {
       "path": "walkthrough.html",
-      "bytes": 9620,
-      "digest": "sha256:fcfa572d3523fe0a7ebd391fd0aeb8c6df65ce772f62a1d93de6903fcabf840e"
+      "bytes": 11562,
+      "digest": "sha256:4ade6149f757c62ab3c60a0cce5c72214093bf3f3b214c553c5c44bb48e16495"
     }
   ],
-  "source_digest": "sha256:2d6faa99fb9f0e5beeb39b9e5090a25ecb14d554bf500b0378a67dae1f6223ea"
+  "source_digest": "sha256:47265b4d055d0f2a07322d225c3bc5919de976d26436c167293a7968530b73a4"
 }

--- a/docs/site-system.css
+++ b/docs/site-system.css
@@ -27,6 +27,12 @@
   --site-nav-height: 72px;
 }
 
+body.site-page *,
+body.site-page *::before,
+body.site-page *::after {
+  box-sizing: border-box;
+}
+
 html {
   color-scheme: dark;
   scroll-behavior: smooth;
@@ -716,10 +722,10 @@ body.site-proof {
   box-shadow: var(--site-inset), 0 16px 42px rgba(0, 9, 28, 0.28);
 }
 
-.site-proof .proof-stat { min-height: 128px; padding: 23px; }
+.site-proof .proof-stat { min-width: 0; min-height: 128px; padding: 23px; }
 .site-proof .proof-stat + .proof-stat { border-color: var(--site-line); }
 .site-proof .proof-stat strong { color: var(--site-green); font: 750 30px/1 var(--site-mono); }
-.site-proof .proof-stat span { color: var(--site-muted); font: 11px/1.55 var(--site-mono); }
+.site-proof .proof-stat span { color: var(--site-muted); font: 11px/1.55 var(--site-mono); overflow-wrap: anywhere; }
 
 .site-proof section {
   position: relative;
@@ -826,8 +832,37 @@ body.site-proof {
 .site-proof td, .site-proof th { border-color: var(--site-line); }
 .site-proof tbody tr:hover { background: rgba(69, 221, 255, 0.035); }
 .site-proof .receipt { border-color: var(--site-line-strong); border-radius: 14px; color: var(--site-muted); background: rgba(5, 23, 41, 0.84); box-shadow: var(--site-inset); }
-.site-proof .button { min-height: 47px; border-color: var(--site-line-strong); border-radius: 10px; }
-.site-proof .button.primary { color: #031017; border-color: var(--site-cyan); background: var(--site-cyan); }
+.site-proof .closing .links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 24px;
+}
+.site-proof .button {
+  display: inline-flex;
+  min-width: 0;
+  min-height: 47px;
+  align-items: center;
+  justify-content: center;
+  padding: 0 16px;
+  border: 1px solid var(--site-line-strong);
+  border-radius: 10px;
+  color: var(--site-text);
+  background: linear-gradient(145deg, rgba(20, 54, 86, 0.92), rgba(8, 27, 46, 0.94));
+  box-shadow: var(--site-inset), 0 9px 24px rgba(10, 75, 119, 0.13);
+  font: 750 12px/1.25 var(--site-sans);
+  text-align: center;
+  text-decoration: none;
+  overflow-wrap: anywhere;
+  transition: transform 160ms ease, border-color 160ms ease, background 160ms ease, box-shadow 160ms ease;
+}
+.site-proof .button:hover {
+  transform: translateY(-2px);
+  border-color: var(--site-cyan);
+  background: linear-gradient(145deg, rgba(32, 86, 126, 0.96), rgba(12, 43, 69, 0.96));
+  box-shadow: var(--site-inset), 0 14px 32px rgba(34, 164, 218, 0.2);
+}
+.site-proof .button.primary { color: #031017; border-color: var(--site-cyan); background: linear-gradient(135deg, var(--site-cyan), #72afff); }
 .site-proof footer { border-color: var(--site-line); color: var(--site-dim); background: var(--site-bg-deep); }
 
 .research-thesis {
@@ -903,6 +938,7 @@ body.site-proof {
   .attempt-card { min-height: auto; }
   .evidence-note { grid-template-columns: 1fr; }
   .site-proof .closing { grid-template-columns: 1fr; }
+  .site-proof .closing .links .button { flex: 1 1 180px; }
   .research-thesis,
   .milestone-grid,
   .claim-boundary-list { grid-template-columns: 1fr; }
@@ -956,6 +992,10 @@ body.site-proof {
   .site-home .operation-fork-heading h2,
   .site-home .proof-heading h2,
   .site-home .cascade-section-heading h2 { font-size: clamp(32px, 10vw, 44px); }
+}
+
+@media (max-width: 430px) {
+  .site-proof .closing .links .button { flex-basis: 100%; width: 100%; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/docs/site-system.js
+++ b/docs/site-system.js
@@ -4,6 +4,12 @@
   const toggle = document.querySelector('[data-site-nav-toggle]');
   const mobile = document.querySelector('[data-site-nav-mobile]');
   if (toggle && mobile) {
+    const closeMobile = (restoreFocus = false) => {
+      toggle.setAttribute('aria-expanded', 'false');
+      toggle.textContent = 'Menu';
+      mobile.hidden = true;
+      if (restoreFocus) toggle.focus();
+    };
     toggle.addEventListener('click', () => {
       const open = toggle.getAttribute('aria-expanded') === 'true';
       toggle.setAttribute('aria-expanded', String(!open));
@@ -11,10 +17,14 @@
       toggle.textContent = open ? 'Menu' : 'Close';
     });
     mobile.querySelectorAll('a, button').forEach((control) => control.addEventListener('click', () => {
-      toggle.setAttribute('aria-expanded', 'false');
-      toggle.textContent = 'Menu';
-      mobile.hidden = true;
+      closeMobile();
     }));
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && toggle.getAttribute('aria-expanded') === 'true') closeMobile(true);
+    });
+    window.matchMedia('(min-width: 1081px)').addEventListener('change', (event) => {
+      if (event.matches) closeMobile();
+    });
   }
 
   const progress = document.querySelector('.site-scroll-progress span');

--- a/docs/walkthrough.html
+++ b/docs/walkthrough.html
@@ -30,11 +30,21 @@
     .transcript { display: grid; grid-template-columns: minmax(220px, .55fr) minmax(0, 1.45fr); gap: 60px; padding: 82px 0; }
     .transcript h2 { margin: 12px 0; font-size: 42px; letter-spacing: -.045em; }
     .transcript-copy { color: var(--site-muted); font-size: 17px; line-height: 1.75; }
-    .transcript-copy p { margin: 0 0 18px; }
+    .transcript-lede { margin: 0 0 20px; color: var(--site-text); font-size: 19px; line-height: 1.65; }
+    .transcript-disclosure { overflow: hidden; border: 1px solid var(--site-line); border-radius: 16px; background: var(--site-panel); box-shadow: var(--site-inset), 0 14px 34px rgba(0, 8, 27, .2); }
+    .transcript-disclosure summary { display: flex; min-height: 68px; align-items: center; justify-content: space-between; gap: 18px; padding: 18px 20px; color: var(--site-text); cursor: pointer; font-weight: 750; list-style: none; }
+    .transcript-disclosure summary::-webkit-details-marker { display: none; }
+    .transcript-disclosure summary small { color: var(--site-dim); font: 11px/1.4 var(--site-mono); }
+    .transcript-disclosure summary::after { content: "+"; display: grid; flex: 0 0 30px; width: 30px; height: 30px; place-items: center; border: 1px solid var(--site-line-strong); border-radius: 50%; color: var(--site-cyan); font: 700 19px/1 var(--site-mono); }
+    .transcript-disclosure[open] summary { border-bottom: 1px solid var(--site-line); }
+    .transcript-disclosure[open] summary::after { content: "-"; }
+    .transcript-body { padding: 22px 20px 8px; }
+    .transcript-body p { margin: 0 0 18px; }
     .walkthrough-footer { padding: 28px 0 48px; border-top: 1px solid var(--site-line); color: var(--site-dim); font: 12px/1.5 var(--site-mono); }
-    @media (max-width: 760px) { .transcript, .verification-demo header { grid-template-columns: 1fr; gap: 20px; } .walkthrough-hero { padding-top: 64px; } }
+    @media (max-width: 900px) { .transcript, .verification-demo header { grid-template-columns: 1fr; gap: 24px; } .walkthrough-hero { padding-top: 64px; } }
+    @media (max-width: 520px) { .transcript { padding: 64px 0; } .transcript h2 { font-size: 36px; } .transcript-disclosure summary { align-items: flex-start; } .transcript-disclosure summary small { display: none; } }
   </style>
-<link rel="stylesheet" href="site-system.css?v=20260801-1" />
+<link rel="stylesheet" href="site-system.css?v=20260803-1" />
 </head>
 <body class="site-page site-walkthrough">
   <a class="site-skip-link" href="#main-content">Skip to content</a>
@@ -96,14 +106,20 @@
     <section class="transcript">
       <div><div class="site-kicker">Accessible transcript</div><h2>The argument, in plain language.</h2><a class="site-button" href="assets/application/walkthrough-narration.txt">Download text</a></div>
       <div class="transcript-copy">
-        <p>Citadel starts with one command: <code>/do</code>. You describe the engineering outcome, and Citadel chooses the smallest operating lane that can carry it. When work lasts longer, Citadel adds repository state, recovery, coordination, bounded execution, and a concrete next action around Claude Code or Codex.</p>
-        <p>The research question begins where ordinary orchestration ends. A smaller model is not cheaper if its answer fails, the verifier forces a retry, or the operation hides part of its cost. Citadel binds the declared route to observed execution, a verdict outside the routed model, cost lenses, and a signed receipt.</p>
-        <p>Earlier prospective studies tested that contract. Three local calibrations failed or missed their gates and remain public. A first Claude-plus-local policy preserved 12/12 outcomes but reduced comparison cost only 28.4%, missing its frozen 30% gate. A separately frozen hybrid v2 used twelve new synthetic tasks, preserved 12/12 outcomes for both policies, reduced Claude calls from twelve to five, and reduced comparison cost 38.7% with every frozen gate passed.</p>
-        <p>The later public holdout is the current result. It used 24 distinct outside-authored repositories, sealed sixteen evaluation routes before model calls, and published all 32 official verdicts. Direct Claude verified 2/16 and the controller 3/16 at 1.26% lower comparison cost. Because the baseline passed only 12.5%, Citadel does not call that useful quality preservation or savings. Sentient funding buys the retrieval, edit protocol, valid baseline, broader stacks, models, tools, hardware, complete cost, and learned operation-value policy still missing. The public gate remains at least 80% absolute verified completion, at least 95% of a valid frontier baseline, and at least 30% lower measured end-to-end cost; frontier must first clear 80% overall and 70% in every frozen task stratum.</p>
+        <p class="transcript-lede">Citadel starts with <code>/do</code>, then adds durable operation control only when the work needs it. The research case asks whether the complete operation—not merely one model call—can be made cheaper without hiding failure.</p>
+        <details class="transcript-disclosure">
+          <summary><span>Read the complete transcript</span><small>Four parts · about two minutes</small></summary>
+          <div class="transcript-body">
+            <p>Citadel starts with one command: <code>/do</code>. You describe the engineering outcome, and Citadel chooses the smallest operating lane that can carry it. When work lasts longer, Citadel adds repository state, recovery, coordination, bounded execution, and a concrete next action around Claude Code or Codex.</p>
+            <p>The research question begins where ordinary orchestration ends. A smaller model is not cheaper if its answer fails, the verifier forces a retry, or the operation hides part of its cost. Citadel binds the declared route to observed execution, a verdict outside the routed model, cost lenses, and a signed receipt.</p>
+            <p>Earlier prospective studies tested that contract. Three local calibrations failed or missed their gates and remain public. A first Claude-plus-local policy preserved 12/12 outcomes but reduced comparison cost only 28.4%, missing its frozen 30% gate. A separately frozen hybrid v2 used twelve new synthetic tasks, preserved 12/12 outcomes for both policies, reduced Claude calls from twelve to five, and reduced comparison cost 38.7% with every frozen gate passed.</p>
+            <p>The later public holdout is the current result. It used 24 distinct outside-authored repositories, sealed sixteen evaluation routes before model calls, and published all 32 official verdicts. Direct Claude verified 2/16 and the controller 3/16 at 1.26% lower comparison cost. Because the baseline passed only 12.5%, Citadel does not call that useful quality preservation or savings. Sentient funding buys the retrieval, edit protocol, valid baseline, broader stacks, models, tools, hardware, complete cost, and learned operation-value policy still missing. The public gate remains at least 80% absolute verified completion, at least 95% of a valid frontier baseline, and at least 30% lower measured end-to-end cost; frontier must first clear 80% overall and 70% in every frozen task stratum.</p>
+          </div>
+        </details>
       </div>
     </section>
   </main>
   <footer class="walkthrough-shell walkthrough-footer">Synthetic narration is disclosed · source transcript and rebuild script are committed · evidence is reproducible outside the routed models.</footer>
-  <script src="site-system.js"></script>
+  <script src="site-system.js?v=20260803-1"></script>
 </body>
 </html>

--- a/output/pdf/citadel-sentient-grant-packet.pdf
+++ b/output/pdf/citadel-sentient-grant-packet.pdf
@@ -343,7 +343,7 @@ endobj
 endobj
 21 0 obj
 <<
-/Author (Seth Gammon) /CreationDate (D:20260803171504-04'00') /Creator (anonymous) /Keywords () /ModDate (D:20260803171504-04'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+/Author (Seth Gammon) /CreationDate (D:20260803210416-04'00') /Creator (anonymous) /Keywords () /ModDate (D:20260803210416-04'00') /Producer (ReportLab PDF Library - \(opensource\)) 
   /Subject (Verifiable token and economic optimization for open agent stacks) /Title (Citadel - Sentient Open Source AGI Grant Support Packet) /Trapped /False
 >>
 endobj
@@ -382,10 +382,10 @@ Gb!;dhfIO1&q8G>JX=U9okG<d!"s+?S60VbUY7_dBd\rM7GDWl;+FMZ4juXp^'-cZo#+.b\(Vm561.N"
 endobj
 27 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2466
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2467
 >>
 stream
-Gb!;d92jkA'#+6EjCKQJB0k$G.d[[YG:t[EZ[ppgYt&41d'bKN,oMGe^L(#5Z60?15#0R'=]/9aX7E<U,_7'%s/n7J(J?gd/4h<phNKdYU#e/VQa8*"?*"Zr;QE\?1!1b"#rN7"atHM"6.Q<VEk;9r(5]sI%5oLa(1Ksk9]L][iY=+;7s6J,U+%js'0;u23iB?UZ7E7o5C9oRD?W21ZcL,\2`6NDBjU"k,VrFV.>9(\ThQY>SOQ2>O;'&87%?;1'C3]h//:3D6Mm0,HZl8hb%eq\8Rp((E#Tg.n@4pHU3Z$h%fE(VWu8O@CAu6SeVURKn^jSnFVlV<SLWUc#&.m!@t[^:=@P%h[MmV&ZkeeQ_XPbqDWGAt7DNT6>lT%Z5F"9#nH9dPAG^'p?s#4R'.cA0iu+"nS:o_LHD6p4LLf@$cXMUE7$@4iRMCIZR$W@p!r&qA8kBT5_hs.(;9lNX13fZDX)nmVc60b.7'CT4`Kp.>Y%Ea]&iMq&huJdglq`@%G--IJ-5EoCi-;2MLc5S"Vouj(o"VR0fcLrk#jbnbbefK>.P^Y!=R>a6!j@pQTB=a(Z$gjA*R7,b$m1os@\&7,e?H?$00G5qQS*XLOF6`Ur:W?s428G=rA<&fo[99FfLQU$JA$F/"\4QDE>ih3%F,Q/]dHEUI+5IS7BoJl&UDt\*/lZdmStr\X<e90I8G&Gkc\R(;+=93.=/f[MS7r+DcbO`\sRu]\Xh44DdP_7IJn2.b#jRhU^SkBLDa!5;rtC.MQ4R4hG@62H+&0qp9E7fo/1ZO3OQK2[VN0$O,csdP\\4l/(a-^nIEQ0Mr-0VQ`]kBMO$$OmdA5,7I<b&jVrLu\jorS<EE/3U3]'6h:?Gje]eI=bOU=d]#17t-EF`,qd$UaZ($(4ICG2r:.1gI:I?C+[Sj*]8u^jG*J[1NU_Cd;V#&lH&GUDAde5l>1AG-KR7LD93,#QcSBh1#mV'48ndc/lh1Eje2FWD.F^7r$m5j)R2(eCenWc_ThEYY0C5WOii,k]H]iJjd@:u*$iJ\F?qndr7i(Mg99ag4[Fn<;;.PQa($5>2,5sZJQH';clq-Y,*3I^!Rjq!F-<Q4u]3N^FB-ak=3")E-C9pNDA`MdD$S5'+HN/a5RB-p*idFuo?bX``<3&[@')3L:_dWnkiaoqEXS^OGl2N0/PcNGrL#!"e5.2^Yk/NnCeQ='2BkT&0hP[J-bEX-?,au0/Okge\N'bWG4i.6)dTHI-&i*\Uc'-2(4A'0<&MCko$5aHtCT"/4gc"02WSWO&YoQ!ENqIQB;jrO"2JkNf.Y_X0Dl\7fUW.^i]o<n.;nGE1Hp(uX-/\YLAQFH&#q8]LGKe"Ik,XKpB!Vj*C8u^n!=cs9:&UqOOdR>(00KaL"T&%kP^O:^<Sr<<tM=E>6hF)_4r)E.<HTQsdk6IXu[r5BC->-]Z6.#dBQJ$/Hdq-5<:]0*7:?\Q+ZV>U0=g_iU/ZK/sG``(gnOp>M^Re4FpJr7,AXj`:GZRj[^i/kMWZHb1,Qc?5hl$gioP+5Co?\Y.JXU0o4Q2Y<lT?bG51&M-@eV>gg(!TS29e\l:@Hg%m5m3ZBT01\rCEXZGm9/]Qh>FcF+O;b=P)Fb=Z(?V'&]Q:mdnuPWluoA6?:cj?<'<o!@pM1@9#?TH(Tgk=anP&#h1]4i<b9X=QaDKo._himT!A#3lh]Y1p$X;]jJ7Xn(=k=_?bE0XM86I,,-H,NJl^:@@(o<e]i];ntroM<`rMR(#_ADMT]FlQ[.0E[*?2&=5ih;63.?PWYcbs\aNY2mIGt^3>^t^9?i85gb]F^S8"$)9Ea_Oe:7S[3\I9\/JMDi&8J==P<F4/(po&=Sp:0@ao_n_,AIYq?"an45fURCH[s1^-o]qj@hcaBT/\Ze"%J:rbI%FE)ZB^L!6^Q,-^bs)1=-'mL5!Hg1LfI;Apun;AT2TjX%'boNgX4dg)H[ia;g0[;Y[tidgN8j56/sOlgq/al-n2Bo'5,a='t,\GDiPSJS]WTPJ5'RiVIh[(9Ko1fQ"7+gMZ>SUV(oqbBh@PY&+2(;Oud*AK@HG-\!Aj`4Yne'_2U5@mAgOM/Hgm2+:_jj3`#^/^]m8]<3a:q.[;'*pX#&n*:UD:3Tq1=tABdT<bb)UMjE[:i5hJ`SBIGpT:KOdlUNo&j8#<h-%">kb:P!g>ose$>nS*gl1-$E;DEC[$5JS1%nZe/&ei8Q3\4>M3EHm,*L%:)i9>85<"#Mr2+f3TU\,p_9V%H3D)\JVGWcRhnF[[9U@OC7.<fnlGG;Hn<72;Sh>B$2f2e0_aj18gYYL^DQDG"rVea@rbD`j0$g`a$Tb3E3d>YYR(mOgr%=!\pJsCCHP6A#B8?l8\3A.=/XY/`V<Iod];,5*c'p*I,UHE;.bq#M&RBFH7F*$0rn5%X:>mAmh-l$T"?q?aPP\,h7>9U(/-0!;#fTV!Pca7'UXaI]d-Ue>Yk/A~>endstream
+Gb!;d92jkA'#+6EjCKQJB0k$G.d[[YG:t[EZ[ppgYt&41d'bKN,oMGe^L(#5Z60?15#0R'=]/9aX7E<U,_7'%s/n7J(J?gd/4h<phNKdYU#e/VQa8*"?*"Zr;QE\?1!1b"#rN7"atHM"6.Q<VEk;9r(5]sI%5oLa(1Ksk9]L][iY=+;7s6J,U+%js'0;u23iB?UZ7E7o5C9oRD?W21ZcL,\2`6NDBjU"k,VrFV.>9(\ThQY>SOQ2>O;'&87%?;1'C3]h//:3D6Mm0,HZl8hb%eq\8Rp((E#Tg.n@4pHU3Z$h%fE(VWu8O@CAu6SeVURKn^jSnFVlV<SLWUc#&.m!@t[^:=@P%h[MmV&ZkeeQ_XPbqDWGAt7DNT6>lT%Z5F"9#nH9dPAG^'p?s#4R'.cA0iu+"nS:o_LHD6p4LLf@$cXMUE7$@4iRMCIZR$W@p!r&qA8kBT5_hs.(;9lNX13fZDX)nmVc60b.7'CT4`Kp.>Y%Ea]&iMq&huJdglq`@%G--IJ-5EoCi-;2MLc5S"Vouj(o"VR0fcLrk#jbnbbefK>.P^Y!=R>a6!j@pQTB=a(Z$gjA*R7,b$m1os@\&7,e?H?$00G5qQS*XLOF6`Ur:W?s428G=rA<&fo[99FfLQU$JA$F/"\4QDE>ih3%F,Q/]dHEUI+5IS7BoJl&UDt\*/lZdmStr\X<e90I8G&Gkc\R(;+=93.=/f[MS7r+DcbO`\sRu]\Xh44DdP_7IJn2.b#jRhU^SkBLDa!5;rtC.MQ4R4hG@62H+&0qp9E7fo/1ZO3OQK2[VN0$O,csdP\\4l/(a-^nIEQ0Mr-0VQ`]kBMO$$OmdA5,7I<b&jVrLu\jorS<EE/3U3]'6h:?Gje]eI=bOU=d]#17t-EF`,qd$UaZ($(4ICG2r:.1gI:I?C+[Sj*]8u^jG*J[1NU_Cd;V#&lH&GUDAde5l>1AG-KR7LD93,#RNb@^f5FgTsUq$2ZGDF%kmS"`:(\umLMFrbLdRML2Cpdui:DkJjS[D`>EE&pk5?E:HmYVT%ME5ma0I:9rVn>5NXVM4[>](t2X'c=nO"UZ+'THF`9]Laleo>*73F8X%/bT@\8X,?rEEa"_c:2ESE#1i9eROW[aMG_X&3Lp5o)&kA/c:j1[UU?_^R#sAVEGRb.1*SHHV":[\PR6^:3i,\bC`$5)T*\o"%<?]J;D>7`>'ffT/AL7ccoJ1Y.Da:NjUTf8P\^2(d&Y.%.jT!H^]X&R5XD3+^qk,O-T^8H`fpK+'O+\'J1Lfe4EJ9WS'-D84!P&<l/dm'oZKWUbWFlC"IFG:@1b<hed[K4:^KKDk%j)Ui:m,nm4Z7:>(!qa/8rk$o8cnn$<Ki_8V3md!q:'ePZ#VuZQpQS,Q*)(V2I/?@<h(#4hIU*J,9@W4W!Lr'B<XL]SZ?Fq5N5WpN?tSc4</tDVqZd:!UK>K;&Ud/@4.nVosCWTD60NSBsu5At/.?Z>.W4>#Z5onKJ3Yig4P$IQa;km]AD6b;_MTn?/_@JD]R#<BUKB8-GTH^JPS\l-oFfk+P0;!]A4hGeu0Wep1HmI%\m9`9pVXZlA'0C7::aS_gR)gNRI?ckp3AqiO5>o*c>D0C.fPk5tPNZ*(iOZ>/[5-,<)Tguk`)<LHebK]KK^]W-Xh!`k!@_l@g3nidM`ZM^$+&?';F_\3O;Yg1^tk@7[\h5dd&FH@<;Bit7VHG=?9hm$TYKb<l@=F\?q6psi7)Ag4S_Cj_VX.'8Uj\9`%XKo"-/&Hdh'UQ]a0Cu9iBq'7+YJTTUK`Vg+<&$FoF5O6CgZ8gFF"YsFQ^SLJ\7lfF37Ap1QjD@'W<!+@F^.UC=t$h\+OjSY-@>A=0PCtY4Rr3_PQqaH7ar=l]$McFJW,(epAg?G:i<d]a!cOd5&k6S#E0WoQ>6_i2#IA"!1"u7:,4g0AY9.d%1@gYB#MhTc2;lUbM_<_<fM@g*AbBR[5U>]O?"4@V!rd[V\`M_IK5h'fB65Md\j.bjjh,LYJ/;CmM8q/"53<3-@Lq._Y*L?/R!kBYiB>4\)#V07sXclQh?Z*?/#F0UcQC2b;qrn:B!_]M0\^U.-)+Ha*t\)'&CPcCPoR_`hVoF>,!UNG?nFSo@%O-4k:(,hUa%fSaNrA[8sdR5@nE27c1d@T\ATsMRg\lmorj(Vg#'h-$j+W]<br[d7'$![E3hU'\^'2\J`0(i:L`dBdqq1@dL9T<f1PO/.jA[&gm^d6mRoR2\HXPIW###q+^PE5rj2jK:TupEg2Bs9VXB-^O68AQnE"eLu=Qfe;%Ioi$Z4T4^Ic'Dq_]@L6(2N\%duGgfCa#qYb=^rRVN_>b5<K(N`EiFn"C<0n8#Xq-=tCm]C_ep*BX$cO^bOEIF8Z=tm/I9@<]RG=V=3Rl=-q8P5rV<4Gl#,J)qoMk3'?rNh!;SAIYc]>G%3#^cXL-MO,ZM@.%.=TZ*V&;m0!-sP;-7]YcCU"TGHV'P[A~>endstream
 endobj
 28 0 obj
 <<
@@ -403,10 +403,10 @@ Gb!;d>>sQ?'Roe[3"L,.2hY^I/@EsP"?+FYAWr\'Co;^Q3Y%rC$"Ja%p>>Taa`\*)(s)D^@6d>kcK188
 endobj
 30 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 2640
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2682
 >>
 stream
-Gb!Sl?ZXs[&qAN2fXJKY,nN=l,g\Ir<Z9:DFt1W$oVk2V[*==LFX.^R2tu:C$\0LeMe2eUc5rG_@fHIeh>Mm+3;s9^5MlLSgVE`>!"m'0(5--(2A`UQba:tD&uEB;*#U'l.FLV\d,*#^.r5h.Z/X+GE;RP3nPh#qClsNN&>+[bP76e4:6C&Efqje0"K%.?dK#35Nas-87quM*hlSLl%X6`fklcK&\&b'b6-CO0WLaF4A&&u73AQ_OV'ZA^<FUg'BJ=.:TD?]MaW`A)8?7T<B[W'iLf,S)>Q_Hu:'WrRfr1?of''n63g7m'ksj)3D5^.'(n^S1)7t!4<[`23EU,QH.V9m@D%o)E9Vap[j3Te<3Ra-A)X14^]L7qjFIFWF?]XPlKlgKL6&n%_G3Bn_A4Cd5k9j_$_]UE\d-is&6oBl["q.>CPXP:C9TXZqP@5_G**8.k*VUZk$N[2`*]YYsU703Vl(F.IUngqCS5+@k#]F^E,#>kDq<X]=KEiTKE<2F2_InV?kf,?[:DjY3*Mu@!:]=(?r;HRY@.OV>I^#fg;i^#WE6he36rBuDDq3i]5H4."ZT)/qKPLJZ1?ih3.7Hi"NEWG@'?2L<PB+QMX'Ku;^OH(if#u7]3W=^Z;Qj9E*)@.kp[Oo[I_n4"#>@Q[=bTG#8)=jnXC(6nU043"i-%6I'\>#DY)dbsag)KA-DsfWlm2=_,F2HNBBQ>Wq[Ip4hnZGYRuae(bJgC@)6B,g?SC"jEOCDEX/iSmpRCiVj%.aH&4`.MD)sN)p7d:R?dQR%gm.ml>3PF]*qHCeIG9-$i8G_ib9"eY0R^$0;F3iKRWrM8qMp8i5@"uh=W2i^'dff8[ABmk8eaoDC8IUrd;!E`9G0S*US#kgP*eY&VmMX)7AZaDV!Trc,=Goha%d5+P!CX>g+_c^J]\UXfg1Mnnc&@f4`NdtS^@DujfM=e6*,rgXPMT"'(nkO4Ech54"P584#0)KoH6Wl"Ho#p,KoPpXP]htX_T2E='.o/_?Ma_Q+</_'7OfTYS4A2$r.;+HVlP.^*26fA>[fJiVN*R^/H1ND4cq%i<jagO=Z5%"%LX9a7q"$U1PM"-T.)i`8"Rf:@+:,CaVZ'>:u;Q;e't."2"*%RGQ)Ch>8pKckfXu6kUp-$`CA6JdosKEM`9.Cl>s0*hgp6];"b%?.=:ZIt-cldsSt=PLWl>k"X[uarIQh1!9?uWP;e_XNe\f,Y_%eD2WlaMQT/n4q[1n_L>l((Z:`[9N9M""p+%UN/'Y@8E!g/JO%^Qe$P7/$j5KrdJaZNQBhV#%8`CJ_n[Zal/\ElYio`],T?IRg-B*H-*\,Q[]%n(gHNJK=`6CC?shK-YoQ19X/f#(kkZk1!Y8jlh]2J+0p7.Y8=tpi^<6#P^;DSP!RbY`4c1)s-@nb3P[C5.D.AMA<u=?e,K;G>#nJ88TSo[]G<Hg5beKmf%&0%g""+O'j!kK_`l4`PGg=+!T9YURi9+l#`f1]p'f!44%eUTie32C]IF2O7mB_gro0<o#c,pA@0iD;f/`7uAMQ3b9Vo'iTKQuaG8^rC5iV!k@5;Se^%g3hhd0kimma1WO(YWN`E?n?9-"9'F7]hHsW(kVW$.Oqtapr6',g*Ma8,3oZMGf?TNNRts("Ya9$(<))h5RHDTfj%MqP0n,^2/B23V`PN"RuGq:4rZuU,9f!Ue'Kc'3A4O.$^4)^dOCW#n<QqYq%oii;oYX5i?>-g':ciM?sqi2"=A?^b0MhST'-a@,gkN^kW479KitQI<r:ek/?8)E3S!1HF*B`%A0i]?(<!Bb>.G<*"DDQ;82#0O`1FHJN+PJ!]o>0\U?%2K]!&sjU!WX,`iqBa+At9]mUooKYa9^e?W1?$PP__%4H/'`>cn,ftK,nmL>3B^;U_;jK?:9ZUNkhd?_8<RkC]J*s`t&?d5\&QN2_fe+Of/.9a(D+-D-oq0kPFRKiq<5=_e/D=oS7!jLSeEo[\f66O>O]`VRHbRW)&?jQ^ZD9SSA%$qFi0EPD7[#a^jm'CP+6'g]dPkm>c'>SqspJ'7L'.U^olc>]351\Z`R%^IfqkbY#%:3.pWkbB\VV@igWoD"M_/@C$*o+h(J8$r*5-UM>_M9QU_mB^=K,^bO2a@q*TEt0"&0`ei9EuCYo_5aZHlb[\GF24rV'u%ZoD\p_3e=pbPHidWXi9:eBSb],Eo4Kn"2l,)Q?W'd#5RM65*%&E6Od%ZB3"VL*5*"mnF1%YC>VHY*B$b7;2`A]2muQ#I0ULq;-5=1hfM[O@QPu$m3S3Wkn6^c,`kZh2LEtBrUugCfGnGK($Fb:%sVV>$GR)t^2"R_mI%'\m_M]PDV*D-(:pAXi9!j:gS2)AfO^EVpfFgmhcT*\A(B#AH;3;7O%l)t0Us]JIUud%>(4_r"6K3:E/.QqE5V6Y2^aBN5BEIao:)bjR?K#iD3K28]/H_eDSH$[EH/\E>ciIqVRP:Wrc,JPZ<^S4=mViTp7XD)FY*G-M(,)$,"3(I?O_^nc48a"Y!+Kl)>pdFSUWV+]Xq9$poq81%tin;CX[sUFIMEM2'Pcoqnng9e)"c(>&0WWG@j(K%BaaG,BWoo`,5m7gI1StL]>04h*Aa$KmC*ijS`;49dTe^#1N!ZZR^ARQD)b]q[:p!HTh~>endstream
+Gb!Sl?W5uE&qA6*kdS1YRh:f0gX88kAdCIt0eerIh:ebYiu%9GA*7Z@=K_)0?ah<8at*[?]Rp9pXSsTT])*i_i:nhhs*P4D@1=Ss!^m1W>7cZ@=C8jQ4_#hd8X'94EFb<LVaqJd6@1YlXftAV`/6od_!MXg``&ubZ:,s,6$sS'9JWim3(3m\A=#W[&stGC9*6`r3g+L(*iY"pjDK7jEOb=H9IKTK\jba,$!JZA9_D'b*Ws^'erbeG/2\j^XqFAQ7Y=9Bqoi]-9,;M]7p8XR7$Epa7[,ZbjVkXoF?8WRcUQGAZpk<"d@#AO9/i#_BL?>L`V@COb1NPcZU2M*Lg.WV<&#$mDPQ-H?m5dF)McUPadJH"d7C0]j<^6oT[Q;Cs*A4*0;R'+$$+hc[R95n+>^Uh4?jJ=)$WrPJUYYE-)t+L0j$D0UEm^3@Y3rNRLCDQj1'+tlF7(u=9q/loZ0Ta&_0Rp:'Zbh+=3R.jE/Np7sKrE'RA^:b\-[W,WtksM[R<W&3_la7Q6?IIEHM2D_XDL^[pn,jKB[*#4(/TrI[fZSoQs.J:$EV-Ak\9J$0V`qb`(1lhTf),#mm;QV!M_9IWT&n'l*KR4q[PR$8O*>OB:Cs5h_5YZb;7cg`YFOa>P=k'2b#\W6uDq%Mm.4CBXJasp(/4S"f:@.d^4'$V&+!4UukVmqHpi;-h/T.LG%DK8?<_+o$S3+@_EI!WM3HsFSBq&4]B?[mYf>g>Pe:1:^.kOi;<'3@j%ZFi63rjZ:J3K@X@#B>t7fqq,HD9m!2Fp7j1bAI(DU4rS1lQOShfX8u5!ZpcL[d9^S!n2r$,pd*oXGM_@WUEsQq"$qZSu!$T<+079=BheoWC4!ZU/i24'Wn6eaX$BY4Snl4.#CMpGtL/T;,f$F:>.mQ1-u,@EpOLf-jerIV[\jH)5o)@QlW!D+7HC/cm'pfcjBYX?Jas\)oSb4a4dY4,Z1aUaC>G]]u/8FZm-5p64[Pt:*<\"1:$gabkb&Vgq#rfH%f6T/8PmX?C>#c2<!0L%6H<1cJ[ap\lU16jr:TH8S0GXB@iKJn3hsm[XCV3KIb\96F%k3$lD9+*TNV+Mjf'%T@?PD&T_l53jDmMZCM[9DRj07:6!eT&+%<2ApPsTG43Ju6!mJt&4rON0:^J!$8s`!`0JWsZ7YX]HA"Itmu"i3<DiK:rr&[GFn6=u9NH(>OZ.Eh/T\FB`@1&qVLH,A=IY.U8X^X*gD9hC(L;MeHm79eL&Je00#0?@R&Hs#$j,!3)%V9`OM\O<"+dD-VJ.8<)$\$oUAZ0%/M.3&)PA\rLOi<Md`FXb@+!<C8Mor.Xb"@g94CCLD-jV=[X!OqZJK\b_60m*@P``IQ<0^Ad.LQ@'ctNs^=i6N@O)-;OZjh]?'XM_I>;+*"/O=JHOqol9`gNE.DJF<g;XsaXtY[S7uUp\&fsLN5o38EmWpXIR"%PU)+6'Y##6(-``3pHN/L9*n=5%u5:\,/^sBJZN#O9j/7NSIm->)bWI(`DqkD+Ng1;;lk+3cAS!=^`@\gSU;nu,Y'ieBQc\G5^#k?=tPGe_I_sJZ_Iq1ID*sad[U)+NcmCqoV0!rgE_aki\9>l3kNEQjp;4F49&uZarPTAE-8<dnLNq+c>'VuR2)I3^o/$=LQ'/W42\l2Zf6[L*$og_Z7IG"`DEq&t6#iP_kSHoBu6tqJ!8<LjP-EaH(:b"80JVb`8',j-l@omi\_ZN:;JABR8[1BQ\'b_p]B]>X\JR.%Z45g7M^r5R%JI`DNR!]s,qYY)\b_a<^i*a9ReU%5\$GKbp\2Z^_Q6"`-3#^_+UO9t?,N/np!c^$s"E_R>F8K,D#f-rob7e9:8K]lcNs,iRHM]`g$%kH\W+E5]&LMnF)c5C-MKb/!Z<^hEh)cV.I>]BUa_cUbAqS%2U+L:V2dKAt4qKn??-TJ$f)UM1e+Of//R#LH+-D-oq0kPFRKiq<5=_e/D=oS7!jLSeEo[\f66O>O]`VRHbRW)&?jQ^ZCWp*S%$qE>0`kM8[#a^]m'BD`6'g]dPkoUN'>Sr"pJ'7L'.U^nlc>]451\Z8R%^H;];?k8%:3.pWkbB\VV@igWoDR]_/@C$*o+h(J8$r*5-UM>_M9QU_mB^=K,^bO2a@q*TEt0"&0`ei9EuCYo_5IRHl5=WGF24r[4$3?oD]j$3e=pbPHidUXi9:eBSb],En@pf"2l,)Q?W'd#5S(F^5ODmI192?B3"VL(qh/$nF1%YC>VHY*B$b7;2`A]2muQ#I0ULq;-5=1hfVaP@QPu$m3S3Wkn6^c,`kZh2LEtBrUugCfGnGK($FbB%sVV>$GR)t^2"R_mI%'[m_M]PG2(O9*kJ4`i+?=sS"d;VfOgKWpfFg-hcT*\A(B#AH;3;7%o!uV"9pB3moRppX:@u)UMFcELCBC452-ekQ8`#urrDump!ZDrdmr]FLo+2.g>;%0/:9n]&ao-LZ+hGV-a[Kpj:bls:2[)ok(FLsZ>&mtjK?bm^,oKq4MSCtYHO8,@:*<CJ,?TT0%`)K"t]I];u>$S`Z&:[]b@_G$O!4K$9h,j@=9.[AR0^e>Vc)"Yrk64T7=@Q0K>P/XG4Q"1Uidn@QLac`%mQ(J,V>R7CY.Qh\kP(i_/%a.^qW/kO2aDQ>jR_7DF9[`6qq3TB=!ihX'k5]tXjes(-hN]t`6d4kAZ?Bpei8CD`C/~>endstream
 endobj
 xref
 0 31
@@ -438,13 +438,13 @@ xref
 0000522515 00000 n 
 0000524348 00000 n 
 0000526970 00000 n 
-0000529528 00000 n 
-0000531717 00000 n 
-0000533938 00000 n 
+0000529529 00000 n 
+0000531718 00000 n 
+0000533939 00000 n 
 trailer
 <<
 /ID 
-[<1b208d0ff7455d60025c0c0033fd8f05><1b208d0ff7455d60025c0c0033fd8f05>]
+[<d58683d662233d59a9aaf57224ff9304><d58683d662233d59a9aaf57224ff9304>]
 % ReportLab generated PDF document -- digest (opensource)
 
 /Info 21 0 R
@@ -452,5 +452,5 @@ trailer
 /Size 31
 >>
 startxref
-536670
+536713
 %%EOF

--- a/scripts/audit-site-runtime.js
+++ b/scripts/audit-site-runtime.js
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { chromium } = require('playwright');
+const { createStaticServer } = require('./capture-application-media');
+const { PAGES, VIEWPORTS } = require('./capture-site-visual-catalog');
+
+const ROOT = path.resolve(__dirname, '..');
+const DEFAULT_OUTPUT = path.join(ROOT, 'output', 'playwright', 'site-runtime-audit.json');
+
+function parseArgs(argv) {
+  const result = { output: DEFAULT_OUTPUT };
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === '--output') result.output = path.resolve(argv[++index]);
+    else throw new Error(`unknown argument: ${argv[index]}`);
+  }
+  return result;
+}
+
+async function inspectPage(page) {
+  return page.evaluate(() => {
+    const root = document.documentElement;
+    const visible = (element) => {
+      const style = getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return style.display !== 'none'
+        && style.visibility !== 'hidden'
+        && Number(style.opacity) > 0
+        && rect.width > 0
+        && rect.height > 0;
+    };
+    const overflowers = [...document.body.querySelectorAll('*')]
+      .filter(visible)
+      .map((element) => {
+        const rect = element.getBoundingClientRect();
+        return { element, rect };
+      })
+      .filter(({ rect }) => rect.right > window.innerWidth + 1 || rect.left < -1)
+      .slice(0, 12)
+      .map(({ element, rect }) => ({
+        selector: `${element.tagName.toLowerCase()}${element.id ? `#${element.id}` : ''}${element.classList.length ? `.${[...element.classList].slice(0, 2).join('.')}` : ''}`,
+        left: Math.round(rect.left * 10) / 10,
+        right: Math.round(rect.right * 10) / 10,
+        width: Math.round(rect.width * 10) / 10,
+        text: (element.innerText || '').trim().replace(/\s+/g, ' ').slice(0, 90),
+      }));
+    const animations = document.getAnimations().map((animation) => {
+      const timing = animation.effect && typeof animation.effect.getTiming === 'function'
+        ? animation.effect.getTiming()
+        : {};
+      return {
+        play_state: animation.playState,
+        duration: Number(timing.duration) || 0,
+        iterations: Number(timing.iterations) || 0,
+      };
+    });
+    const details = [...document.querySelectorAll('details')].map((element) => ({
+      open: element.open,
+      summary: element.querySelector('summary')?.innerText.trim() || '',
+    }));
+    return {
+      title: document.title,
+      h1: document.querySelector('h1')?.innerText.trim() || '',
+      scroll_width: root.scrollWidth,
+      client_width: root.clientWidth,
+      scroll_height: root.scrollHeight,
+      overflowers,
+      active_animations: animations.filter((entry) => entry.play_state === 'running').length,
+      infinite_animations: animations.filter((entry) => entry.iterations === Infinity).length,
+      details,
+      html_scrollbar_width: getComputedStyle(root).scrollbarWidth || 'auto',
+      has_skip_link: Boolean(document.querySelector('.site-skip-link')),
+      has_main: Boolean(document.querySelector('main')),
+    };
+  });
+}
+
+async function inspectFocus(page) {
+  await page.evaluate(() => {
+    if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
+    document.body.focus();
+  });
+  await page.keyboard.press('Tab');
+  return page.evaluate(() => {
+    const active = document.activeElement;
+    const style = active ? getComputedStyle(active) : null;
+    return {
+      tag: active?.tagName || '',
+      text: (active?.innerText || active?.getAttribute?.('aria-label') || '').trim().slice(0, 80),
+      outline_style: style?.outlineStyle || '',
+      outline_width: style?.outlineWidth || '',
+    };
+  });
+}
+
+async function inspectMobileMenu(page) {
+  const toggle = page.locator('[data-site-nav-toggle]');
+  if (!(await toggle.count()) || !(await toggle.isVisible())) return null;
+  await toggle.click();
+  const opened = await page.evaluate(() => ({
+    expanded: document.querySelector('[data-site-nav-toggle]')?.getAttribute('aria-expanded'),
+    hidden: document.querySelector('[data-site-nav-mobile]')?.hidden,
+  }));
+  await page.keyboard.press('Escape');
+  const closed = await page.evaluate(() => ({
+    expanded: document.querySelector('[data-site-nav-toggle]')?.getAttribute('aria-expanded'),
+    hidden: document.querySelector('[data-site-nav-mobile]')?.hidden,
+    focus_restored: document.activeElement === document.querySelector('[data-site-nav-toggle]'),
+  }));
+  return { opened, closed };
+}
+
+async function inspectDisclosure(page, pageId) {
+  if (pageId !== 'walkthrough') return null;
+  const disclosure = page.locator('.transcript-disclosure');
+  assert.equal(await disclosure.count(), 1, 'walkthrough transcript disclosure missing');
+  const initial = await disclosure.evaluate((element) => element.open);
+  await disclosure.locator('summary').click();
+  const afterClick = await disclosure.evaluate((element) => element.open);
+  return { initial, after_click: afterClick };
+}
+
+async function inspectReducedMotion(browser, baseUrl, pageSpec, viewport) {
+  const context = await browser.newContext({
+    viewport: { width: viewport.width, height: viewport.height },
+    colorScheme: 'dark',
+    reducedMotion: 'reduce',
+  });
+  const page = await context.newPage();
+  try {
+    const response = await page.goto(`${baseUrl}${pageSpec.path}`, { waitUntil: 'load' });
+    assert(response && response.ok(), `${pageSpec.path} reduced-motion request failed`);
+    await page.waitForTimeout(160);
+    return await page.evaluate(() => ({
+      prefers_reduce: matchMedia('(prefers-reduced-motion: reduce)').matches,
+      active_animations: document.getAnimations().filter((animation) => animation.playState === 'running').length,
+      hidden_reveals: [...document.querySelectorAll('[data-site-reveal]')].filter((element) => {
+        const style = getComputedStyle(element);
+        return style.visibility === 'hidden' || style.display === 'none' || Number(style.opacity) === 0;
+      }).length,
+    }));
+  } finally {
+    await context.close();
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const server = createStaticServer();
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const baseUrl = `http://127.0.0.1:${server.address().port}`;
+  const browser = await chromium.launch({ headless: true });
+  const results = [];
+  const issues = [];
+  try {
+    for (const pageSpec of PAGES) {
+      for (const viewport of VIEWPORTS) {
+        const context = await browser.newContext({
+          viewport: { width: viewport.width, height: viewport.height },
+          colorScheme: 'dark',
+          reducedMotion: 'no-preference',
+        });
+        const page = await context.newPage();
+        const consoleErrors = [];
+        page.on('console', (message) => {
+          if (message.type() !== 'error') return;
+          const source = message.location().url || '';
+          if (!source || source.startsWith(baseUrl)) consoleErrors.push(message.text());
+        });
+        page.on('pageerror', (error) => consoleErrors.push(error.message));
+        try {
+          const response = await page.goto(`${baseUrl}${pageSpec.path}`, { waitUntil: 'load' });
+          assert(response && response.ok(), `${pageSpec.path} returned ${response ? response.status() : 'no response'}`);
+          await page.evaluate(() => document.fonts.ready);
+          await page.waitForTimeout(180);
+          const facts = await inspectPage(page);
+          const focus = await inspectFocus(page);
+          const mobileMenu = await inspectMobileMenu(page);
+          const disclosure = await inspectDisclosure(page, pageSpec.id);
+          const entry = { page: pageSpec.id, viewport: viewport.id, facts, focus, mobile_menu: mobileMenu, disclosure, console_errors: consoleErrors };
+          results.push(entry);
+          if (facts.scroll_width > facts.client_width + 1) issues.push({ page: pageSpec.id, viewport: viewport.id, issue: `horizontal overflow ${facts.scroll_width}/${facts.client_width}`, overflowers: facts.overflowers });
+          if (!facts.has_main) issues.push({ page: pageSpec.id, viewport: viewport.id, issue: 'main landmark missing' });
+          if (pageSpec.id !== 'home' && pageSpec.id !== 'not-found' && !facts.has_skip_link) issues.push({ page: pageSpec.id, viewport: viewport.id, issue: 'skip link missing' });
+          if (focus.outline_style === 'none' || focus.outline_width === '0px') issues.push({ page: pageSpec.id, viewport: viewport.id, issue: 'first keyboard target lacks a visible outline', focus });
+          if (mobileMenu && (mobileMenu.opened.expanded !== 'true' || mobileMenu.opened.hidden || mobileMenu.closed.expanded !== 'false' || !mobileMenu.closed.hidden || !mobileMenu.closed.focus_restored)) issues.push({ page: pageSpec.id, viewport: viewport.id, issue: 'mobile menu open/Escape/focus contract failed', mobileMenu });
+          if (disclosure && (disclosure.initial !== false || disclosure.after_click !== true)) issues.push({ page: pageSpec.id, viewport: viewport.id, issue: 'transcript progressive disclosure contract failed', disclosure });
+          if (consoleErrors.length) issues.push({ page: pageSpec.id, viewport: viewport.id, issue: 'console errors', console_errors: consoleErrors });
+        } finally {
+          await context.close();
+        }
+      }
+    }
+
+    const reducedMotion = [];
+    for (const pageSpec of PAGES) {
+      for (const viewport of [VIEWPORTS[0], VIEWPORTS[3]]) {
+        const facts = await inspectReducedMotion(browser, baseUrl, pageSpec, viewport);
+        reducedMotion.push({ page: pageSpec.id, viewport: viewport.id, ...facts });
+        if (!facts.prefers_reduce || facts.active_animations || facts.hidden_reveals) issues.push({ page: pageSpec.id, viewport: viewport.id, issue: 'reduced-motion contract failed', facts });
+      }
+    }
+
+    const manifest = {
+      schema: 1,
+      kind: 'citadel-site-runtime-audit',
+      combinations: results.length,
+      reduced_motion_combinations: reducedMotion.length,
+      issues,
+      results,
+      reduced_motion: reducedMotion,
+    };
+    fs.mkdirSync(path.dirname(args.output), { recursive: true });
+    fs.writeFileSync(args.output, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+    process.stdout.write(`${JSON.stringify({
+      combinations: manifest.combinations,
+      reduced_motion_combinations: manifest.reduced_motion_combinations,
+      issues: issues.length,
+      output: path.relative(ROOT, args.output).replace(/\\/g, '/'),
+    }, null, 2)}\n`);
+    if (issues.length) process.exitCode = 1;
+  } finally {
+    await browser.close();
+    await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  }
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(`site runtime audit failed: ${error.stack || error.message}\n`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = Object.freeze({ parseArgs });

--- a/scripts/build-site-visual-contact-sheets.py
+++ b/scripts/build-site-visual-contact-sheets.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Build labeled contact sheets for the Citadel viewport-slice catalog."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFont
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_INPUT = ROOT / "output" / "playwright" / "site-visual-audit" / "before"
+
+
+def arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", type=Path, default=DEFAULT_INPUT)
+    parser.add_argument("--columns", type=int, default=4)
+    parser.add_argument("--tile-width", type=int, default=320)
+    return parser.parse_args()
+
+
+def build_sheet(entry: dict, input_root: Path, output_root: Path, columns: int, tile_width: int) -> Path:
+    slices = entry["slices"]
+    viewport = entry["viewport"]
+    page = entry["page"]
+    ratio = viewport["height"] / viewport["width"]
+    tile_height = round(tile_width * ratio)
+    label_height = 34
+    rows = math.ceil(len(slices) / columns)
+    sheet = Image.new("RGB", (columns * tile_width, rows * (tile_height + label_height)), "#071725")
+    draw = ImageDraw.Draw(sheet)
+    font = ImageFont.load_default()
+    for index, slice_record in enumerate(slices):
+        source = ROOT / slice_record["path"]
+        with Image.open(source) as image:
+            tile = image.convert("RGB").resize((tile_width, tile_height), Image.Resampling.LANCZOS)
+        x = (index % columns) * tile_width
+        y = (index // columns) * (tile_height + label_height)
+        sheet.paste(tile, (x, y + label_height))
+        label = f"{page['id']} / {viewport['id']} / {index + 1:02d} / y={slice_record['scroll_y']}"
+        draw.rectangle((x, y, x + tile_width, y + label_height), fill="#0e2b40")
+        draw.text((x + 8, y + 10), label, fill="#dff7ff", font=font)
+    output_root.mkdir(parents=True, exist_ok=True)
+    target = output_root / f"{page['id']}--{viewport['id']}.png"
+    sheet.save(target, format="PNG", optimize=True)
+    return target
+
+
+def main() -> None:
+    args = arguments()
+    input_root = args.input.resolve()
+    manifest = json.loads((input_root / "manifest.json").read_text(encoding="utf-8"))
+    output_root = input_root / "contact-sheets"
+    targets = [
+        build_sheet(entry, input_root, output_root, args.columns, args.tile_width)
+        for entry in manifest["captures"]
+    ]
+    print(json.dumps({"contact_sheets": len(targets), "output": str(output_root.relative_to(ROOT))}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/capture-site-visual-catalog.js
+++ b/scripts/capture-site-visual-catalog.js
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { chromium } = require('playwright');
+const { createStaticServer } = require('./capture-application-media');
+
+const ROOT = path.resolve(__dirname, '..');
+const DEFAULT_OUTPUT = path.join(ROOT, 'output', 'playwright', 'site-visual-audit');
+const PAGES = Object.freeze([
+  { id: 'home', path: '/' },
+  { id: 'evidence', path: '/evidence.html' },
+  { id: 'operation-control', path: '/operation-control.html' },
+  { id: 'optimizer', path: '/optimizer.html' },
+  { id: 'research', path: '/research.html' },
+  { id: 'walkthrough', path: '/walkthrough.html' },
+  { id: 'not-found', path: '/404.html' },
+]);
+const VIEWPORTS = Object.freeze([
+  { id: 'desktop', width: 1440, height: 900 },
+  { id: 'laptop', width: 1280, height: 720 },
+  { id: 'tablet', width: 768, height: 1024 },
+  { id: 'mobile', width: 390, height: 844 },
+  { id: 'small-mobile', width: 320, height: 568 },
+]);
+
+function parseArgs(argv) {
+  const result = { label: 'before', output: DEFAULT_OUTPUT, reuse: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === '--label') result.label = argv[++index];
+    else if (argv[index] === '--output') result.output = path.resolve(argv[++index]);
+    else if (argv[index] === '--reuse') result.reuse = true;
+    else throw new Error(`unknown argument: ${argv[index]}`);
+  }
+  if (!/^[a-z0-9][a-z0-9-]*$/i.test(result.label)) throw new Error(`invalid label: ${result.label}`);
+  return result;
+}
+
+function slicePositions(scrollHeight, viewportHeight) {
+  const maximum = Math.max(0, scrollHeight - viewportHeight);
+  const step = Math.max(1, viewportHeight - 96);
+  const positions = [];
+  for (let y = 0; y < maximum; y += step) positions.push(y);
+  positions.push(maximum);
+  return [...new Set(positions)];
+}
+
+function existingCaptures(outputRoot) {
+  const captures = [];
+  for (const pageSpec of PAGES) {
+    for (const viewport of VIEWPORTS) {
+      const pageRoot = path.join(outputRoot, pageSpec.id, viewport.id);
+      if (!fs.existsSync(pageRoot)) return null;
+      const files = fs.readdirSync(pageRoot).filter((file) => /^slice-\d+\.png$/.test(file)).sort();
+      if (!files.length) return null;
+      captures.push({
+        page: pageSpec,
+        viewport,
+        facts: { reused: true },
+        slices: files.map((file, index) => ({
+          index: index + 1,
+          path: path.relative(ROOT, path.join(pageRoot, file)).replace(/\\/g, '/'),
+          scroll_y: null,
+        })),
+        issues: [],
+        console_errors: [],
+      });
+    }
+  }
+  return captures;
+}
+
+async function pageFacts(page) {
+  return page.evaluate(() => {
+    const root = document.documentElement;
+    const body = document.body;
+    const animations = document.getAnimations().map((animation) => {
+      const timing = animation.effect && typeof animation.effect.getTiming === 'function'
+        ? animation.effect.getTiming()
+        : {};
+      return {
+        duration: Number(timing.duration) || 0,
+        iterations: Number(timing.iterations) || 0,
+        play_state: animation.playState,
+      };
+    });
+    return {
+      title: document.title,
+      h1: document.querySelector('h1')?.innerText.trim() || '',
+      scroll_height: Math.max(root.scrollHeight, body.scrollHeight),
+      scroll_width: root.scrollWidth,
+      client_width: root.clientWidth,
+      sections: document.querySelectorAll('main section').length,
+      links: document.querySelectorAll('a[href]').length,
+      buttons: document.querySelectorAll('button').length,
+      animations: {
+        total: animations.length,
+        long_running: animations.filter((entry) => entry.play_state === 'running' && (entry.duration >= 1000 || entry.iterations === Infinity)).length,
+      },
+      has_skip_link: Boolean(document.querySelector('.site-skip-link')),
+      has_nav_toggle: Boolean(document.querySelector('[data-site-nav-toggle]')),
+    };
+  });
+}
+
+async function sliceFacts(page) {
+  return page.evaluate(() => {
+    const top = window.scrollY;
+    const bottom = top + window.innerHeight;
+    const visible = (element) => {
+      const style = getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return style.display !== 'none'
+        && style.visibility !== 'hidden'
+        && Number(style.opacity) > 0
+        && rect.width > 0
+        && rect.height > 0
+        && rect.bottom > 0
+        && rect.top < window.innerHeight;
+    };
+    const textNodes = [...document.querySelectorAll('h1,h2,h3,p,li,code,blockquote')].filter(visible);
+    const interactive = [...document.querySelectorAll('a[href],button,input,select,textarea')].filter(visible);
+    return {
+      scroll_y: top,
+      document_range: [top, bottom],
+      visible_text_blocks: textNodes.length,
+      visible_characters: textNodes.reduce((sum, element) => sum + element.innerText.trim().length, 0),
+      visible_headings: textNodes.filter((element) => /^H[1-3]$/.test(element.tagName)).map((element) => element.innerText.trim()).slice(0, 8),
+      visible_interactive: interactive.length,
+    };
+  });
+}
+
+async function capturePage(browser, baseUrl, outputRoot, pageSpec, viewport, reuse) {
+  const context = await browser.newContext({
+    viewport: { width: viewport.width, height: viewport.height },
+    colorScheme: 'dark',
+    reducedMotion: 'no-preference',
+  });
+  const page = await context.newPage();
+  const errors = [];
+  page.on('console', (message) => {
+    if (message.type() !== 'error') return;
+    const source = message.location().url || '';
+    if (!source || source.startsWith(baseUrl)) errors.push(message.text());
+  });
+  page.on('pageerror', (error) => errors.push(error.message));
+
+  try {
+    const response = await page.goto(`${baseUrl}${pageSpec.path}`, { waitUntil: 'load' });
+    assert(response && response.ok(), `${pageSpec.path} returned ${response ? response.status() : 'no response'}`);
+    await page.evaluate(() => document.fonts.ready);
+    await page.waitForTimeout(reuse ? 20 : 350);
+
+    const facts = await pageFacts(page);
+    const issues = [];
+    if (facts.scroll_width > facts.client_width + 1) {
+      issues.push(`horizontal overflow ${facts.scroll_width}/${facts.client_width}`);
+    }
+    const positions = slicePositions(facts.scroll_height, viewport.height);
+    const pageRoot = path.join(outputRoot, pageSpec.id, viewport.id);
+    fs.mkdirSync(pageRoot, { recursive: true });
+    const slices = [];
+    for (let index = 0; index < positions.length; index += 1) {
+      const y = positions[index];
+      await page.evaluate((offset) => window.scrollTo(0, offset), y);
+      const filename = `slice-${String(index + 1).padStart(3, '0')}.png`;
+      const target = path.join(pageRoot, filename);
+      if (reuse && fs.existsSync(target)) await page.waitForTimeout(0);
+      else {
+        await page.waitForTimeout(100);
+        await page.screenshot({ path: target, fullPage: false });
+      }
+      slices.push({
+        index: index + 1,
+        path: path.relative(ROOT, target).replace(/\\/g, '/'),
+        ...(await sliceFacts(page)),
+      });
+    }
+    if (errors.length) issues.push(`console errors: ${errors.join(' | ')}`);
+    return { page: pageSpec, viewport, facts, slices, issues, console_errors: errors };
+  } finally {
+    await context.close();
+  }
+}
+
+async function reducedMotionFacts(baseUrl, pageSpec, viewport) {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    viewport: { width: viewport.width, height: viewport.height },
+    colorScheme: 'dark',
+    reducedMotion: 'reduce',
+  });
+  const page = await context.newPage();
+  try {
+    const response = await page.goto(`${baseUrl}${pageSpec.path}`, { waitUntil: 'load' });
+    assert(response && response.ok(), `${pageSpec.path} reduced-motion load failed`);
+    await page.waitForTimeout(160);
+    return await page.evaluate(() => {
+      const active = document.getAnimations().filter((animation) => animation.playState === 'running');
+      return { active_animations: active.length, prefers_reduce: matchMedia('(prefers-reduced-motion: reduce)').matches };
+    });
+  } finally {
+    await context.close();
+    await browser.close();
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const outputRoot = path.join(args.output, args.label);
+  fs.mkdirSync(outputRoot, { recursive: true });
+  const server = createStaticServer();
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+  const captures = [];
+  try {
+    const reused = args.reuse ? existingCaptures(outputRoot) : null;
+    if (reused) captures.push(...reused);
+    else {
+      const browser = await chromium.launch({ headless: true });
+      try {
+        for (const pageSpec of PAGES) {
+          for (const viewport of VIEWPORTS) captures.push(await capturePage(browser, baseUrl, outputRoot, pageSpec, viewport, args.reuse));
+        }
+      } finally {
+        await browser.close();
+      }
+    }
+    const reducedMotion = [];
+    for (const pageSpec of PAGES) {
+      for (const viewport of [VIEWPORTS[0], VIEWPORTS[3]]) {
+        try {
+          reducedMotion.push({ page: pageSpec.id, viewport: viewport.id, ...(await reducedMotionFacts(baseUrl, pageSpec, viewport)) });
+        } catch (error) {
+          reducedMotion.push({ page: pageSpec.id, viewport: viewport.id, error: error.message });
+        }
+      }
+    }
+    const manifest = {
+      schema: 1,
+      kind: 'citadel-site-visual-catalog',
+      label: args.label,
+      pages: PAGES.length,
+      viewports: VIEWPORTS.length,
+      viewport_slices: captures.reduce((sum, entry) => sum + entry.slices.length, 0),
+      issues: captures.flatMap((entry) => entry.issues.map((issue) => ({ page: entry.page.id, viewport: entry.viewport.id, issue }))),
+      captures,
+      reduced_motion: reducedMotion,
+    };
+    fs.writeFileSync(path.join(outputRoot, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+    process.stdout.write(`${JSON.stringify({
+      schema: manifest.schema,
+      label: manifest.label,
+      pages: manifest.pages,
+      viewports: manifest.viewports,
+      viewport_slices: manifest.viewport_slices,
+      issues: manifest.issues.length,
+      output: path.relative(ROOT, outputRoot).replace(/\\/g, '/'),
+    }, null, 2)}\n`);
+  } finally {
+    await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  }
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(`site visual catalog failed: ${error.stack || error.message}\n`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = Object.freeze({ PAGES, VIEWPORTS, existingCaptures, parseArgs, slicePositions });

--- a/scripts/render-sentient-grant-packet.py
+++ b/scripts/render-sentient-grant-packet.py
@@ -347,7 +347,7 @@ def slide_5(pdf: canvas.Canvas) -> None:
     text_block(pdf, "Citadel is a public system with continuing repository pull, not a grant-funded mockup.", MARGIN, 348, 800, 14, 19, MUTED)
 
     metric(pdf, 72, 300, 155, "136", "days public", GREEN)
-    metric(pdf, 270, 300, 175, "514 / 538", "main commits attributed to Seth", CYAN)
+    metric(pdf, 270, 300, 175, "518 / 542", "main commits attributed to Seth", CYAN)
     metric(pdf, 500, 300, 155, "809 / 80", "stars / forks", BLUE)
     metric(pdf, 714, 300, 175, "524", "unique cloners in 14 days", VIOLET)
 
@@ -465,8 +465,10 @@ def slide_8(pdf: canvas.Canvas) -> None:
     pdf.setFont(FONT_BOLD, 16.5)
     pdf.drawString(88, 122, "Seth Gammon - solo builder and maintainer")
     pdf.setFillColor(HexColor("#D8E5EA"))
-    pdf.setFont(FONT, 10.8)
-    pdf.drawString(88, 98, "Evaluator: github.com/SethGammon/Citadel/blob/main/docs/grants/EVALUATOR_START_HERE.md")
+    pdf.setFont(FONT, 10.3)
+    pdf.drawString(88, 99, "seth@softwareshaped.com  |  softwareshaped.com")
+    pdf.setFont(FONT, 8.8)
+    pdf.drawString(88, 84, "Evidence: github.com/SethGammon/Citadel/blob/main/docs/grants/EVALUATOR_START_HERE.md")
     pdf.setFillColor(HexColor("#83E0E8"))
     pdf.setFont(FONT_BOLD, 11)
     pdf.drawRightString(872, 121, "OPEN. VERIFIABLE. FALSIFIABLE.")

--- a/scripts/test-application-claim-discipline.js
+++ b/scripts/test-application-claim-discipline.js
@@ -36,7 +36,7 @@ const FORBIDDEN = [
   [/5\s*\/\s*5\s+passed/gi, 'Fresh-clone stages completed; doctor semantic health is unknown.'],
   [/independent(?:ly)?\s+(?:verifier|verified|graded)/gi, 'Say model-external or verifier outside the routed model.'],
   [/citadel improved this result/gi, 'V1 apparent savings reverse under matched-timeout sensitivity.'],
-  [/510\s+(?:repository\s+)?commits/gi, 'The merged main branch contains 538 commits.'],
+  [/510\s+(?:repository\s+)?commits/gi, 'The merged main branch contains 542 commits.'],
 ];
 
 const failures = [];
@@ -106,7 +106,7 @@ for (const relative of [
   'docs/grants/TYPEFORM_ANSWER_PACK.md',
 ]) {
   const value = fs.readFileSync(path.join(ROOT, relative), 'utf8');
-  assert.match(value, /538\s+commits|514\s+of\s+538\s+main-branch\s+commits/i, `${relative}: missing current main-branch delivery count`);
+  assert.match(value, /542\s+commits|518\s+of\s+542\s+main-branch\s+commits/i, `${relative}: missing current main-branch delivery count`);
   assert.match(value, /524 unique cloners/i, `${relative}: missing qualified 14-day clone signal`);
   assert.match(value, /not\s+(?:users|installation|installations)|not\s+manually\s+typed\s+code/i, `${relative}: missing interest-signal boundary`);
 }

--- a/scripts/test-sentient-application-package.js
+++ b/scripts/test-sentient-application-package.js
@@ -27,14 +27,15 @@ const formCheck = fs.readFileSync(formCheckFile, 'utf8');
 const pdf = fs.readFileSync(pdfFile);
 const packageJson = JSON.parse(fs.readFileSync(packageFile, 'utf8'));
 
-const oneLine = 'An open control layer that proves whether AI agents finished and what it cost.';
+const oneLine = 'An open layer that finds the cheapest verified path through any agent stack.';
 assert.ok(oneLine.length <= 80, `one-line answer exceeds Typeform limit: ${oneLine.length}`);
 assert.match(answers, new RegExp(`Character count: ${oneLine.length} of 80\\.`));
 assert.ok(answers.includes(`\`${oneLine}\``), 'one-line answer and recorded count drifted');
 
-for (const placeholder of ['[SETH EMAIL]', '[CITY, COUNTRY]']) {
+for (const placeholder of ['[CITY, COUNTRY]']) {
   assert.ok(answers.includes(placeholder), `missing human-owned placeholder: ${placeholder}`);
 }
+assert.match(answers, /seth@softwareshaped\.com/);
 assert.ok(!answers.includes('[HOW SETH HEARD ABOUT SENTIENT]'), 'Grant path must not require the skipped how-heard field');
 assert.match(answers, /jumps from the required supporting-document upload\s+directly to the thank-you screen/i);
 assert.match(readiness, /Grant-branch logic jumps from the supporting\s+document field to the grant thank-you screen/i);


### PR DESCRIPTION
## What changed

- completed the final multi-viewport site experience audit and visual QA tooling
- refreshed the Sentient Typeform answer pack, reviewer-facing evidence, founder/contact facts, and claim boundaries
- rebuilt and visually verified the eight-page grant packet
- updated public pages and the release manifest to match the final application state

## Why

The public site, evidence path, PDF, and application wording must present one current, readable, internally consistent review surface before submission.

## Validation

- final site viewport and runtime audits completed
- eight PDF pages rendered and visually inspected
- grant verification: 17/17 canonical checks passed
- application package, media, evidence, and claim-discipline checks passed
- live Typeform contract checked against all 13 required Grant fields