### PR TITLE
fix(release): canonicalize gzip metadata

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -18,7 +18,7 @@
       "interface": {
         "displayName": "Citadel Harness"
       },
-      "version": "1.3.1",
+      "version": "1.3.2",
       "description": "Route requests, preserve run state, enforce hooks, and surface reviewable evidence in Codex.",
       "repository": "https://github.com/SethGammon/Citadel",
       "metadata": "../../citadel-metadata.json"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "citadel",
       "description": "Route requests, preserve run state, enforce hooks, and surface reviewable evidence in Claude Code",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "source": "./",
       "author": {
         "name": "SethGammon",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "citadel",
   "description": "Claude Code harness for routing requests, preserving run state, enforcing hooks, and recording evidence",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "author": {
     "name": "SethGammon"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "citadel",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Codex-native harness for routing requests, preserving run state, enforcing hooks, and recording evidence.",
   "author": {
     "name": "Citadel",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable Citadel changes are recorded here. Citadel follows semantic versioning.
 
+## 1.3.2 - 2026-08-12
+
+### Fixed
+
+- Deterministic release archives now canonicalize the informational GZIP
+  source-OS marker, producing identical bytes on Windows, macOS, and Linux.
+
 ## 1.3.1 - 2026-08-12
 
 ### Fixed

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,14 +15,14 @@ Authentication depends on the runtime you use. Citadel layers on top of the runt
 
 ## Recommended: Native Plugin Marketplace
 
-The commands below pin `v1.3.1`. If that tag is not present on
+The commands below pin `v1.3.2`. If that tag is not present on
 [GitHub Releases](https://github.com/SethGammon/Citadel/releases), stop rather
 than substituting floating `main`.
 
 ### OpenAI Codex
 
 ```bash
-codex plugin marketplace add SethGammon/Citadel --ref v1.3.1
+codex plugin marketplace add SethGammon/Citadel --ref v1.3.2
 codex plugin add citadel@citadel-local
 ```
 
@@ -33,7 +33,7 @@ or duplicate it.
 ### Claude Code
 
 ```bash
-claude plugin marketplace add SethGammon/Citadel@v1.3.1 --scope local
+claude plugin marketplace add SethGammon/Citadel@v1.3.2 --scope local
 claude plugin install citadel@citadel-local --scope local
 ```
 
@@ -52,7 +52,7 @@ adds one /do entry point, repository-local state that survives sessions,
 guarded multi-step workflows, and reviewable evidence with explicit Needs You
 and Resume boundaries.
 
-Install Citadel v1.3.1 from https://github.com/SethGammon/Citadel using this
+Install Citadel v1.3.2 from https://github.com/SethGammon/Citadel using this
 runtime's native plugin marketplace, then enable it for this repository. Use
 project-local defaults and preserve removal evidence for every change. Do not clone main or change shared
 configuration, sandbox settings, permissions, or user-wide settings without

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ and handoffs around the coding agent you already use.
 **Requires:** Claude Code or OpenAI Codex, Node.js 22+, and a git repository.
 
 Citadel is installed through the plugin marketplace already built into your
-coding agent. The commands below pin the complete `v1.3.1` release; if that tag
+coding agent. The commands below pin the complete `v1.3.2` release; if that tag
 is not present on [GitHub Releases](https://github.com/SethGammon/Citadel/releases),
 do not substitute floating `main`.
 
@@ -33,7 +33,7 @@ do not substitute floating `main`.
 Run these commands from the repository you want Citadel to manage:
 
 ```bash
-codex plugin marketplace add SethGammon/Citadel --ref v1.3.1
+codex plugin marketplace add SethGammon/Citadel --ref v1.3.2
 codex plugin add citadel@citadel-local
 ```
 
@@ -45,7 +45,7 @@ request such as `/do review README.md`.
 Run these commands from the repository you want Citadel to manage:
 
 ```bash
-claude plugin marketplace add SethGammon/Citadel@v1.3.1 --scope local
+claude plugin marketplace add SethGammon/Citadel@v1.3.2 --scope local
 claude plugin install citadel@citadel-local --scope local
 ```
 
@@ -63,7 +63,7 @@ adds one /do entry point, repository-local state that survives sessions,
 guarded multi-step workflows, and reviewable evidence with explicit Needs You
 and Resume boundaries.
 
-Install Citadel v1.3.1 from https://github.com/SethGammon/Citadel using this
+Install Citadel v1.3.2 from https://github.com/SethGammon/Citadel using this
 runtime's native plugin marketplace, then enable it for this repository. Use
 project-local defaults and preserve removal evidence for every change. Do not clone main or change shared
 configuration, sandbox settings, permissions, or user-wide settings without

--- a/citadel-metadata.json
+++ b/citadel-metadata.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "name": "citadel",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Route requests, preserve run state, enforce hooks, and record reviewable evidence",
   "license": "MIT",
   "source_repository": "https://github.com/SethGammon/Citadel",

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -55,10 +55,10 @@ of `refs/tags/v*`. Once the source and all version manifests are ready, the
 release tag must exactly match the package version. For example:
 
 ```sh
-TAG=v1.3.1
+TAG=v1.3.2
 node scripts/release-package.js --ref "$TAG" --dry-run --verify-reproducible
 node scripts/release-package.js --ref "$TAG" --output-dir dist/release --verify-reproducible
-node scripts/release-verify.js "dist/release/citadel-$TAG.tar.gz" --ref "$TAG" --version 1.3.1
+node scripts/release-verify.js "dist/release/citadel-$TAG.tar.gz" --ref "$TAG" --version 1.3.2
 ```
 
 A pushed `v*` tag runs the same strict and reproducibility checks on Node 22 and
@@ -76,8 +76,8 @@ Download the complete trio from the GitHub Release. From a trusted Citadel
 checkout, verify the archive's offline integrity and internal manifest consistency:
 
 ```sh
-node scripts/release-verify.js /path/to/citadel-v1.3.1.tar.gz \
-  --ref v1.3.1 --version 1.3.1
+node scripts/release-verify.js /path/to/citadel-v1.3.2.tar.gz \
+  --ref v1.3.2 --version 1.3.2
 ```
 
 This offline check proves that the archive, checksum sidecar, embedded manifest,
@@ -89,9 +89,9 @@ for authenticated build provenance. See [GitHub's artifact-attestation guide](ht
 When online, independently verify GitHub's signed build provenance:
 
 ```sh
-gh attestation verify /path/to/citadel-v1.3.1.tar.gz -R SethGammon/Citadel
-gh attestation verify /path/to/citadel-v1.3.1.tar.gz.manifest.json -R SethGammon/Citadel
-gh attestation verify /path/to/citadel-v1.3.1.tar.gz.sha256 -R SethGammon/Citadel
+gh attestation verify /path/to/citadel-v1.3.2.tar.gz -R SethGammon/Citadel
+gh attestation verify /path/to/citadel-v1.3.2.tar.gz.manifest.json -R SethGammon/Citadel
+gh attestation verify /path/to/citadel-v1.3.2.tar.gz.sha256 -R SethGammon/Citadel
 ```
 
 The archive, sidecar, external manifest, embedded manifest, GitHub asset digest,
@@ -104,14 +104,14 @@ Point the updater at a standalone Citadel installation, not at a target project
 that Citadel manages. The default command is a read-only plan:
 
 ```sh
-node scripts/update.js --archive /path/to/citadel-v1.3.1.tar.gz --target /path/to/Citadel
+node scripts/update.js --archive /path/to/citadel-v1.3.2.tar.gz --target /path/to/Citadel
 ```
 
 After reviewing the verified source, backup path, and rollback command, apply it
 explicitly:
 
 ```sh
-node scripts/update.js --archive /path/to/citadel-v1.3.1.tar.gz --target /path/to/Citadel --apply
+node scripts/update.js --archive /path/to/citadel-v1.3.2.tar.gz --target /path/to/Citadel --apply
 ```
 
 The updater preserves `.git/` and `.planning/`, creates a backup beside the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "citadel",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "description": "Route requests, preserve run state, enforce hooks, and record reviewable evidence",
   "author": "",

--- a/scripts/release-package.js
+++ b/scripts/release-package.js
@@ -1264,6 +1264,15 @@ function makeTar(entries, prefix, mtime) {
   return Buffer.concat(chunks);
 }
 
+function makeCanonicalGzip(data) {
+  const archive = zlib.gzipSync(data, { level: 9, mtime: 0 });
+  // RFC 1952 byte 9 is an informational source-OS marker. Node writes the host
+  // OS here even when the compressed payload is identical, so normalize it to
+  // "unknown" to keep release bytes identical across supported builders.
+  archive[9] = 0xff;
+  return archive;
+}
+
 function buildRelease(options = {}) {
   const sourceDir = path.resolve(options.sourceDir || ROOT);
   const ref = options.ref || null;
@@ -1294,7 +1303,7 @@ function buildRelease(options = {}) {
   const manifestData = Buffer.from(`${JSON.stringify(internalManifest, null, 2)}\n`);
   const archiveEntries = [...entries, { name: MANIFEST_NAME, data: manifestData, mode: 0o644 }]
     .sort(compareNames);
-  const archive = zlib.gzipSync(makeTar(archiveEntries, prefix, epoch), { level: 9, mtime: 0 });
+  const archive = makeCanonicalGzip(makeTar(archiveEntries, prefix, epoch));
   const refLabel = ref ? path.basename(ref) : `v${identity.version}`;
   const archiveName = `citadel-${refLabel.replace(/[^A-Za-z0-9._-]/g, '-')}.tar.gz`;
   const archiveHash = sha256(archive);

--- a/scripts/test-public-install-path.js
+++ b/scripts/test-public-install-path.js
@@ -58,11 +58,11 @@ for (const snippet of WINDOWS_SNIPPETS) {
 assert(INSTALL.includes('node "$CITADEL_ROOT/scripts/release-verify.js"'), 'INSTALL.md missing Linux/macOS release verifier path');
 assert(README.includes('Windows users should use the'), 'README must identify its compact manual block as Linux/macOS syntax');
 for (const [name, document] of [['README.md', README], ['INSTALL.md', INSTALL]]) {
-  assert(document.includes('codex plugin marketplace add SethGammon/Citadel --ref v1.3.1'),
+  assert(document.includes('codex plugin marketplace add SethGammon/Citadel --ref v1.3.2'),
     `${name} missing exact Codex marketplace install`);
   assert(document.includes('codex plugin add citadel@citadel-local'),
     `${name} missing exact Codex plugin install`);
-  assert(document.includes('claude plugin marketplace add SethGammon/Citadel@v1.3.1 --scope local'),
+  assert(document.includes('claude plugin marketplace add SethGammon/Citadel@v1.3.2 --scope local'),
     `${name} missing exact Claude marketplace install`);
   assert(document.includes('claude plugin install citadel@citadel-local --scope local'),
     `${name} missing exact Claude plugin install`);

--- a/scripts/test-release-integrity.js
+++ b/scripts/test-release-integrity.js
@@ -165,6 +165,11 @@ try {
   assert.equal(first.sha256, second.sha256, 'same source must produce identical archives');
   assert.equal(fs.readFileSync(first.manifestPath, 'utf8'), fs.readFileSync(second.manifestPath, 'utf8'));
   assert.equal(
+    fs.readFileSync(first.archivePath)[9],
+    0xff,
+    'gzip source-OS marker must be canonical across supported builders',
+  );
+  assert.equal(
     first.manifest.files.find((file) => file.path === 'assets/fixture.bin')?.sha256,
     sha256(LARGE_BINARY_FIXTURE),
     'release text normalization must not alter binary payloads',
@@ -339,7 +344,7 @@ try {
     assert(!productPaths.has(sourceOnlyProofPath), `release leaked source-only proof path ${sourceOnlyProofPath}`);
   }
   assert(![...productPaths].some((relative) => relative.startsWith('.planning/rubrics/')), 'release leaked maintainer-only rubrics');
-  assert.equal(verifyRelease(product.archivePath, { version: '1.3.1', ref: product.manifest.ref }).files, productPaths.size);
+  assert.equal(verifyRelease(product.archivePath, { version: '1.3.2', ref: product.manifest.ref }).files, productPaths.size);
 
   const extracted = path.join(temp, 'product-extracted');
   const archiveFiles = parseTar(zlib.gunzipSync(fs.readFileSync(product.archivePath)));


### PR DESCRIPTION
Closes the final cross-platform reproducibility gap found after v1.3.1 publication. The archive payload and all 297 file hashes were identical across Windows and Ubuntu, but RFC 1952's informational source-OS byte differed. Release packaging now canonicalizes that byte to unknown (255), with a direct regression assertion. Package/plugin/install surfaces roll forward to v1.3.2. Focused release, public-install, docs, metadata, syntax, and diff gates pass locally.