### PR TITLE
Fix Codex plugin screenshot manifest closure

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -27,6 +27,9 @@
     "displayName": "Citadel Harness",
     "composerIcon": "./assets/icon.svg",
     "logo": "./assets/icon.svg",
+    "screenshots": [
+      "./assets/terminal-demo.svg"
+    ],
     "websiteURL": "https://sethgammon.github.io/Citadel/",
     "privacyPolicyURL": "https://github.com/SethGammon/Citadel/blob/main/PRIVACY.md",
     "termsOfServiceURL": "https://github.com/SethGammon/Citadel/blob/main/LICENSE",

--- a/scripts/codex-compat.js
+++ b/scripts/codex-compat.js
@@ -361,6 +361,9 @@ function generatePluginManifest() {
   const skillCount = countSkills();
   const pluginInCitadelRoot = path.resolve(PROJECT_ROOT) === CITADEL_ROOT;
   const rootIconPath = pluginInCitadelRoot ? './assets/icon.svg' : './.agents/assets/icon.svg';
+  const rootScreenshotPath = pluginInCitadelRoot
+    ? './assets/terminal-demo.svg'
+    : './.agents/assets/terminal-demo.svg';
 
   const manifest = {
     name: pkg.name || 'citadel',
@@ -381,6 +384,7 @@ function generatePluginManifest() {
       displayName: 'Citadel Harness',
       composerIcon: rootIconPath,
       logo: rootIconPath,
+      screenshots: [rootScreenshotPath],
       websiteURL: 'https://sethgammon.github.io/Citadel/',
       privacyPolicyURL: 'https://github.com/SethGammon/Citadel/blob/main/PRIVACY.md',
       termsOfServiceURL: 'https://github.com/SethGammon/Citadel/blob/main/LICENSE',
@@ -416,6 +420,7 @@ function generatePluginManifest() {
       ...manifest.interface,
       composerIcon: './assets/icon.svg',
       logo: './assets/icon.svg',
+      screenshots: ['./assets/terminal-demo.svg'],
     },
   };
   delete projectedManifest.hooks;
@@ -432,6 +437,10 @@ function syncPluginAssets() {
   copyFile(
     path.join(CITADEL_ROOT, 'assets', 'icon.svg'),
     path.join(PROJECT_ROOT, '.agents', 'assets', 'icon.svg')
+  );
+  copyFile(
+    path.join(CITADEL_ROOT, 'assets', 'terminal-demo.svg'),
+    path.join(PROJECT_ROOT, '.agents', 'assets', 'terminal-demo.svg')
   );
 }
 

--- a/scripts/test-codex-operational-improvements.js
+++ b/scripts/test-codex-operational-improvements.js
@@ -49,8 +49,10 @@ function snapshotSourcePluginArtifacts() {
   }));
 }
 
-function assertPluginAssetsExist(pluginRoot, manifest) {
+function assertPluginAssetsExist(pluginRoot, manifest, expectedScreenshots) {
   const interfaceMetadata = manifest.interface || {};
+  assert.deepEqual(interfaceMetadata.screenshots, expectedScreenshots,
+    'plugin manifest must expose the shipped terminal demo screenshot');
   const references = [
     interfaceMetadata.composerIcon,
     interfaceMetadata.logo,
@@ -68,6 +70,12 @@ function assertPluginAssetsExist(pluginRoot, manifest) {
 }
 
 function testReadinessCheck() {
+  const repositoryManifest = JSON.parse(fs.readFileSync(
+    path.join(CITADEL_ROOT, '.codex-plugin', 'plugin.json'),
+    'utf8'
+  ));
+  assertPluginAssetsExist(CITADEL_ROOT, repositoryManifest, ['./assets/terminal-demo.svg']);
+
   const tmp = tempProject('citadel-readiness-');
   try {
     fs.writeFileSync(path.join(tmp, 'AGENTS.md'), '# Test\n\n## Review guidelines\n\n- Focus on P0/P1 issues.\n', 'utf8');
@@ -81,14 +89,16 @@ function testReadinessCheck() {
     const report = checkCodexReadiness({ projectRoot: tmp, write: true });
     assert(report.pass, JSON.stringify(report.checks.filter((check) => !check.pass), null, 2));
     assert(fs.existsSync(path.join(tmp, '.planning', 'verification', 'codex-readiness.json')));
-    const manifest = fs.readFileSync(path.join(tmp, '.codex-plugin', 'plugin.json'), 'utf8');
-    assert.doesNotThrow(() => JSON.parse(manifest), 'target-project plugin manifest must be strict JSON');
-    assert(manifest.includes('./.agents/skills/'), 'target-project plugin manifest should point at generated skills');
+    const manifestText = fs.readFileSync(path.join(tmp, '.codex-plugin', 'plugin.json'), 'utf8');
+    assert.doesNotThrow(() => JSON.parse(manifestText), 'target-project plugin manifest must be strict JSON');
+    assert(manifestText.includes('./.agents/skills/'), 'target-project plugin manifest should point at generated skills');
+    const manifest = JSON.parse(manifestText);
+    assertPluginAssetsExist(tmp, manifest, ['./.agents/assets/terminal-demo.svg']);
     const projectedManifest = JSON.parse(fs.readFileSync(
       path.join(tmp, '.agents', '.codex-plugin', 'plugin.json'),
       'utf8'
     ));
-    assertPluginAssetsExist(path.join(tmp, '.agents'), projectedManifest);
+    assertPluginAssetsExist(path.join(tmp, '.agents'), projectedManifest, ['./assets/terminal-demo.svg']);
     fs.rmSync(path.join(tmp, '.agents', 'assets', 'icon.svg'));
     const missingAssetReport = checkCodexReadiness({ projectRoot: tmp });
     assert(!missingAssetReport.pass, 'readiness must fail when a declared plugin asset is missing');
@@ -117,7 +127,7 @@ function testPluginMarketplaceSmoke() {
     assert.equal(report.marketplace.plugins[0].version, generatedManifest.version);
     assert.equal(report.marketplace.plugins[0].description, generatedManifest.description);
     assert.equal(report.marketplace.plugins[0].repository, generatedManifest.repository);
-    assertPluginAssetsExist(path.join(tmp, '.agents'), generatedManifest);
+    assertPluginAssetsExist(path.join(tmp, '.agents'), generatedManifest, ['./assets/terminal-demo.svg']);
     assert(report.codexCliCommands.some((command) => command.includes('codex plugin marketplace add')));
 
     const smoke = execFileSync(process.execPath, [

--- a/scripts/test-release-integrity.js
+++ b/scripts/test-release-integrity.js
@@ -590,6 +590,8 @@ try {
   assert.deepEqual(releaseMetadata.interoperability, { remote_registry_verification: 'not-claimed' });
   const releaseCodexManifest = JSON.parse(fs.readFileSync(path.join(productRoot, '.codex-plugin', 'plugin.json'), 'utf8'));
   assert(!/\b49 skills\b|PR triage/i.test(JSON.stringify(releaseCodexManifest)), 'release Codex metadata overstates excluded surfaces');
+  assert.deepEqual(releaseCodexManifest.interface?.screenshots, ['./assets/terminal-demo.svg'],
+    'release Codex metadata must expose the shipped terminal demo screenshot');
 
   const publicMarkdown = [...productPaths].filter((relative) => (
     relative === 'README.md' || relative === 'INSTALL.md' || relative === 'CHANGELOG.md'
@@ -796,7 +798,12 @@ try {
   }
 
   const codexManifest = JSON.parse(fs.readFileSync(path.join(productRoot, '.codex-plugin', 'plugin.json'), 'utf8'));
-  for (const asset of [codexManifest.interface?.composerIcon, codexManifest.interface?.logo].filter(Boolean)) {
+  const interfaceAssets = [
+    codexManifest.interface?.composerIcon,
+    codexManifest.interface?.logo,
+    ...(codexManifest.interface?.screenshots || []),
+  ].filter(Boolean);
+  for (const asset of interfaceAssets) {
     const relative = asset.replace(/^\.\//, '');
     assert(fs.existsSync(path.join(productRoot, ...relative.split('/'))), `Codex plugin references omitted asset ${asset}`);
   }


### PR DESCRIPTION
Closes code-scanning alert #71 by declaring the already-shipped terminal demo as the Codex plugin screenshot, preserving root and projected manifest paths, copying the generated asset, and enforcing packaged asset closure. Focused plugin, native-integration, and release-integrity tests pass; an independent arbiter accepted the exact commit.