### PR TITLE
fix(codex): repair MCP and hook integration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -5,6 +5,7 @@
       "args": [
         "mcp-servers/citadel-state/index.js"
       ],
+      "cwd": ".",
       "env": {
         "CITADEL_MCP_SERVER": "citadel-state"
       },
@@ -20,6 +21,7 @@
       "args": [
         "mcp-servers/codebase-memory/index.js"
       ],
+      "cwd": ".",
       "env": {
         "CITADEL_MCP_SERVER": "codebase-memory"
       },

--- a/hooks_src/codex-adapter.js
+++ b/hooks_src/codex-adapter.js
@@ -249,9 +249,55 @@ function isValidCodexStopOutput(output) {
   return output.reason === undefined;
 }
 
+function isValidCodexContextOutput(output, eventName) {
+  if (!output || typeof output !== 'object' || Array.isArray(output)) return false;
+  const allowedKeys = new Set([
+    'continue',
+    'stopReason',
+    'suppressOutput',
+    'systemMessage',
+    'hookSpecificOutput',
+  ]);
+  if (Object.keys(output).some((key) => !allowedKeys.has(key))) return false;
+  const specific = output.hookSpecificOutput;
+  if (!specific || typeof specific !== 'object' || Array.isArray(specific)) return false;
+  if (specific.hookEventName !== eventName) return false;
+  return typeof specific.additionalContext === 'string';
+}
+
+function projectCodexContextOutput(stdout, eventName) {
+  if (stdout.trim().length === 0) return '';
+
+  let parsed;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    parsed = null;
+  }
+
+  if (isValidCodexContextOutput(parsed, eventName)) return stdout;
+
+  const context = parsed
+    && typeof parsed === 'object'
+    && !Array.isArray(parsed)
+    && typeof parsed.message === 'string'
+    ? parsed.message
+    : stdout.trim();
+
+  return JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: eventName,
+      additionalContext: context,
+    },
+  });
+}
+
 function projectCodexOutput(result) {
   const stdout = result.stdout || '';
   const stderr = result.stderr || '';
+  if (['SessionStart', 'PostToolUse'].includes(result.nativeEventName)) {
+    return { stdout: projectCodexContextOutput(stdout, result.nativeEventName), stderr };
+  }
   if (result.nativeEventName !== 'Stop' || stdout.trim().length === 0) {
     return { stdout, stderr };
   }
@@ -308,8 +354,10 @@ module.exports = Object.freeze({
   extractApplyPatchTargets,
   isValidCodexStopOutput,
   isSecurityHook,
+  isValidCodexContextOutput,
   parseApplyPatchOperations,
   projectLegacyPayloads,
   projectCodexOutput,
+  projectCodexContextOutput,
   validateSecurityEnvelope,
 });

--- a/mcp-servers/citadel-state/index.js
+++ b/mcp-servers/citadel-state/index.js
@@ -273,7 +273,7 @@ function handleRequest(req) {
   if (method === 'notifications/initialized') return;
   if (method === 'tools/list') { respond(id, { tools: TOOL_DEFS }); return; }
   if (method === 'tools/call') {
-    if (!isPlainObject(params) || Object.keys(params).some((key) => !['name', 'arguments'].includes(key))
+    if (!isPlainObject(params) || Object.keys(params).some((key) => !['name', 'arguments', '_meta'].includes(key))
       || typeof params.name !== 'string') {
       respondError(id, -32602, 'Invalid tool call');
       return;

--- a/runtimes/codex/generators/install-hooks.js
+++ b/runtimes/codex/generators/install-hooks.js
@@ -92,7 +92,9 @@ function translateCodexHooks(hooksTemplate, adapterScriptPath, options = {}) {
           type: 'command',
           command: commandForHook(hookName),
           statusMessage: `Citadel: ${hookName}`,
-          timeout: hook.timeout || 30,
+          timeout: codexEvent === 'SessionEnd'
+            ? Math.min(hook.timeout || 30, 3)
+            : hook.timeout || 30,
         };
         if (commandWindowsForHook) translatedHook.commandWindows = commandWindowsForHook(hookName);
         hooks.push(translatedHook);

--- a/runtimes/codex/hooks.json
+++ b/runtimes/codex/hooks.json
@@ -229,7 +229,7 @@
             "type": "command",
             "command": "node \"${PLUGIN_ROOT}/hooks_src/codex-adapter.js\" session-end",
             "statusMessage": "Citadel: session-end",
-            "timeout": 10,
+            "timeout": 3,
             "commandWindows": "node \"%PLUGIN_ROOT%\\hooks_src\\codex-adapter.js\" session-end"
           }
         ]

--- a/scripts/fixtures/codex-hooks.json
+++ b/scripts/fixtures/codex-hooks.json
@@ -211,7 +211,7 @@
             "type": "command",
             "command": "node ${CITADEL_ROOT}/codex-adapter.js session-end",
             "statusMessage": "Citadel: session-end",
-            "timeout": 10
+            "timeout": 3
           }
         ]
       }

--- a/scripts/test-backward-compat.js
+++ b/scripts/test-backward-compat.js
@@ -397,6 +397,72 @@ check('Codex Stop output rejects malformed block decisions but leaves other even
   }).stdout, nonStop);
 });
 
+check('Codex SessionStart output wraps inner hook text in the native envelope', () => {
+  const projected = projectCodexOutput({
+    nativeEventName: 'SessionStart',
+    stdout: '[citadel] restored durable memory\n',
+    stderr: '',
+  });
+  assert.deepStrictEqual(JSON.parse(projected.stdout), {
+    hookSpecificOutput: {
+      hookEventName: 'SessionStart',
+      additionalContext: '[citadel] restored durable memory',
+    },
+  });
+  assert.equal(projected.stderr, '');
+});
+
+check('Codex SessionStart output converts Citadel UI JSON to native context', () => {
+  const projected = projectCodexOutput({
+    nativeEventName: 'SessionStart',
+    stdout: JSON.stringify({
+      hook: 'intake-scanner',
+      action: 'allowed',
+      message: '[Intake] Work items detected',
+      data: { pending: ['example'] },
+    }),
+    stderr: '',
+  });
+  assert.deepStrictEqual(JSON.parse(projected.stdout), {
+    hookSpecificOutput: {
+      hookEventName: 'SessionStart',
+      additionalContext: '[Intake] Work items detected',
+    },
+  });
+});
+
+check('Codex SessionStart output preserves an already native envelope', () => {
+  const native = JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: 'SessionStart',
+      additionalContext: 'Load project memory.',
+    },
+  });
+  assert.equal(projectCodexOutput({
+    nativeEventName: 'SessionStart',
+    stdout: native,
+    stderr: '',
+  }).stdout, native);
+});
+
+check('Codex PostToolUse output wraps Citadel UI JSON in the native envelope', () => {
+  const projected = projectCodexOutput({
+    nativeEventName: 'PostToolUse',
+    stdout: JSON.stringify({
+      hook: 'post-edit',
+      action: 'allowed',
+      message: '[citadel] post-edit checks passed',
+    }),
+    stderr: '',
+  });
+  assert.deepStrictEqual(JSON.parse(projected.stdout), {
+    hookSpecificOutput: {
+      hookEventName: 'PostToolUse',
+      additionalContext: '[citadel] post-edit checks passed',
+    },
+  });
+});
+
 check('Codex apply_patch target extraction covers add, update, delete, and move paths', () => {
   const command = [
     '*** Begin Patch',

--- a/scripts/test-citadel-state-mcp.js
+++ b/scripts/test-citadel-state-mcp.js
@@ -195,7 +195,7 @@ async function run() {
       call(16, 'citadel_operation_pause', mutation('operation-pause', 'pause', 'key-root', { project_root: path.dirname(root) })),
       {
         ...call(17, 'citadel_status', {}),
-        params: { ...call(17, 'citadel_status', {}).params, _meta: { progressToken: 'codex-call-17' } },
+        params: { ...call(17, 'citadel_status', {}).params, _meta: { progressToken: 17 } },
       },
       call(18, 'citadel_workflow_prompt', { workflow: 'qa', target: 'control surface' }),
     ];

--- a/scripts/test-citadel-state-mcp.js
+++ b/scripts/test-citadel-state-mcp.js
@@ -193,7 +193,10 @@ async function run() {
       call(14, 'citadel_operation_pause', { operation_id: 'operation-pause' }),
       call(15, 'citadel_operation_get', { operation_id: '../campaigns/escape' }),
       call(16, 'citadel_operation_pause', mutation('operation-pause', 'pause', 'key-root', { project_root: path.dirname(root) })),
-      call(17, 'citadel_status', {}),
+      {
+        ...call(17, 'citadel_status', {}),
+        params: { ...call(17, 'citadel_status', {}).params, _meta: { progressToken: 'codex-call-17' } },
+      },
       call(18, 'citadel_workflow_prompt', { workflow: 'qa', target: 'control surface' }),
     ];
     const responses = await drive(root, requests);

--- a/scripts/test-codex-native-integrations.js
+++ b/scripts/test-codex-native-integrations.js
@@ -105,7 +105,7 @@ function testMcpServer() {
     const input = [
       JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
       JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }),
-      JSON.stringify({ jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'citadel_status', arguments: { includeFiles: true }, _meta: { progressToken: 'codex-call-3' } } }),
+      JSON.stringify({ jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'citadel_status', arguments: { includeFiles: true }, _meta: { progressToken: 3 } } }),
       JSON.stringify({ jsonrpc: '2.0', id: 4, method: 'resources/read', params: { uri: 'citadel://status' } }),
       '',
     ].join('\n');

--- a/scripts/test-codex-native-integrations.js
+++ b/scripts/test-codex-native-integrations.js
@@ -45,6 +45,11 @@ function testRepositoryHookPackagingBoundary() {
 }
 
 function testGeneratedCodexArtifacts() {
+  const bundledMcp = readJson(path.join(CITADEL_ROOT, '.mcp.json'));
+  for (const server of Object.values(bundledMcp.mcpServers)) {
+    assert.equal(server.cwd, '.', 'bundled MCP entrypoints must resolve from the plugin root');
+  }
+
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'citadel-codex-native-'));
   try {
     execFileSync(process.execPath, [path.join(CITADEL_ROOT, 'scripts', 'codex-compat.js'), tmp], {
@@ -100,7 +105,7 @@ function testMcpServer() {
     const input = [
       JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
       JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }),
-      JSON.stringify({ jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'citadel_status', arguments: { includeFiles: true } } }),
+      JSON.stringify({ jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'citadel_status', arguments: { includeFiles: true }, _meta: { progressToken: 'codex-call-3' } } }),
       JSON.stringify({ jsonrpc: '2.0', id: 4, method: 'resources/read', params: { uri: 'citadel://status' } }),
       '',
     ].join('\n');

--- a/scripts/test-hook-installers.js
+++ b/scripts/test-hook-installers.js
@@ -125,6 +125,9 @@ assert(translated.hooks.SubagentStop, 'codex translation should install Subagent
 assert(translated.hooks.SessionEnd?.some((entry) =>
   entry.hooks.some((hook) => hook.command.includes('session-end'))
 ), 'codex translation should install session-end on native SessionEnd');
+assert(translated.hooks.SessionEnd.every((entry) =>
+  entry.hooks.every((hook) => hook.timeout <= 3)
+), 'Codex SessionEnd hooks must stay within the native three-second limit');
 assert(!translated.hooks.Stop.some((entry) =>
   entry.hooks.some((hook) => hook.command.includes('session-end'))
 ), 'codex translation must not project SessionEnd handlers onto Stop');


### PR DESCRIPTION
## Summary

- resolve bundled MCP entrypoints from the plugin root
- accept standard MCP `_meta` fields
- project `SessionStart` and `PostToolUse` output into Codex-native envelopes
- clamp `SessionEnd` hooks to Codex's three-second limit
- add regression coverage for each integration boundary

Fixes #270.

## Verification

- `node scripts/test-all.js`
- `git diff --check`
- sanitized diff scan: no personal paths, project names, credentials, OAuth state, tokens, or private data
