### PR TITLE
fix: surface and protect against ambiguous runtime detection in init-project

### DIFF
--- a/hooks_src/init-project.js
+++ b/hooks_src/init-project.js
@@ -14,6 +14,7 @@ const path = require('path');
 const activation = require('../core/telemetry/activation');
 const configControl = require('../core/config');
 const { ensureMachineLocalExcludes } = require('../core/runtime/install-contract');
+const { RuntimeDetectionError } = require('../core/runtime/detect-runtime');
 
 const PLUGIN_ROOT = path.resolve(__dirname, '..');
 const PROJECT_ROOT = process.env.CLAUDE_PROJECT_DIR || process.cwd();
@@ -69,7 +70,21 @@ const PLANNING_DIRS_BY_BUNDLE = Object.freeze({
 });
 
 function activationAuthority() {
-  const runtime = configControl.detectRuntimeContract(PROJECT_ROOT);
+  let runtime;
+  let runtimeDetectionError = null;
+  try {
+    runtime = configControl.detectRuntimeContract(PROJECT_ROOT);
+  } catch (error) {
+    // Multiple runtime marker directories (e.g. .claude/ + .codex/) or an
+    // invalid CITADEL_RUNTIME make the active runtime unknowable rather than
+    // wrong. Degrade to the same unknown-runtime contract the zero-marker case
+    // already uses -- proceeding is what makes the machine-local excludes and
+    // .planning/ scaffold happen at all -- but keep the error so main() can
+    // surface it instead of failing in silence.
+    if (!(error instanceof RuntimeDetectionError)) throw error;
+    runtimeDetectionError = error;
+    runtime = configControl.UNKNOWN_LOCAL_RUNTIME;
+  }
   const context = configControl.loadActivationContext(PROJECT_ROOT, { runtime });
   const decision = configControl.preflightHook(context, 'init-project');
   return {
@@ -77,6 +92,7 @@ function activationAuthority() {
     decision,
     runtime: runtime.id,
     bundles: context.receipt?.bundles?.effective || [],
+    runtimeDetectionError,
   };
 }
 
@@ -183,13 +199,23 @@ function generateDelegate(scriptName) {
 
 function main() {
   try {
+    // Protect the repository before anything else. This must not depend on
+    // resolving the active runtime -- an ambiguous or misconfigured runtime is
+    // exactly the case a mixed Claude/Codex/OpenCode checkout hits, and it must
+    // not leave machine-local state (plugin-root.txt, coordination claims,
+    // telemetry) uncommitted-but-unprotected in the repo.
+    ensureMachineLocalExcludes(PROJECT_ROOT);
+
     const authority = activationAuthority();
+    if (authority.runtimeDetectionError) {
+      process.stderr.write(`[init-project] ${authority.runtimeDetectionError.message}\n`);
+      process.stderr.write(`[init-project] repair: ${authority.runtimeDetectionError.repairCommand}\n`);
+    }
     if (!authority.allowed) {
       process.stderr.write(`[init-project] skipped: ${authority.decision.reasonCode}\n`);
       return;
     }
     const effectiveBundles = new Set(authority.bundles);
-    ensureMachineLocalExcludes(PROJECT_ROOT);
 
     // 1. Create .planning/ directory tree
     for (const dir of planningDirs(authority.bundles)) {

--- a/hooks_src/init-project.js
+++ b/hooks_src/init-project.js
@@ -282,12 +282,19 @@ function main() {
 
     // 5. Copy the runtime-neutral delegated-agent context into the active
     // runtime's project namespace. Never create another runtime's marker: it
-    // makes later runtime detection ambiguous.
-    const pluginAgentContext = path.join(PLUGIN_ROOT, 'templates', 'agent-context');
-    const runtimeDirectory = authority.runtime === 'codex' ? '.codex' : '.claude';
-    const agentContext = path.join(PROJECT_ROOT, runtimeDirectory, 'agent-context');
-    if (!fs.existsSync(agentContext) && fs.existsSync(pluginAgentContext)) {
-      copyDirRecursive(pluginAgentContext, agentContext);
+    // makes later runtime detection ambiguous. A disputed runtime (multiple
+    // markers, or an invalid CITADEL_RUNTIME) must not fall through to the
+    // .claude default below -- that would create a .claude/ marker in a repo
+    // that may have neither .claude/ nor .codex/ (e.g. .codex/ + .opencode/),
+    // turning a temporary ambiguity into a permanent one. A genuinely fresh
+    // project (no markers at all) is unaffected and keeps the existing default.
+    if (!authority.runtimeDetectionError) {
+      const pluginAgentContext = path.join(PLUGIN_ROOT, 'templates', 'agent-context');
+      const runtimeDirectory = authority.runtime === 'codex' ? '.codex' : '.claude';
+      const agentContext = path.join(PROJECT_ROOT, runtimeDirectory, 'agent-context');
+      if (!fs.existsSync(agentContext) && fs.existsSync(pluginAgentContext)) {
+        copyDirRecursive(pluginAgentContext, agentContext);
+      }
     }
 
     // 6. Write .citadel-root marker (plugin path for reference)

--- a/scripts/test-installers.js
+++ b/scripts/test-installers.js
@@ -346,8 +346,54 @@ function testInitProjectSurfacesAmbiguousRuntimeAndStillProtectsRepo() {
   }
 }
 
+function testInitProjectDoesNotCreateClaudeMarkerUnderAmbiguity() {
+  // Codex review on #294: a disputed runtime used to fall through to the
+  // .codex/.claude default in step 5's agent-context copy, so .codex/ +
+  // .opencode/ (no .claude/ at all) got a brand-new .claude/agent-context/
+  // written into it -- creating a THIRD runtime marker and turning a
+  // temporary ambiguity into a permanent one.
+  const repository = tempProject('citadel-ambiguous-no-claude-marker-');
+  try {
+    execFileSync('git', ['init', '--quiet'], { cwd: repository, stdio: 'ignore' });
+    fs.mkdirSync(path.join(repository, '.codex'), { recursive: true });
+    fs.mkdirSync(path.join(repository, '.opencode'), { recursive: true });
+
+    const { CITADEL_RUNTIME, ...envWithoutRuntime } = process.env;
+    const result = spawnSync(
+      process.execPath,
+      [path.join(CITADEL_ROOT, 'hooks_src', 'init-project.js')],
+      {
+        cwd: repository,
+        encoding: 'utf8',
+        env: { ...envWithoutRuntime, CLAUDE_PROJECT_DIR: repository },
+        timeout: 30000,
+      },
+    );
+
+    assert.equal(result.status, 0, 'ambiguous runtime must never block session start');
+    assert.equal(
+      fs.existsSync(path.join(repository, '.claude')),
+      false,
+      'a disputed runtime must never mint a new .claude/ marker',
+    );
+    assert.equal(
+      fs.existsSync(path.join(repository, '.codex', 'agent-context')),
+      false,
+      'agent-context must wait for an explicit runtime, not guess codex either',
+    );
+    assert.equal(
+      fs.existsSync(path.join(repository, '.opencode', 'agent-context')),
+      false,
+      'agent-context must wait for an explicit runtime, not guess opencode either',
+    );
+  } finally {
+    fs.rmSync(repository, { recursive: true, force: true });
+  }
+}
+
 testPortableInstallContractAndTwoClones();
 testLinkedWorktreeExcludesUseCommonGitDirectory();
 testInitProjectSurfacesAmbiguousRuntimeAndStillProtectsRepo();
+testInitProjectDoesNotCreateClaudeMarkerUnderAmbiguity();
 
 console.log('installer tests passed');

--- a/scripts/test-installers.js
+++ b/scripts/test-installers.js
@@ -3,7 +3,7 @@
 'use strict';
 
 const assert = require('assert');
-const { execFileSync } = require('child_process');
+const { execFileSync, spawnSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -300,7 +300,54 @@ testCodexMarketplaceTargetsPluginRoot();
 testUnifiedDispatcherRecordsSuccessfulInstall();
 testUnifiedDispatcherRecordsFailureWithoutChangingExit();
 testUnifiedDispatcherRespectsNonInstallModesAndOptOut();
+function testInitProjectSurfacesAmbiguousRuntimeAndStillProtectsRepo() {
+  // Regression for #293: two runtime marker directories with no CITADEL_RUNTIME
+  // used to make the session-start hook exit 0 in total silence, before it
+  // ever reached ensureMachineLocalExcludes(). That left a mixed
+  // Claude/Codex/OpenCode checkout with no .git/info/exclude protection at
+  // all -- the one case the machine-local/shared contract exists to cover.
+  const repository = tempProject('citadel-ambiguous-runtime-');
+  try {
+    execFileSync('git', ['init', '--quiet'], { cwd: repository, stdio: 'ignore' });
+    fs.mkdirSync(path.join(repository, '.claude'), { recursive: true });
+    fs.mkdirSync(path.join(repository, '.codex'), { recursive: true });
+
+    const { CITADEL_RUNTIME, ...envWithoutRuntime } = process.env;
+    const result = spawnSync(
+      process.execPath,
+      [path.join(CITADEL_ROOT, 'hooks_src', 'init-project.js')],
+      {
+        cwd: repository,
+        encoding: 'utf8',
+        env: { ...envWithoutRuntime, CLAUDE_PROJECT_DIR: repository },
+        timeout: 30000,
+      },
+    );
+
+    assert.equal(result.status, 0, 'ambiguous runtime must never block session start');
+    assert.match(
+      result.stderr,
+      /Multiple Citadel runtimes are present/,
+      'the ambiguity must be surfaced, not swallowed silently',
+    );
+    assert.match(
+      result.stderr,
+      /repair: Set CITADEL_RUNTIME/,
+      'a concrete repair command must accompany the diagnostic',
+    );
+
+    const excludePath = path.join(repository, '.git', 'info', 'exclude');
+    assert(fs.existsSync(excludePath), 'machine-local exclude file must be written even under ambiguity');
+    const excludeContents = fs.readFileSync(excludePath, 'utf8');
+    assert.match(excludeContents, /CITADEL MACHINE-LOCAL/, 'exclude file must carry the Citadel block');
+    assert(fs.existsSync(path.join(repository, '.planning')), 'planning scaffold must still be created in degraded mode');
+  } finally {
+    fs.rmSync(repository, { recursive: true, force: true });
+  }
+}
+
 testPortableInstallContractAndTwoClones();
 testLinkedWorktreeExcludesUseCommonGitDirectory();
+testInitProjectSurfacesAmbiguousRuntimeAndStillProtectsRepo();
 
 console.log('installer tests passed');


### PR DESCRIPTION
Addresses the init-project silent-failure and missing-excludes defect in item 1 of #293. Remaining follow-up work stays tracked in #293.

## Bug

`hooks_src/init-project.js` (the SessionStart hook) let a `RuntimeDetectionError` escape into its outer catch-all whenever two runtime marker directories are present (e.g. `.claude/` + `.codex/`) with `CITADEL_RUNTIME` unset, or the env var holds an invalid value. That catch-all exits 0 with no output, and it ran *before* `ensureMachineLocalExcludes()` ever executed — so a mixed Claude/Codex/OpenCode checkout, exactly the case the shared/machine-local install contract from #289/#292 exists to protect, got no `.git/info/exclude` protection at all, and no message explaining why.

Reproduction (from the issue, on `e414d52`):

```
$ mkdir repo && cd repo && git init -q . && mkdir .claude .codex
$ CLAUDE_PROJECT_DIR="$PWD" node path/to/Citadel/hooks_src/init-project.js
$ echo $?                                    # 0
$ grep -c 'CITADEL MACHINE-LOCAL' .git/info/exclude   # 0 (not written)
```

## Fix

- `activationAuthority()` now catches `RuntimeDetectionError`, degrades to the same `UNKNOWN_LOCAL_RUNTIME` contract the zero-marker case already used (so downstream activation logic takes an already-exercised path), and carries the error back to the caller.
- `main()` calls `ensureMachineLocalExcludes()` unconditionally, before resolving the runtime at all, then prints the error's `message` and `repairCommand` to stderr when ambiguity was detected. Session start still never blocks (unchanged exit-0 contract) — it now explains itself instead of failing silently.

## Tests

Added `testInitProjectSurfacesAmbiguousRuntimeAndStillProtectsRepo` to `scripts/test-installers.js`: spawns `init-project.js` in a repo with both `.claude/` and `.codex/` and no `CITADEL_RUNTIME`, and asserts exit 0, the diagnostic + repair command on stderr, the exclude block actually written, and `.planning/` still scaffolded. Verified it fails against the pre-fix hook (empty stderr) and passes with the fix.

## Verification

- `node hooks_src/smoke-test.js`, `node scripts/verify-hooks.js`, `node scripts/integration-test.js` — all pass.
- `node scripts/test-all.js` — passes; diffed the full 86-check PASS/FAIL summary against the unmodified base commit in the same ambient environment (this checkout's own `.claude/`+`.codex/` markers, no `CITADEL_RUNTIME`) — **identical results, no regressions**.
- Two checks (Security tests, Route Preview) fail in that same ambient environment on *both* base and patched commits — pre-existing, unrelated to this fix (`scripts/route-preview.js` and `scripts/test-security.js` call `detectRuntimeContract` without the resilience `init-project.js` now has); both pass cleanly once `CITADEL_RUNTIME` is set. Left out of scope here since #293 is specifically about the session-start hook's silent failure; happy to file that separately if useful.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0162s4WbzkdYf3RMJzszphVa
