### PR TITLE
fix: make Codex Fleet activation recoverable

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -18,7 +18,7 @@
       "interface": {
         "displayName": "Citadel Harness"
       },
-      "version": "1.3.2",
+      "version": "1.3.3",
       "description": "Route requests, preserve run state, enforce hooks, and surface reviewable evidence in Codex.",
       "repository": "https://github.com/SethGammon/Citadel",
       "metadata": "../../citadel-metadata.json"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "citadel",
       "description": "Route requests, preserve run state, enforce hooks, and surface reviewable evidence in Claude Code",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "source": "./",
       "author": {
         "name": "SethGammon",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "citadel",
   "description": "Claude Code harness for routing requests, preserving run state, enforcing hooks, and recording evidence",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "author": {
     "name": "SethGammon"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "citadel",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Codex-native harness for routing requests, preserving run state, enforcing hooks, and recording evidence.",
   "author": {
     "name": "Citadel",

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,8 +26,8 @@ body:
     attributes:
       label: Steps to reproduce
       placeholder: |
-        1. /do setup --express
-        2. /do review src/auth
+        1. Codex: $do setup --express (Claude Code: /do setup --express)
+        2. Codex: $do review src/auth (Claude Code: /do review src/auth)
         3. ...
     validations:
       required: true
@@ -49,7 +49,8 @@ body:
     validations:
       required: true
   - type: textarea
-    id: doctor
+    id: diagnostics
     attributes:
-      label: Output of `npm test` from your Citadel clone (optional)
+      label: Additional Citadel diagnostics (optional)
+      description: Paste relevant Citadel error output here. You do not need to clone Citadel or run its maintainer test suite just to file a report.
       render: text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable Citadel changes are recorded here. Citadel follows semantic versioning.
 
+## 1.3.3 - 2026-08-13
+
+### Fixed
+
+- Codex `$skill` invocations now pass the same product-bundle activation gate
+  as Claude Code `/skill` invocations.
+- Fleet activation now presents one complete, runtime-bound recovery command.
+  When Codex needs Citadel's managed worktree and approval adapter, that command
+  explicitly records the required degraded-runtime opt-in instead of leaving
+  Fleet unavailable after the bundle is enabled.
+- The bug-report form no longer asks plugin users to clone Citadel and run the
+  maintainer test suite, and its examples show both Codex and Claude Code skill
+  syntax.
+
 ## 1.3.2 - 2026-08-12
 
 ### Fixed

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,14 +15,14 @@ Authentication depends on the runtime you use. Citadel layers on top of the runt
 
 ## Recommended: Native Plugin Marketplace
 
-The commands below pin `v1.3.2`. If that tag is not present on
+The commands below pin `v1.3.3`. If that tag is not present on
 [GitHub Releases](https://github.com/SethGammon/Citadel/releases), stop rather
 than substituting floating `main`.
 
 ### OpenAI Codex
 
 ```bash
-codex plugin marketplace add SethGammon/Citadel --ref v1.3.2
+codex plugin marketplace add SethGammon/Citadel --ref v1.3.3
 codex plugin add citadel@citadel-local
 ```
 
@@ -33,7 +33,7 @@ or duplicate it.
 ### Claude Code
 
 ```bash
-claude plugin marketplace add SethGammon/Citadel@v1.3.2 --scope local
+claude plugin marketplace add SethGammon/Citadel@v1.3.3 --scope local
 claude plugin install citadel@citadel-local --scope local
 ```
 
@@ -52,7 +52,7 @@ adds one /do entry point, repository-local state that survives sessions,
 guarded multi-step workflows, and reviewable evidence with explicit Needs You
 and Resume boundaries.
 
-Install Citadel v1.3.2 from https://github.com/SethGammon/Citadel using this
+Install Citadel v1.3.3 from https://github.com/SethGammon/Citadel using this
 runtime's native plugin marketplace, then enable it for this repository. Use
 project-local defaults and preserve removal evidence for every change. Do not clone main or change shared
 configuration, sandbox settings, permissions, or user-wide settings without

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ and handoffs around the coding agent you already use.
 **Requires:** Claude Code or OpenAI Codex, Node.js 22+, and a git repository.
 
 Citadel is installed through the plugin marketplace already built into your
-coding agent. The commands below pin the complete `v1.3.2` release; if that tag
+coding agent. The commands below pin the complete `v1.3.3` release; if that tag
 is not present on [GitHub Releases](https://github.com/SethGammon/Citadel/releases),
 do not substitute floating `main`.
 
@@ -33,7 +33,7 @@ do not substitute floating `main`.
 Run these commands from the repository you want Citadel to manage:
 
 ```bash
-codex plugin marketplace add SethGammon/Citadel --ref v1.3.2
+codex plugin marketplace add SethGammon/Citadel --ref v1.3.3
 codex plugin add citadel@citadel-local
 ```
 
@@ -45,7 +45,7 @@ request such as `/do review README.md`.
 Run these commands from the repository you want Citadel to manage:
 
 ```bash
-claude plugin marketplace add SethGammon/Citadel@v1.3.2 --scope local
+claude plugin marketplace add SethGammon/Citadel@v1.3.3 --scope local
 claude plugin install citadel@citadel-local --scope local
 ```
 
@@ -63,7 +63,7 @@ adds one /do entry point, repository-local state that survives sessions,
 guarded multi-step workflows, and reviewable evidence with explicit Needs You
 and Resume boundaries.
 
-Install Citadel v1.3.2 from https://github.com/SethGammon/Citadel using this
+Install Citadel v1.3.3 from https://github.com/SethGammon/Citadel using this
 runtime's native plugin marketplace, then enable it for this repository. Use
 project-local defaults and preserve removal evidence for every change. Do not clone main or change shared
 configuration, sandbox settings, permissions, or user-wide settings without

--- a/citadel-metadata.json
+++ b/citadel-metadata.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "name": "citadel",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Route requests, preserve run state, enforce hooks, and record reviewable evidence",
   "license": "MIT",
   "source_repository": "https://github.com/SethGammon/Citadel",

--- a/core/config/activation.js
+++ b/core/config/activation.js
@@ -80,9 +80,28 @@ function createActivationPlan(receipt, bundleId) {
         && bundle.autoSafe === true
         && bundle.reversibleActivation === true;
     });
-  const prospective = negotiateBundles(closure, receipt.runtime, {
-    allowDegradedRuntime: receipt.activation.allowDegradedRuntime,
+  const configuredAllowDegraded = receipt.activation.allowDegradedRuntime === true;
+  let prospective = negotiateBundles(closure, receipt.runtime, {
+    allowDegradedRuntime: configuredAllowDegraded,
   });
+  let degradedRuntimeOptInRequired = false;
+  if (!configuredAllowDegraded
+    && prospective.unavailable.some((entry) => (
+      entry.reasonCode === 'DEGRADED_RUNTIME_REQUIRES_OPT_IN'
+    ))) {
+    const adapterAware = negotiateBundles(closure, receipt.runtime, {
+      allowDegradedRuntime: true,
+    });
+    if (adapterAware.effective.includes(bundleId)) {
+      prospective = adapterAware;
+      degradedRuntimeOptInRequired = true;
+    }
+  }
+  const runtimeId = receipt.runtime && /^[a-z0-9-]+$/i.test(receipt.runtime.id)
+    ? receipt.runtime.id
+    : 'unknown';
+  const commandOptions = `--runtime ${runtimeId}`
+    + (degradedRuntimeOptInRequired ? ' --allow-degraded-runtime' : '');
   return deepFreeze({
     contractVersion: 1,
     action: 'enable-bundle',
@@ -92,10 +111,11 @@ function createActivationPlan(receipt, bundleId) {
     resources: resourceChanges(addedBundles),
     onDemand: receipt.activation.onDemand,
     autoSafeEligible,
+    degradedRuntimeOptInRequired,
     requiresExplicitApply: true,
     mutatesConfig: false,
-    previewCommand: `node scripts/citadel-config.js enable ${bundleId} --json`,
-    applyCommand: `node scripts/citadel-config.js enable ${bundleId} --apply --json`,
+    previewCommand: `node scripts/citadel-config.js enable ${bundleId} ${commandOptions} --json`,
+    applyCommand: `node scripts/citadel-config.js enable ${bundleId} ${commandOptions} --apply --json`,
     prospective,
   });
 }

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -55,10 +55,10 @@ of `refs/tags/v*`. Once the source and all version manifests are ready, the
 release tag must exactly match the package version. For example:
 
 ```sh
-TAG=v1.3.2
+TAG=v1.3.3
 node scripts/release-package.js --ref "$TAG" --dry-run --verify-reproducible
 node scripts/release-package.js --ref "$TAG" --output-dir dist/release --verify-reproducible
-node scripts/release-verify.js "dist/release/citadel-$TAG.tar.gz" --ref "$TAG" --version 1.3.2
+node scripts/release-verify.js "dist/release/citadel-$TAG.tar.gz" --ref "$TAG" --version 1.3.3
 ```
 
 A pushed `v*` tag runs the same strict and reproducibility checks on Node 22 and
@@ -76,8 +76,8 @@ Download the complete trio from the GitHub Release. From a trusted Citadel
 checkout, verify the archive's offline integrity and internal manifest consistency:
 
 ```sh
-node scripts/release-verify.js /path/to/citadel-v1.3.2.tar.gz \
-  --ref v1.3.2 --version 1.3.2
+node scripts/release-verify.js /path/to/citadel-v1.3.3.tar.gz \
+  --ref v1.3.3 --version 1.3.3
 ```
 
 This offline check proves that the archive, checksum sidecar, embedded manifest,
@@ -89,9 +89,9 @@ for authenticated build provenance. See [GitHub's artifact-attestation guide](ht
 When online, independently verify GitHub's signed build provenance:
 
 ```sh
-gh attestation verify /path/to/citadel-v1.3.2.tar.gz -R SethGammon/Citadel
-gh attestation verify /path/to/citadel-v1.3.2.tar.gz.manifest.json -R SethGammon/Citadel
-gh attestation verify /path/to/citadel-v1.3.2.tar.gz.sha256 -R SethGammon/Citadel
+gh attestation verify /path/to/citadel-v1.3.3.tar.gz -R SethGammon/Citadel
+gh attestation verify /path/to/citadel-v1.3.3.tar.gz.manifest.json -R SethGammon/Citadel
+gh attestation verify /path/to/citadel-v1.3.3.tar.gz.sha256 -R SethGammon/Citadel
 ```
 
 The archive, sidecar, external manifest, embedded manifest, GitHub asset digest,
@@ -104,14 +104,14 @@ Point the updater at a standalone Citadel installation, not at a target project
 that Citadel manages. The default command is a read-only plan:
 
 ```sh
-node scripts/update.js --archive /path/to/citadel-v1.3.2.tar.gz --target /path/to/Citadel
+node scripts/update.js --archive /path/to/citadel-v1.3.3.tar.gz --target /path/to/Citadel
 ```
 
 After reviewing the verified source, backup path, and rollback command, apply it
 explicitly:
 
 ```sh
-node scripts/update.js --archive /path/to/citadel-v1.3.2.tar.gz --target /path/to/Citadel --apply
+node scripts/update.js --archive /path/to/citadel-v1.3.3.tar.gz --target /path/to/Citadel --apply
 ```
 
 The updater preserves `.git/` and `.planning/`, creates a backup beside the

--- a/hooks_src/user-prompt-submit.js
+++ b/hooks_src/user-prompt-submit.js
@@ -44,9 +44,10 @@ function main() {
     });
 
     const prompt = event.original_prompt || event.prompt || '';
-    const match = String(prompt).trim().match(/^\/([a-z][a-z0-9-]*)/i);
+    const match = String(prompt).trim().match(/^([/$])((?:[a-z][a-z0-9-]*:)?[a-z][a-z0-9-]*)/i);
     if (match) {
-      const skillName = match[1].toLowerCase();
+      const invocation = `${match[1]}${match[2]}`;
+      const skillName = match[2].toLowerCase().split(':').pop();
       const decision = health.checkSkillActivation(skillName).decision;
       if (!['enabled', 'degraded'].includes(decision.status)
         && decision.reasonCode !== 'ACTIVATION_OWNERSHIP_UNKNOWN') {
@@ -59,7 +60,7 @@ function main() {
           `${skillName}:${decision.reasonCode}`,
         );
         process.stderr.write(
-          `[Citadel activation] /${skillName} is ${decision.status} `
+          `[Citadel activation] ${invocation} is ${decision.status} `
           + `(${decision.reasonCode}).${apply}\n`,
         );
         process.exit(2);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "citadel",
-  "version": "1.3.0",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "citadel",
-      "version": "1.3.0",
+      "version": "1.3.3",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "citadel",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "description": "Route requests, preserve run state, enforce hooks, and record reviewable evidence",
   "author": "",

--- a/scripts/test-citadel-state-mcp.js
+++ b/scripts/test-citadel-state-mcp.js
@@ -130,8 +130,12 @@ async function run() {
       call(0, 'citadel_operation_list', {}),
     ]);
     assert.equal(disabled.get(0).error.code, -32003);
-    assert.equal(disabled.get(0).error.data.activation.status, 'unavailable');
+    assert.equal(disabled.get(0).error.data.activation.status, 'disabled');
     assert.equal(disabled.get(0).error.data.activation.bundleId, 'operations');
+    assert.match(
+      disabled.get(0).error.data.activation.plan.applyCommand,
+      /--runtime codex --allow-degraded-runtime --apply --json$/,
+    );
     assert.equal(
       fs.existsSync(path.join(disabledRoot, '.citadel')),
       false,

--- a/scripts/test-config-activation.js
+++ b/scripts/test-config-activation.js
@@ -253,6 +253,20 @@ test('runtime negotiation distinguishes degraded and unavailable activation', ()
     unavailableDecision.causeReasonCode,
     'DEGRADED_RUNTIME_REQUIRES_OPT_IN',
   );
+  assert.equal(unavailableDecision.plan.degradedRuntimeOptInRequired, true);
+  assert.equal(unavailableDecision.plan.prospective.unavailable.length, 0);
+  assert(unavailableDecision.plan.prospective.degraded.some((entry) => (
+    entry.id === 'parallel'
+    && entry.adapter === 'citadel-managed-worktrees-and-approvals'
+  )));
+  assert.equal(
+    unavailableDecision.plan.previewCommand,
+    'node scripts/citadel-config.js enable parallel --runtime codex --allow-degraded-runtime --json',
+  );
+  assert.equal(
+    unavailableDecision.plan.applyCommand,
+    'node scripts/citadel-config.js enable parallel --runtime codex --allow-degraded-runtime --apply --json',
+  );
 });
 
 test('repository policy overrides use a deterministic custom display identity', () => {

--- a/scripts/test-config-consumers.js
+++ b/scripts/test-config-consumers.js
@@ -65,7 +65,7 @@ assert.equal(bootstrapMarshal.activation.decision.bundleId, 'operations');
 assert.equal(bootstrapMarshal.activation.decision.status, 'disabled');
 assert.equal(bootstrapMarshal.boundary, 'product-bundle-activation');
 assert.equal(bootstrapMarshal.canRunNow, false);
-assert.match(bootstrapMarshal.approval, /citadel-config\.js enable operations --apply/);
+assert.match(bootstrapMarshal.approval, /citadel-config\.js enable operations .*--apply/);
 
 const value = config.createDefaultConfig();
 writeHarness(value);
@@ -99,6 +99,54 @@ const customAllowed = run(
   { CLAUDE_PROJECT_DIR: root, CITADEL_RUNTIME: 'claude-code' },
 );
 assert.equal(customAllowed.status, 0, customAllowed.stderr);
+
+const codexRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'citadel-config-codex-fleet-'));
+fs.mkdirSync(path.join(codexRoot, '.claude'), { recursive: true });
+fs.writeFileSync(
+  path.join(codexRoot, '.claude', 'harness.json'),
+  `${JSON.stringify(config.createDefaultConfig(), null, 2)}\n`,
+);
+config.reconcileEffectiveConfig(codexRoot, {
+  runtime: require('../runtimes/codex/runtime'),
+  reconciledAt: '2026-07-30T20:00:30.000Z',
+});
+const codexFleetBlocked = spawnSync(
+  process.execPath,
+  [path.join(__dirname, '..', 'hooks_src', 'user-prompt-submit.js')],
+  {
+    cwd: codexRoot,
+    encoding: 'utf8',
+    input: JSON.stringify({ prompt: '$fleet coordinate these tasks' }),
+    env: { ...process.env, CLAUDE_PROJECT_DIR: codexRoot, CITADEL_RUNTIME: 'codex' },
+  },
+);
+assert.equal(codexFleetBlocked.status, 2);
+assert.match(codexFleetBlocked.stderr, /\$fleet is disabled \(ACTIVATION_PROMPT_REQUIRED\)/);
+assert.match(
+  codexFleetBlocked.stderr,
+  /enable parallel --runtime codex --allow-degraded-runtime --apply --json/,
+);
+
+const codexFleetApply = spawnSync(
+  process.execPath,
+  [
+    path.join(__dirname, 'citadel-config.js'),
+    'enable', 'parallel', '--runtime', 'codex', '--allow-degraded-runtime', '--apply', '--json',
+  ],
+  { cwd: codexRoot, encoding: 'utf8', env: { ...process.env } },
+);
+assert.equal(codexFleetApply.status, 0, codexFleetApply.stderr || codexFleetApply.stdout);
+const codexFleetEnabled = spawnSync(
+  process.execPath,
+  [path.join(__dirname, '..', 'hooks_src', 'user-prompt-submit.js')],
+  {
+    cwd: codexRoot,
+    encoding: 'utf8',
+    input: JSON.stringify({ prompt: '$fleet coordinate these tasks' }),
+    env: { ...process.env, CLAUDE_PROJECT_DIR: codexRoot, CITADEL_RUNTIME: 'codex' },
+  },
+);
+assert.equal(codexFleetEnabled.status, 0, codexFleetEnabled.stderr);
 
 value.activation = {
   ...value.activation,

--- a/scripts/test-governed-lifecycle-usecases.js
+++ b/scripts/test-governed-lifecycle-usecases.js
@@ -533,8 +533,12 @@ function configScenario(suite) {
     display: 'config check route marshal --project-root <project> --runtime codex --json',
     expected: [2],
   }).json;
-  assert.equal(disabled.decision.status, 'unavailable');
-  assert.equal(disabled.decision.reasonCode, 'ACTIVATION_BUNDLE_UNAVAILABLE');
+  assert.equal(disabled.decision.status, 'disabled');
+  assert.equal(disabled.decision.reasonCode, 'ACTIVATION_PROMPT_REQUIRED');
+  assert.match(
+    disabled.decision.plan.applyCommand,
+    /--runtime codex --allow-degraded-runtime --apply --json$/,
+  );
 
   const beforePlan = fs.readFileSync(path.join(projectRoot, '.claude', 'harness.json'));
   runCitadel(scenario, 'operations-enable-plan', [

--- a/scripts/test-public-install-path.js
+++ b/scripts/test-public-install-path.js
@@ -19,6 +19,7 @@ const SECURITY = fs.readFileSync(path.join(ROOT, 'SECURITY.md'), 'utf8');
 const ROUTING = fs.readFileSync(path.join(ROOT, 'docs', 'ROUTING_PREVIEW.md'), 'utf8');
 const ARCHITECTURE = fs.readFileSync(path.join(ROOT, 'docs', 'ARCHITECTURE.md'), 'utf8');
 const RELEASES = fs.readFileSync(path.join(ROOT, 'docs', 'RELEASES.md'), 'utf8');
+const VERSION = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8')).version;
 
 const TRIO = Object.freeze([
   'citadel-vX.Y.Z.tar.gz',
@@ -58,11 +59,11 @@ for (const snippet of WINDOWS_SNIPPETS) {
 assert(INSTALL.includes('node "$CITADEL_ROOT/scripts/release-verify.js"'), 'INSTALL.md missing Linux/macOS release verifier path');
 assert(README.includes('Windows users should use the'), 'README must identify its compact manual block as Linux/macOS syntax');
 for (const [name, document] of [['README.md', README], ['INSTALL.md', INSTALL]]) {
-  assert(document.includes('codex plugin marketplace add SethGammon/Citadel --ref v1.3.2'),
+  assert(document.includes(`codex plugin marketplace add SethGammon/Citadel --ref v${VERSION}`),
     `${name} missing exact Codex marketplace install`);
   assert(document.includes('codex plugin add citadel@citadel-local'),
     `${name} missing exact Codex plugin install`);
-  assert(document.includes('claude plugin marketplace add SethGammon/Citadel@v1.3.2 --scope local'),
+  assert(document.includes(`claude plugin marketplace add SethGammon/Citadel@v${VERSION} --scope local`),
     `${name} missing exact Claude marketplace install`);
   assert(document.includes('claude plugin install citadel@citadel-local --scope local'),
     `${name} missing exact Claude plugin install`);

--- a/scripts/test-release-integrity.js
+++ b/scripts/test-release-integrity.js
@@ -12,6 +12,7 @@ const { buildRelease, sanitizeReleaseInstructions, sha256 } = require('./release
 const { parseTar, verifyRelease } = require('./release-verify');
 
 const ROOT = path.resolve(__dirname, '..');
+const SOURCE_VERSION = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8')).version;
 const LARGE_BINARY_FIXTURE = Buffer.concat([
   Buffer.from([0x00, 0x0d, 0x0a, 0xff]),
   Buffer.alloc((2 * 1024 * 1024) + 17, 0xa5),
@@ -344,7 +345,7 @@ try {
     assert(!productPaths.has(sourceOnlyProofPath), `release leaked source-only proof path ${sourceOnlyProofPath}`);
   }
   assert(![...productPaths].some((relative) => relative.startsWith('.planning/rubrics/')), 'release leaked maintainer-only rubrics');
-  assert.equal(verifyRelease(product.archivePath, { version: '1.3.2', ref: product.manifest.ref }).files, productPaths.size);
+  assert.equal(verifyRelease(product.archivePath, { version: SOURCE_VERSION, ref: product.manifest.ref }).files, productPaths.size);
 
   const extracted = path.join(temp, 'product-extracted');
   const archiveFiles = parseTar(zlib.gunzipSync(fs.readFileSync(product.archivePath)));


### PR DESCRIPTION
Fixes #258

## What changed
- recognize native Codex $skill invocations in the activation hook
- emit one runtime-bound Fleet activation command that includes the required managed-adapter opt-in
- verify that applying the displayed command makes Fleet pass preflight
- remove the maintainer-test burden from the public bug form
- prepare patch release 1.3.3

## Verification
- node scripts/test-all.js --strict
- node scripts/test-config-activation.js
- node scripts/test-config-consumers.js
- node scripts/test-release-integrity.js
- reproducible 1.3.3 artifact verified at SHA-256 af4ec7356c75099787b5a3a9d1d8730f4d339ad69abc202df66ca4b9b9bbf46b