### PR TITLE
fix: run Fleet recovery from installed projects

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -18,7 +18,7 @@
       "interface": {
         "displayName": "Citadel Harness"
       },
-      "version": "1.3.3",
+      "version": "1.3.4",
       "description": "Route requests, preserve run state, enforce hooks, and surface reviewable evidence in Codex.",
       "repository": "https://github.com/SethGammon/Citadel",
       "metadata": "../../citadel-metadata.json"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "citadel",
       "description": "Route requests, preserve run state, enforce hooks, and surface reviewable evidence in Claude Code",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "source": "./",
       "author": {
         "name": "SethGammon",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "citadel",
   "description": "Claude Code harness for routing requests, preserving run state, enforcing hooks, and recording evidence",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "author": {
     "name": "SethGammon"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "citadel",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Codex-native harness for routing requests, preserving run state, enforcing hooks, and recording evidence.",
   "author": {
     "name": "Citadel",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable Citadel changes are recorded here. Citadel follows semantic versioning.
 
+## 1.3.4 - 2026-08-13
+
+### Fixed
+
+- Fleet activation recovery now executes through the project-local
+  `.citadel/scripts/citadel-config.js` delegate, so the displayed command works
+  from an installed project rather than requiring a Citadel source checkout.
+
 ## 1.3.3 - 2026-08-13
 
 ### Fixed

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,14 +15,14 @@ Authentication depends on the runtime you use. Citadel layers on top of the runt
 
 ## Recommended: Native Plugin Marketplace
 
-The commands below pin `v1.3.3`. If that tag is not present on
+The commands below pin `v1.3.4`. If that tag is not present on
 [GitHub Releases](https://github.com/SethGammon/Citadel/releases), stop rather
 than substituting floating `main`.
 
 ### OpenAI Codex
 
 ```bash
-codex plugin marketplace add SethGammon/Citadel --ref v1.3.3
+codex plugin marketplace add SethGammon/Citadel --ref v1.3.4
 codex plugin add citadel@citadel-local
 ```
 
@@ -33,7 +33,7 @@ or duplicate it.
 ### Claude Code
 
 ```bash
-claude plugin marketplace add SethGammon/Citadel@v1.3.3 --scope local
+claude plugin marketplace add SethGammon/Citadel@v1.3.4 --scope local
 claude plugin install citadel@citadel-local --scope local
 ```
 
@@ -52,7 +52,7 @@ adds one /do entry point, repository-local state that survives sessions,
 guarded multi-step workflows, and reviewable evidence with explicit Needs You
 and Resume boundaries.
 
-Install Citadel v1.3.3 from https://github.com/SethGammon/Citadel using this
+Install Citadel v1.3.4 from https://github.com/SethGammon/Citadel using this
 runtime's native plugin marketplace, then enable it for this repository. Use
 project-local defaults and preserve removal evidence for every change. Do not clone main or change shared
 configuration, sandbox settings, permissions, or user-wide settings without

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ and handoffs around the coding agent you already use.
 **Requires:** Claude Code or OpenAI Codex, Node.js 22+, and a git repository.
 
 Citadel is installed through the plugin marketplace already built into your
-coding agent. The commands below pin the complete `v1.3.3` release; if that tag
+coding agent. The commands below pin the complete `v1.3.4` release; if that tag
 is not present on [GitHub Releases](https://github.com/SethGammon/Citadel/releases),
 do not substitute floating `main`.
 
@@ -33,7 +33,7 @@ do not substitute floating `main`.
 Run these commands from the repository you want Citadel to manage:
 
 ```bash
-codex plugin marketplace add SethGammon/Citadel --ref v1.3.3
+codex plugin marketplace add SethGammon/Citadel --ref v1.3.4
 codex plugin add citadel@citadel-local
 ```
 
@@ -45,7 +45,7 @@ request such as `/do review README.md`.
 Run these commands from the repository you want Citadel to manage:
 
 ```bash
-claude plugin marketplace add SethGammon/Citadel@v1.3.3 --scope local
+claude plugin marketplace add SethGammon/Citadel@v1.3.4 --scope local
 claude plugin install citadel@citadel-local --scope local
 ```
 
@@ -63,7 +63,7 @@ adds one /do entry point, repository-local state that survives sessions,
 guarded multi-step workflows, and reviewable evidence with explicit Needs You
 and Resume boundaries.
 
-Install Citadel v1.3.3 from https://github.com/SethGammon/Citadel using this
+Install Citadel v1.3.4 from https://github.com/SethGammon/Citadel using this
 runtime's native plugin marketplace, then enable it for this repository. Use
 project-local defaults and preserve removal evidence for every change. Do not clone main or change shared
 configuration, sandbox settings, permissions, or user-wide settings without

--- a/citadel-metadata.json
+++ b/citadel-metadata.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "name": "citadel",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Route requests, preserve run state, enforce hooks, and record reviewable evidence",
   "license": "MIT",
   "source_repository": "https://github.com/SethGammon/Citadel",

--- a/core/config/activation.js
+++ b/core/config/activation.js
@@ -102,6 +102,7 @@ function createActivationPlan(receipt, bundleId) {
     : 'unknown';
   const commandOptions = `--runtime ${runtimeId}`
     + (degradedRuntimeOptInRequired ? ' --allow-degraded-runtime' : '');
+  const configCommand = 'node .citadel/scripts/citadel-config.js';
   return deepFreeze({
     contractVersion: 1,
     action: 'enable-bundle',
@@ -114,8 +115,8 @@ function createActivationPlan(receipt, bundleId) {
     degradedRuntimeOptInRequired,
     requiresExplicitApply: true,
     mutatesConfig: false,
-    previewCommand: `node scripts/citadel-config.js enable ${bundleId} ${commandOptions} --json`,
-    applyCommand: `node scripts/citadel-config.js enable ${bundleId} ${commandOptions} --apply --json`,
+    previewCommand: `${configCommand} enable ${bundleId} ${commandOptions} --json`,
+    applyCommand: `${configCommand} enable ${bundleId} ${commandOptions} --apply --json`,
     prospective,
   });
 }

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -55,10 +55,10 @@ of `refs/tags/v*`. Once the source and all version manifests are ready, the
 release tag must exactly match the package version. For example:
 
 ```sh
-TAG=v1.3.3
+TAG=v1.3.4
 node scripts/release-package.js --ref "$TAG" --dry-run --verify-reproducible
 node scripts/release-package.js --ref "$TAG" --output-dir dist/release --verify-reproducible
-node scripts/release-verify.js "dist/release/citadel-$TAG.tar.gz" --ref "$TAG" --version 1.3.3
+node scripts/release-verify.js "dist/release/citadel-$TAG.tar.gz" --ref "$TAG" --version 1.3.4
 ```
 
 A pushed `v*` tag runs the same strict and reproducibility checks on Node 22 and
@@ -76,8 +76,8 @@ Download the complete trio from the GitHub Release. From a trusted Citadel
 checkout, verify the archive's offline integrity and internal manifest consistency:
 
 ```sh
-node scripts/release-verify.js /path/to/citadel-v1.3.3.tar.gz \
-  --ref v1.3.3 --version 1.3.3
+node scripts/release-verify.js /path/to/citadel-v1.3.4.tar.gz \
+  --ref v1.3.4 --version 1.3.4
 ```
 
 This offline check proves that the archive, checksum sidecar, embedded manifest,
@@ -89,9 +89,9 @@ for authenticated build provenance. See [GitHub's artifact-attestation guide](ht
 When online, independently verify GitHub's signed build provenance:
 
 ```sh
-gh attestation verify /path/to/citadel-v1.3.3.tar.gz -R SethGammon/Citadel
-gh attestation verify /path/to/citadel-v1.3.3.tar.gz.manifest.json -R SethGammon/Citadel
-gh attestation verify /path/to/citadel-v1.3.3.tar.gz.sha256 -R SethGammon/Citadel
+gh attestation verify /path/to/citadel-v1.3.4.tar.gz -R SethGammon/Citadel
+gh attestation verify /path/to/citadel-v1.3.4.tar.gz.manifest.json -R SethGammon/Citadel
+gh attestation verify /path/to/citadel-v1.3.4.tar.gz.sha256 -R SethGammon/Citadel
 ```
 
 The archive, sidecar, external manifest, embedded manifest, GitHub asset digest,
@@ -104,14 +104,14 @@ Point the updater at a standalone Citadel installation, not at a target project
 that Citadel manages. The default command is a read-only plan:
 
 ```sh
-node scripts/update.js --archive /path/to/citadel-v1.3.3.tar.gz --target /path/to/Citadel
+node scripts/update.js --archive /path/to/citadel-v1.3.4.tar.gz --target /path/to/Citadel
 ```
 
 After reviewing the verified source, backup path, and rollback command, apply it
 explicitly:
 
 ```sh
-node scripts/update.js --archive /path/to/citadel-v1.3.3.tar.gz --target /path/to/Citadel --apply
+node scripts/update.js --archive /path/to/citadel-v1.3.4.tar.gz --target /path/to/Citadel --apply
 ```
 
 The updater preserves `.git/` and `.planning/`, creates a backup beside the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "citadel",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "citadel",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "citadel",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "private": true,
   "description": "Route requests, preserve run state, enforce hooks, and record reviewable evidence",
   "author": "",

--- a/scripts/test-config-activation.js
+++ b/scripts/test-config-activation.js
@@ -261,11 +261,11 @@ test('runtime negotiation distinguishes degraded and unavailable activation', ()
   )));
   assert.equal(
     unavailableDecision.plan.previewCommand,
-    'node scripts/citadel-config.js enable parallel --runtime codex --allow-degraded-runtime --json',
+    'node .citadel/scripts/citadel-config.js enable parallel --runtime codex --allow-degraded-runtime --json',
   );
   assert.equal(
     unavailableDecision.plan.applyCommand,
-    'node scripts/citadel-config.js enable parallel --runtime codex --allow-degraded-runtime --apply --json',
+    'node .citadel/scripts/citadel-config.js enable parallel --runtime codex --allow-degraded-runtime --apply --json',
   );
 });
 

--- a/scripts/test-config-consumers.js
+++ b/scripts/test-config-consumers.js
@@ -65,7 +65,7 @@ assert.equal(bootstrapMarshal.activation.decision.bundleId, 'operations');
 assert.equal(bootstrapMarshal.activation.decision.status, 'disabled');
 assert.equal(bootstrapMarshal.boundary, 'product-bundle-activation');
 assert.equal(bootstrapMarshal.canRunNow, false);
-assert.match(bootstrapMarshal.approval, /citadel-config\.js enable operations .*--apply/);
+assert.match(bootstrapMarshal.approval, /\.citadel\/scripts\/citadel-config\.js enable operations .*--apply/);
 
 const value = config.createDefaultConfig();
 writeHarness(value);
@@ -110,6 +110,16 @@ config.reconcileEffectiveConfig(codexRoot, {
   runtime: require('../runtimes/codex/runtime'),
   reconciledAt: '2026-07-30T20:00:30.000Z',
 });
+const codexInit = spawnSync(
+  process.execPath,
+  [path.join(__dirname, '..', 'hooks_src', 'init-project.js')],
+  {
+    cwd: codexRoot,
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_PROJECT_DIR: codexRoot, CITADEL_RUNTIME: 'codex' },
+  },
+);
+assert.equal(codexInit.status, 0, codexInit.stderr);
 const codexFleetBlocked = spawnSync(
   process.execPath,
   [path.join(__dirname, '..', 'hooks_src', 'user-prompt-submit.js')],
@@ -127,12 +137,14 @@ assert.match(
   /enable parallel --runtime codex --allow-degraded-runtime --apply --json/,
 );
 
+const displayedApply = codexFleetBlocked.stderr.match(/Review and explicitly apply: (.+)\r?\n$/)?.[1];
+assert(displayedApply, 'Codex Fleet block must contain one apply command');
+const displayedArgs = displayedApply.split(/\s+/);
+assert.equal(displayedArgs.shift(), 'node');
+const displayedScript = displayedArgs.shift();
 const codexFleetApply = spawnSync(
   process.execPath,
-  [
-    path.join(__dirname, 'citadel-config.js'),
-    'enable', 'parallel', '--runtime', 'codex', '--allow-degraded-runtime', '--apply', '--json',
-  ],
+  [displayedScript, ...displayedArgs],
   { cwd: codexRoot, encoding: 'utf8', env: { ...process.env } },
 );
 assert.equal(codexFleetApply.status, 0, codexFleetApply.stderr || codexFleetApply.stdout);


### PR DESCRIPTION
Follow-up to #259 and #258.

The activation plan was correct but still named the maintainer-checkout path. This changes the displayed command to the installed project delegate at `.citadel/scripts/citadel-config.js` and makes the regression execute the exact displayed command from a plugin-managed target.

Verification:
- `node scripts/test-all.js --strict`
- exact displayed-command integration test
- hook verification 94/94
- release integrity
- reproducible 1.3.4 candidate SHA-256 `a061b9c074e47bdaae390b976c6f7dd6e530ccc294da8067766754bfbb36e08d`