### PR TITLE
Fix stale config recovery guidance

### DIFF
--- a/core/config/activation.js
+++ b/core/config/activation.js
@@ -159,8 +159,9 @@ function activationDecision(effective, target) {
       deepFreeze({
         contractVersion: 1,
         action: 'reconcile-effective-config',
-        requiresExplicitApply: false,
+        requiresExplicitApply: true,
         mutatesConfig: false,
+        applyCommand: 'node .citadel/scripts/citadel-config.js reconcile --apply --json',
       }),
     );
   }

--- a/hooks_src/init-project.js
+++ b/hooks_src/init-project.js
@@ -81,6 +81,13 @@ function shouldSyncScripts() {
     const pluginScripts = path.join(PLUGIN_ROOT, 'scripts');
     const projectScripts = path.join(PROJECT_ROOT, '.citadel', 'scripts');
     if (!fs.existsSync(pluginScripts) || !fs.existsSync(projectScripts)) return true;
+    const moduleScope = path.join(projectScripts, 'package.json');
+    if (!fs.existsSync(moduleScope)) return true;
+    try {
+      if (JSON.parse(fs.readFileSync(moduleScope, 'utf8')).type !== 'commonjs') return true;
+    } catch {
+      return true;
+    }
     return fs.readdirSync(pluginScripts)
       .filter((file) => file.endsWith('.js') || file.endsWith('.cjs'))
       .some((file) => !fs.existsSync(path.join(projectScripts, file)));
@@ -209,6 +216,10 @@ function main() {
       const projectScripts = path.join(PROJECT_ROOT, '.citadel', 'scripts');
       if (fs.existsSync(pluginScripts)) {
         ensureDir(projectScripts);
+        fs.writeFileSync(
+          path.join(projectScripts, 'package.json'),
+          `${JSON.stringify({ type: 'commonjs' }, null, 2)}\n`,
+        );
         for (const file of fs.readdirSync(pluginScripts)) {
           if (file.endsWith('.js') || file.endsWith('.cjs')) {
             fs.writeFileSync(

--- a/scripts/codex-compat.js
+++ b/scripts/codex-compat.js
@@ -629,6 +629,10 @@ function syncProjectScripts() {
   }
 
   writeFile(path.join(PROJECT_ROOT, '.citadel', 'plugin-root.txt'), CITADEL_ROOT);
+  writeFile(
+    path.join(PROJECT_ROOT, '.citadel', 'scripts', 'package.json'),
+    `${JSON.stringify({ type: 'commonjs' }, null, 2)}\n`
+  );
 
   let synced = 0;
   for (const file of fs.readdirSync(sourceDir)) {

--- a/scripts/test-codex-operational-improvements.js
+++ b/scripts/test-codex-operational-improvements.js
@@ -79,12 +79,18 @@ function testReadinessCheck() {
   const tmp = tempProject('citadel-readiness-');
   try {
     fs.writeFileSync(path.join(tmp, 'AGENTS.md'), '# Test\n\n## Review guidelines\n\n- Focus on P0/P1 issues.\n', 'utf8');
+    fs.writeFileSync(path.join(tmp, 'package.json'), '{"type":"module"}\n', 'utf8');
     execFileSync(process.execPath, [path.join(CITADEL_ROOT, 'scripts', 'codex-compat.js'), tmp], {
       cwd: CITADEL_ROOT,
       stdio: 'pipe',
       encoding: 'utf8',
       timeout: 20000,
     });
+    execFileSync(
+      process.execPath,
+      [path.join(tmp, '.citadel', 'scripts', 'citadel-config.js'), 'show', '--json'],
+      { cwd: tmp, stdio: 'pipe', encoding: 'utf8', timeout: 20000 },
+    );
 
     const report = checkCodexReadiness({ projectRoot: tmp, write: true });
     assert(report.pass, JSON.stringify(report.checks.filter((check) => !check.pass), null, 2));

--- a/scripts/test-config-activation.js
+++ b/scripts/test-config-activation.js
@@ -101,6 +101,11 @@ test('stale effective receipts are rejected and preflight fails closed', () => {
   assert.equal(decision.status, 'blocked');
   assert.equal(decision.reasonCode, config.EFFECTIVE_RECEIPT_REASONS.STALE);
   assert.equal(decision.plan.action, 'reconcile-effective-config');
+  assert.equal(decision.plan.requiresExplicitApply, true);
+  assert.equal(
+    decision.plan.applyCommand,
+    'node .citadel/scripts/citadel-config.js reconcile --apply --json',
+  );
 });
 
 test('malformed and future effective receipts are rejected distinctly', () => {

--- a/scripts/test-config-consumers.js
+++ b/scripts/test-config-consumers.js
@@ -228,6 +228,18 @@ assert.equal(stalePreview.activation.context.status, 'stale');
 assert.equal(stalePreview.activation.decision.status, 'blocked');
 assert.equal(stalePreview.boundary, 'product-bundle-activation');
 
+const staleDirectBlocked = run(
+  '../hooks_src/user-prompt-submit.js',
+  [],
+  JSON.stringify({ prompt: '/do diagnose the card-effect engine' }),
+  { CLAUDE_PROJECT_DIR: root, CITADEL_RUNTIME: 'claude-code' },
+);
+assert.equal(staleDirectBlocked.status, 2);
+assert.match(
+  staleDirectBlocked.stderr,
+  /EFFECTIVE_CONFIG_STALE.*reconcile --apply --json/,
+);
+
 const healthUtil = path.join(__dirname, '..', 'hooks_src', 'harness-health-util.js');
 const health = spawnSync(
   process.execPath,

--- a/scripts/verify-hooks.js
+++ b/scripts/verify-hooks.js
@@ -192,6 +192,10 @@ console.log('\nPhase 2: Init project (SessionStart → init-project.js)');
 console.log('─'.repeat(40));
 
 const initDir = sandbox();
+fs.writeFileSync(
+  path.join(initDir, 'package.json'),
+  `${JSON.stringify({ type: 'module' }, null, 2)}\n`,
+);
 
 test('init-project.js exits 0', () => {
   const r = fireHook('init-project.js', {}, initDir);
@@ -226,6 +230,30 @@ test('.citadel/scripts/ populated with delegates', () => {
     return !content.includes(delegateMarker);
   });
   if (nonDelegate.length > 0) return `non-delegate scripts found: ${nonDelegate.join(', ')}`;
+});
+
+test('.citadel script delegates execute inside an ESM target', () => {
+  const moduleScope = JSON.parse(fs.readFileSync(
+    path.join(initDir, '.citadel', 'scripts', 'package.json'),
+    'utf8',
+  ));
+  if (moduleScope.type !== 'commonjs') return 'delegate package scope is not CommonJS';
+  const result = spawnSync(
+    process.execPath,
+    [path.join(initDir, '.citadel', 'scripts', 'citadel-config.js'), 'show', '--json'],
+    { cwd: initDir, encoding: 'utf8' },
+  );
+  if (result.status !== 0) return `delegate failed: ${result.stderr || result.stdout}`;
+  JSON.parse(result.stdout);
+});
+
+test('init-project repairs a missing delegate module scope without a version change', () => {
+  const moduleScopePath = path.join(initDir, '.citadel', 'scripts', 'package.json');
+  fs.rmSync(moduleScopePath);
+  const result = fireHook('init-project.js', {}, initDir);
+  if (result.exitCode !== 0) return `repair failed: ${result.stderr || result.stdout}`;
+  const moduleScope = JSON.parse(fs.readFileSync(moduleScopePath, 'utf8'));
+  if (moduleScope.type !== 'commonjs') return 'delegate package scope was not repaired';
 });
 
 test('.citadel/plugin-root.txt written', () => {


### PR DESCRIPTION
## What changed

- add the concrete reconciliation command to unusable effective-config activation plans
- mark reconciliation as requiring explicit apply because it writes the derived receipt
- establish a CommonJS package scope for generated `.citadel/scripts/*.js` delegates
- repair missing delegate module scope even when the installed Citadel version is unchanged
- cover the activation plan, `/do` hook guidance, session initialization, and Codex projection in ESM target repositories

## Root cause

When `.claude/harness.json` changed after reconciliation, Citadel correctly blocked direct skill invocation with `EFFECTIVE_CONFIG_STALE`, but the recovery plan omitted its command.

The first recovery command exposed a second defect in repositories whose root `package.json` declares `"type": "module"`: Citadel's generated delegates use CommonJS `require` with a `.js` suffix, so Node treated them as ESM before they could delegate to the real Citadel script.

Generated delegates now live under an explicit CommonJS package scope, while the target application retains its own module type.

## Verification

- `node hooks_src/smoke-test.js`
- `node scripts/verify-hooks.js`
- `node scripts/test-codex-operational-improvements.js`
- `node scripts/test-config-activation.js`
- `node scripts/test-config-consumers.js`
- `node scripts/integration-test.js`
- `node scripts/test-all.js`

The complete-history full suite passed all gates. The new regressions execute a generated `.js` delegate from a target repository with `"type": "module"` and verify same-version module-scope repair.
