### PR TITLE
Pin public holdout workflow actions to immutable commits

### DIFF
--- a/.github/workflows/public-holdout-evaluation.yml
+++ b/.github/workflows/public-holdout-evaluation.yml
@@ -39,7 +39,7 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       count: ${{ steps.matrix.outputs.count }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - id: matrix
         shell: bash
         run: node scripts/public-holdout-matrix.js "${{ inputs.mode }}" "${{ inputs.selection_path }}" "${{ inputs.pool_path }}" "${{ inputs.prediction_path }}" "${{ inputs.reserve_per_stratum }}" "${{ inputs.reserve_offset_per_stratum }}" >> "$GITHUB_OUTPUT"
@@ -55,11 +55,11 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     steps:
       - name: Check out Citadel protocol and predictions
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           path: citadel
       - name: Check out pinned official evaluator
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: microsoft/SWE-bench-Live
           ref: 70ec57e852e3f2d195790fe71f553e272c691833
@@ -70,7 +70,7 @@ jobs:
         run: |
           test "$(git -C swe-bench-live rev-parse HEAD)" = "70ec57e852e3f2d195790fe71f553e272c691833"
           test "$(git -C swe-bench-live/launch rev-parse HEAD)" = "7735b1e7363dd3bbc69bd0ef80db646a2ae391fd"
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
           cache: pip
@@ -119,7 +119,7 @@ jobs:
         run: node citadel/scripts/public-holdout-evaluator-summary.js "${{ inputs.mode }}" "${{ matrix.instance_id }}" "${{ matrix.split }}" "${{ matrix.feature_key }}" "${{ github.workspace }}/evaluator-output" "$([ '${{ inputs.mode }}' = 'gold' ] && echo 3 || echo 1)" "${{ github.workspace }}/evaluator-output/summary.json"
       - name: Upload verifier evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ inputs.mode }}-${{ matrix.artifact_name }}
           path: evaluator-output

--- a/.github/workflows/public-holdout-pilot-evaluation.yml
+++ b/.github/workflows/public-holdout-pilot-evaluation.yml
@@ -26,7 +26,7 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       count: ${{ steps.matrix.outputs.count }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - id: matrix
         shell: bash
         run: node scripts/public-holdout-matrix.js prediction "${{ inputs.selection_path }}" "${{ inputs.pool_path }}" "${{ inputs.prediction_path }}" 0 0 >> "$GITHUB_OUTPUT"
@@ -42,11 +42,11 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     steps:
       - name: Check out Citadel protocol and predictions
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           path: citadel
       - name: Check out pinned official evaluator
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: microsoft/SWE-bench-Live
           ref: 70ec57e852e3f2d195790fe71f553e272c691833
@@ -57,7 +57,7 @@ jobs:
         run: |
           test "$(git -C swe-bench-live rev-parse HEAD)" = "70ec57e852e3f2d195790fe71f553e272c691833"
           test "$(git -C swe-bench-live/launch rev-parse HEAD)" = "7735b1e7363dd3bbc69bd0ef80db646a2ae391fd"
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
           cache: pip
@@ -97,7 +97,7 @@ jobs:
         run: node citadel/scripts/public-holdout-evaluator-summary.js prediction "${{ matrix.instance_id }}" "${{ matrix.split }}" "${{ matrix.feature_key }}" "${{ github.workspace }}/evaluator-output" 1 "${{ github.workspace }}/evaluator-output/summary.json"
       - name: Upload verifier evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: prediction-${{ matrix.artifact_name }}
           path: evaluator-output


### PR DESCRIPTION
## What changed

- Replaced ten mutable action tags across the public holdout evaluator and pilot workflows with immutable commit SHAs.
- Preserved readable patch-version comments for `actions/checkout` v4.4.0, `actions/setup-python` v5.6.0, and `actions/upload-artifact` v4.6.2.

## Why

GitHub code scanning reports 20 open `GITHUB_ACTION_UNPINNED` records for these workflows. They reduce to ten real `uses:` occurrences; the scanner emitted each workflow finding twice. Pinning the underlying refs removes the supply-chain ambiguity without changing workflow behavior.

## Verification

- Upstream GitHub commit APIs confirm all three tag-to-SHA mappings.
- `actionlint` v1.7.12: PASS in the implementation worktree.
- `node scripts/test-public-holdout-capstone.js`: PASS.
- `node scripts/test-public-holdout-pilot.js`: PASS.
- `node scripts/test-github-action.js`: PASS.
- Immutable-ref/version-comment assertion: 10/10.
- `git diff --check`: PASS.

## Limitation

A full `test-all.js` attempt timed out after 15 minutes in unrelated `test-adoption-lifecycle.js` at a child `git symbolic-ref` while other suites were running concurrently. No aggregate pass is claimed; this two-file workflow change is covered by the focused workflow tests and hosted CI remains the final gate.